### PR TITLE
Fix Block Reset and remove not needed code

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -129,10 +129,7 @@ func (ch *clickhouse) beginTx(ctx context.Context, opts txOptions) (*clickhouse,
 func (ch *clickhouse) Commit() error {
 	ch.logf("[commit] tx=%t, data=%t", ch.inTransaction, ch.block != nil)
 	defer func() {
-		if ch.block != nil {
-			ch.block.Reset()
-			ch.block = nil
-		}
+		ch.block = nil
 		ch.inTransaction = false
 	}()
 	switch {
@@ -161,9 +158,6 @@ func (ch *clickhouse) Rollback() error {
 	ch.logf("[rollback] tx=%t, data=%t", ch.inTransaction, ch.block != nil)
 	if !ch.inTransaction {
 		return sql.ErrTxDone
-	}
-	if ch.block != nil {
-		ch.block.Reset()
 	}
 	ch.block = nil
 	ch.buffer = nil

--- a/lib/data/block.go
+++ b/lib/data/block.go
@@ -178,10 +178,7 @@ func (block *Block) Reset() {
 	for _, buffer := range block.buffers {
 		buffer.reset()
 	}
-	{
-		block.offsets = nil
-		block.buffers = nil
-	}
+	block.offsets = make([]offset, len(block.Columns))
 }
 
 func (block *Block) Write(serverInfo *ServerInfo, encoder *binary.Encoder) error {


### PR DESCRIPTION
As I know in Golang we don't need to reset data and then nil child of an object and then nil object and ...
Only nil data is enough and GC removes data from memory.