### PR TITLE
Add check for date/datetime values range

### DIFF
--- a/lib/column/datetime.go
+++ b/lib/column/datetime.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kshvakov/clickhouse/lib/binary"
 )
 
+// NOTE: Supported values range: 1970-01-01 - 2106-01-01.
 type DateTime struct {
 	base
 	Timezone *time.Location
@@ -15,6 +16,9 @@ func (dt *DateTime) Read(decoder *binary.Decoder) (interface{}, error) {
 	sec, err := decoder.Int32()
 	if err != nil {
 		return nil, err
+	}
+	if sec == 0 {
+		return time.Time{}, nil
 	}
 	return time.Unix(int64(sec), 0).In(dt.Timezone), nil
 }
@@ -61,6 +65,10 @@ func (dt *DateTime) Write(encoder *binary.Encoder, v interface{}) error {
 			T:      v,
 			Column: dt,
 		}
+	}
+
+	if timestamp <= minTimestamp || timestamp >= maxTimestamp {
+		timestamp = 0
 	}
 
 	return encoder.Int32(int32(timestamp))


### PR DESCRIPTION
Related to https://github.com/kshvakov/clickhouse/issues/191 https://github.com/kshvakov/clickhouse/issues/177

I tried to fix datetime issue by adding a simple validation inside `Date` and `DateTime` types' methods. But got a problem and not sure how to fix it.

`datetime.Read()` reads int32 with maximum value of 2147483647 (`2038-01-19T03:14:07Z`) ([here](https://github.com/kshvakov/clickhouse/blob/master/lib/column/datetime.go#L15)). Which is less then a limit provided by clickhouse server - `2106-01-01`. When I change it to `decoder.UInt32()`, everything works fine - maximum value is 4294967294 (`2106-02-07T06:28:14Z`), and I get the right datetimes without overflow issues. Same for `Date` field. Since I'm not sure what can be affected by this change, I decided to ask first.

Currently test with id:8 fails:
```
--- FAIL: Test_Insert_Date_DateTime (0.02s)
    clickhouse_test.go:854: 
        	Error Trace:	clickhouse_test.go:854
        	Error:      	Not equal: 
        	            	expected: time.Time{wall:0x0, ext:66427257600, loc:(*time.Location)(nil)}
        	            	actual  : time.Time{wall:0x0, ext:60764947200, loc:(*time.Location)(nil)}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,2 +1,2 @@
        	            	-(time.Time) 2105-12-31 00:00:00 +0000 UTC
        	            	+(time.Time) 1926-07-27 00:00:00 +0000 UTC
        	            	 
        	Test:       	Test_Insert_Date_DateTime
        	Messages:   	failed date field for item: 8
```