### PR TITLE
nothing to do with query when @ haven't params

### DIFF
--- a/stmt.go
+++ b/stmt.go
@@ -126,6 +126,8 @@ func (stmt *stmt) bind(args []driver.NamedValue) string {
 								buf.WriteString(quote(v.Value))
 							}
 						}
+					} else {
+						buf.WriteRune(char)
 					}
 				case '?':
 					if keyword && index < len(args) && len(args[index].Name) == 0 {


### PR DESCRIPTION
I have problems when try to use where statement like this:

`AND (search_text like ('@%') OR search_text = '@' OR search_text like ('[%') OR search_text = '[')`

and it parsed in next result query `AND (search_text like ('%') OR search_text = '' OR search_text like ('[%') OR search_text = '[')`

so i add `else` statement like for '?', for fix it
is it right way?