### PR TITLE
Add connOpenTimeRandom strategy to distribute connections equally across shards. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Golang SQL database driver for [Yandex ClickHouse](https://clickhouse.yandex/)
 * no_delay   - disable/enable the Nagle Algorithm for tcp socket (default is 'true' - disable)
 * alt_hosts  - comma separated list of single address host for load-balancing
 * connection_open_strategy - random/in_order (default random).
-    * random   - choose random server from set
-    * in_order - first live server is choosen in specified order
+    * random      - choose random server from set  
+    * in_order    - first live server is choosen in specified order
+    * time_random - choose random(based on current time) server from set. This option differs from `random` in that randomness is based on current time rather than on amount of previous connections.
 * block_size - maximum rows in block (default is 1000000). If the rows are larger then the data will be split into several blocks to send them to the server. If one block was sent to the server, the data will be persisted on the server disk, we can't rollback the transaction. So always keep in mind that the batch size no larger than the block_size if you want atomic batch insert.
 * pool_size - maximum amount of preallocated byte chunks used in queries (default is 100). Decrease this if you experience memory problems at the expense of more GC pressure and vice versa.
 * debug - enable debug output (boolean value)

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -152,6 +152,8 @@ func open(dsn string) (*clickhouse, error) {
 		connOpenStrategy = connOpenRandom
 	case "in_order":
 		connOpenStrategy = connOpenInOrder
+	case "time_random":
+		connOpenStrategy = connOpenTimeRandom
 	}
 
 	settings, err := makeQuerySettings(query)


### PR DESCRIPTION
I have 10 instances of application that is writing to a sharded cluster of clickhouse. There are more than 20 hosts and i want to distribute connections equally across all of them. In dsn i pass them as alt_hosts.

Unfortunately I couldn't archive desirable outcome with currently available strategies for opening connections. The `random` strategy, which is used by default, chooses host depending on [the number of connections opened before](https://github.com/ClickHouse/clickhouse-go/blob/master/connect.go#L64). So the connections are opened in the same order for each app instance and that leads to an uneven spread of connections across hosts.

I added new strategy for choosing a host to connect. Using this strategy I was able to archive somewhat even spread of connections across shards. 

It's not perfect but it does the job. If you have any thoughts on this, or know a better way to do that - let me know.