### PR TITLE
Use the same way as clickhouse to get Datatime/Date data from string data

### DIFF
--- a/lib/column/date.go
+++ b/lib/column/date.go
@@ -1,6 +1,7 @@
 package column
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/lib/binary"
@@ -71,14 +72,15 @@ func (dt *Date) Write(encoder *binary.Encoder, v interface{}) error {
 }
 
 func (dt *Date) parse(value string) (int64, error) {
-	tv, err := time.Parse("2006-01-02", value)
+	var year, month, day int
+	_, err := fmt.Sscanf(value, "%d-%d-%d",
+		&year, &month, &day)
 	if err != nil {
 		return 0, err
 	}
-	return time.Date(
-		time.Time(tv).Year(),
-		time.Time(tv).Month(),
-		time.Time(tv).Day(),
-		0, 0, 0, 0, time.UTC,
-	).Unix(), nil
+
+	if year == 0 {
+		return 0, nil
+	}
+	return makeDaySecond(year, month, day, time.UTC), nil
 }

--- a/lib/column/datetime.go
+++ b/lib/column/datetime.go
@@ -1,6 +1,7 @@
 package column
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/lib/binary"
@@ -71,17 +72,39 @@ func (dt *DateTime) Write(encoder *binary.Encoder, v interface{}) error {
 }
 
 func (dt *DateTime) parse(value string) (int64, error) {
-	tv, err := time.Parse("2006-01-02 15:04:05", value)
+	var year, month, day, hour, minute, second int
+	_, err := fmt.Sscanf(value, "%d-%d-%d %d:%d:%d",
+		&year, &month, &day, &hour, &minute, &second)
 	if err != nil {
 		return 0, err
 	}
-	return time.Date(
-		time.Time(tv).Year(),
-		time.Time(tv).Month(),
-		time.Time(tv).Day(),
-		time.Time(tv).Hour(),
-		time.Time(tv).Minute(),
-		time.Time(tv).Second(),
-		0, time.Local,    //use local timzone when insert into clickhouse
-	).Unix(), nil
+
+	if year == 0 {
+		return 0, nil
+	}
+
+	seconds := makeDaySecond(year, month, day, time.Local) +
+		int64(hour*3600+minute*60+second)
+	return seconds, nil
+}
+
+const (
+	DATE_LUT_MIN_YEAR = 1970
+	DATE_LUT_MAX_YEAR = 2106
+)
+
+func makeDaySecond(year, month, day int, loc *time.Location) int64 {
+	switch {
+	case year < DATE_LUT_MIN_YEAR:
+	case year > DATE_LUT_MAX_YEAR:
+	case month < 1:
+	case month > 12:
+	case day < 1:
+	case day > 31:
+	default:
+		//use local timzone when insert into clickhouse
+		return time.Date(year, time.Month(month), day,
+			0, 0, 0, 0, loc).Unix()
+	}
+	return 0
 }


### PR DESCRIPTION
I try to fix the bug #171  , This PR refers to the implementation in the c++ source code. [src](https://github.com/ClickHouse/ClickHouse/blob/master/base/common/DateLUTImpl.h)
```
    // Create DayNum from year, month, day of month.
    inline DayNum makeDayNum(UInt16 year, UInt8 month, UInt8 day_of_month) const
    {
        if (unlikely(year < DATE_LUT_MIN_YEAR || year > DATE_LUT_MAX_YEAR || month < 1 || month > 12 || day_of_month < 1 || day_of_month > 31))
            return DayNum(0); // TODO (nemkov, DateTime64 phase 2): implement creating real date for year outside of LUT range.

        return DayNum(years_months_lut[(year - DATE_LUT_MIN_YEAR) * 12 + month - 1] + day_of_month - 1);
    }
```