### PR TITLE
Omit block.info when serverInfo.Revision isn't set, mirroring behavior

### DIFF
--- a/lib/data/block.go
+++ b/lib/data/block.go
@@ -41,8 +41,10 @@ func (block *Block) ColumnNames() []string {
 }
 
 func (block *Block) Read(serverInfo *ServerInfo, decoder *binary.Decoder) (err error) {
-	if err = block.info.read(decoder); err != nil {
-		return err
+	if serverInfo.Revision > 0 {
+		if err = block.info.read(decoder); err != nil {
+			return err
+		}
 	}
 
 	if block.NumColumns, err = decoder.Uvarint(); err != nil {
@@ -185,10 +187,14 @@ func (block *Block) Reset() {
 }
 
 func (block *Block) Write(serverInfo *ServerInfo, encoder *binary.Encoder) error {
-	if err := block.info.write(encoder); err != nil {
+	if serverInfo.Revision > 0 {
+		if err := block.info.write(encoder); err != nil {
+			return err
+		}
+	}
+	if err := encoder.Uvarint(block.NumColumns); err != nil {
 		return err
 	}
-	encoder.Uvarint(block.NumColumns)
 	encoder.Uvarint(block.NumRows)
 	defer func() {
 		block.NumRows = 0


### PR DESCRIPTION
of C++ code.

This allows writing data in Native format that can be loaded with table functions.