### PR TITLE
Don't close the connection after a server exception is received.

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -207,6 +207,7 @@ func open(dsn string) (*clickhouse, error) {
 	ch.encoder = binary.NewEncoderWithCompress(ch.buffer)
 
 	if err := ch.hello(database, username, password); err != nil {
+		ch.conn.Close()
 		return nil, err
 	}
 	return &ch, nil
@@ -245,7 +246,6 @@ func (ch *clickhouse) hello(database, username, password string) error {
 			ch.logf("[bootstrap] <- end of stream")
 			return nil
 		default:
-			ch.conn.Close()
 			return fmt.Errorf("[hello] unexpected packet [%d] from server", packet)
 		}
 	}

--- a/clickhouse_exception.go
+++ b/clickhouse_exception.go
@@ -18,7 +18,6 @@ func (e *Exception) Error() string {
 }
 
 func (ch *clickhouse) exception() error {
-	defer ch.conn.Close()
 	var (
 		e         Exception
 		err       error


### PR DESCRIPTION
I have a requirement to query the system.zookeeper table in order to find out whether all copies of a replicated table have been dropped. When the last replica has been dropped, the zookeeper path is deleted. The server returns an exception in this case, which is normal. E.g.:

```
:) select * from system.zookeeper where path ='/clickhouse/foo';

SELECT *
FROM system.zookeeper
WHERE path = '/clickhouse/foo'

Received exception from server (version 19.11.8):
Code: 999. DB::Exception: Received from 127.0.0.1:9000. Coordination::Exception. Coordination::Exception: No node, path: /clickhouse/foo. 

0 rows in set. Elapsed: 0.002 sec. 
```

The problem I'm having is that the Go client closes the connection when it receives any server exception, which means I have to re-establish a connection after running this query. As far as I can tell, this behavior is different from the command-line client, which keeps the connection open in this case.

This PR changes the exception code such that the connection is left open after receiving an exception. I've also lifted the conn.Close() into open() so the connection is always closed when the hello fails. This seems like a straightforward change, and all the tests pass, but please let me know if there's something I'm missing.