### PR TITLE
Non nil return of driver.Conn with error 

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -71,7 +71,12 @@ func SetLogOutput(output io.Writer) {
 
 // Open the connection
 func Open(dsn string) (driver.Conn, error) {
-	return open(dsn)
+	clickhouse, err := open(dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	return clickhouse, err
 }
 
 func open(dsn string) (*clickhouse, error) {

--- a/bootstrap_test.go
+++ b/bootstrap_test.go
@@ -1,0 +1,71 @@
+package clickhouse
+
+import (
+	"database/sql/driver"
+	"reflect"
+	"testing"
+)
+
+func Test_bootstrap_Open(t *testing.T) {
+	type args struct {
+		dsn string
+	}
+	tests := []struct {
+		name    string
+		d       *bootstrap
+		args    args
+		want    driver.Conn
+		wantErr bool
+	}{
+		{
+			name:    "Return nil connection when error occured",
+			d:       &bootstrap{},
+			args:    args{dsn: "rubbish"},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &bootstrap{}
+			got, err := d.Open(tt.args.dsn)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("bootstrap.Open() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("bootstrap.Open() = %#v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpen(t *testing.T) {
+	type args struct {
+		dsn string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    driver.Conn
+		wantErr bool
+	}{
+		{
+			name:    "Return nil connection when error occured",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Open(tt.args.dsn)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Open() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Open() = %#v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When clickhouse.Open function or *clickhouse.Bootstrap.Open method are called and it returned error, driver.Conn interface being returned is non nil. It may cause error on client side because such behavior is unexpected.

I made a fix and added unit tests to show my point.