### PR TITLE
Better write array with benchmark

### DIFF
--- a/lib/data/block.go
+++ b/lib/data/block.go
@@ -95,13 +95,13 @@ func (block *Block) Read(serverInfo *ServerInfo, decoder *binary.Decoder) (err e
 	return nil
 }
 
-func (block *Block) writeLen(l, num, level int) {
+func (block *Block) writeLen(length, num, level int) {
 	if len(block.offsets[num]) < level {
-		block.offsets[num] = append(block.offsets[num], []int{l})
+		block.offsets[num] = append(block.offsets[num], []int{length})
 	} else {
 		block.offsets[num][level-1] = append(
 			block.offsets[num][level-1],
-			block.offsets[num][level-1][len(block.offsets[num][level-1])-1]+l,
+			block.offsets[num][level-1][len(block.offsets[num][level-1])-1]+length,
 		)
 	}
 }

--- a/lib/data/block_benchmark_test.go
+++ b/lib/data/block_benchmark_test.go
@@ -1,0 +1,46 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/lib/column"
+)
+
+func Benchmark_BlockWriteArrayWithLen4(b *testing.B) {
+
+	block := &Block{}
+	block.NumColumns = 1
+	// blocks.Columns = 1
+	c, err := column.Factory("test", "Int32", nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	block.Columns = append(block.Columns, c)
+	block.Reserve()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		block.WriteArrayLen(4, 0, 1)
+		for i := 0; i > 4; i++ {
+			block.WriteInt32(0, 1)
+		}
+	}
+}
+
+func Benchmark_BlockWriteArray4(b *testing.B) {
+
+	block := &Block{}
+	block.NumColumns = 1
+	// blocks.Columns = 1
+	c, err := column.Factory("test", "Int32", nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	block.Columns = append(block.Columns, c)
+	block.Reserve()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		block.WriteArray(0, []int32{0, 1, 2, 3})
+	}
+}

--- a/lib/data/block_benchmark_test.go
+++ b/lib/data/block_benchmark_test.go
@@ -10,7 +10,7 @@ func Benchmark_BlockWriteArrayWithLen4(b *testing.B) {
 
 	block := &Block{}
 	block.NumColumns = 1
-	// blocks.Columns = 1
+
 	c, err := column.Factory("test", "Int32", nil)
 	if err != nil {
 		b.Fatal(err)

--- a/lib/data/block_benchmark_test.go
+++ b/lib/data/block_benchmark_test.go
@@ -31,7 +31,7 @@ func Benchmark_BlockWriteArray4(b *testing.B) {
 
 	block := &Block{}
 	block.NumColumns = 1
-	// blocks.Columns = 1
+
 	c, err := column.Factory("test", "Int32", nil)
 	if err != nil {
 		b.Fatal(err)

--- a/lib/data/block_benchmark_test.go
+++ b/lib/data/block_benchmark_test.go
@@ -18,11 +18,13 @@ func Benchmark_BlockWriteArrayWithLen4(b *testing.B) {
 	block.Columns = append(block.Columns, c)
 	block.Reserve()
 	b.ReportAllocs()
-
+	input := []int32{
+		1, 2, 3,
+	}
 	for i := 0; i < b.N; i++ {
-		block.WriteArrayLen(4, 0, 1)
-		for i := 0; i > 4; i++ {
-			block.WriteInt32(0, 1)
+		block.WriteArrayLen(len(input), 0, 1)
+		for _, val := range input {
+			block.WriteInt32(0, val)
 		}
 	}
 }
@@ -39,8 +41,67 @@ func Benchmark_BlockWriteArray4(b *testing.B) {
 	block.Columns = append(block.Columns, c)
 	block.Reserve()
 	b.ReportAllocs()
-
+	input := []int32{
+		1, 2, 3,
+	}
 	for i := 0; i < b.N; i++ {
-		block.WriteArray(0, []int32{0, 1, 2, 3})
+		block.WriteArray(0, input)
+	}
+}
+
+func Benchmark_BlockWriteArrayTwoLevelWithLen(b *testing.B) {
+
+	block := &Block{}
+	block.NumColumns = 1
+
+	c, err := column.Factory("test", "Array(Int32)", nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	block.Columns = append(block.Columns, c)
+	block.Reserve()
+	b.ReportAllocs()
+	input := [][]int32{
+		{
+			1, 2, 3,
+		},
+		{
+			4, 5, 6,
+		},
+	}
+	for i := 0; i < b.N; i++ {
+		block.WriteArrayLen(len(input), 0, 1)
+		for _, val := range input {
+			block.WriteArrayLen(len(val), 0, 2)
+			for _, v := range val {
+				block.WriteInt32(0, v)
+			}
+		}
+
+	}
+}
+
+func Benchmark_BlockWriteArrayTwoLevel(b *testing.B) {
+
+	block := &Block{}
+	block.NumColumns = 1
+
+	c, err := column.Factory("test", "Array(Int32)", nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	block.Columns = append(block.Columns, c)
+	block.Reserve()
+	b.ReportAllocs()
+	input := [][]int32{
+		{
+			1, 2, 3,
+		},
+		{
+			4, 5, 6,
+		},
+	}
+	for i := 0; i < b.N; i++ {
+		block.WriteArray(0, input)
 	}
 }

--- a/lib/data/block_write_column.go
+++ b/lib/data/block_write_column.go
@@ -89,8 +89,8 @@ func (block *Block) WriteFixedString(c int, v []byte) error {
 	return block.Columns[c].Write(block.buffers[c].Column, v)
 }
 
-func (block *Block) WriteArrayLen(l, c, level int) {
-	block.writeLen(l, c, level)
+func (block *Block) WriteArrayLen(length, c, level int) {
+	block.writeLen(length, c, level)
 }
 
 func (block *Block) WriteArray(c int, v interface{}) error {

--- a/lib/data/block_write_column.go
+++ b/lib/data/block_write_column.go
@@ -89,6 +89,10 @@ func (block *Block) WriteFixedString(c int, v []byte) error {
 	return block.Columns[c].Write(block.buffers[c].Column, v)
 }
 
+func (block *Block) WriteArrayLen(l, c, level int) {
+	block.writeLen(l, c, level)
+}
+
 func (block *Block) WriteArray(c int, v interface{}) error {
 	return block.WriteArrayWithValue(c, newValue(reflect.ValueOf(v)))
 }


### PR DESCRIPTION
For better performance, I add a write length function. For check it I also provide a benchmark.
this is a result of my benchmark
```
Benchmark_BlockWriteArrayWithLen4-4   	32752696	        45.5 ns/op	      49 B/op	       0 allocs/op
Benchmark_BlockWriteArray4-4          	 4509878	       264 ns/op	     113 B/op	       4 allocs/op
```
