### PR TITLE
Add time rfc 3339 support

### DIFF
--- a/issues_test.go
+++ b/issues_test.go
@@ -250,6 +250,8 @@ func TestQuerySettings(t *testing.T) {
 			settings += "1000"
 		case boolQS:
 			settings += "false"
+		case stringQS:
+			settings += "foo"
 		}
 	}
 

--- a/lib/column/column_test.go
+++ b/lib/column/column_test.go
@@ -449,7 +449,12 @@ func Test_Column_DateTime(t *testing.T) {
 				assert.Equal(t, timeNow, v)
 			}
 		}
-		if err := column.Write(encoder, timeNow.In(time.UTC).Format("2006-01-02 15:04:05")); assert.NoError(t, err) {
+		if err := column.Write(encoder, timeNow.In(time.Local).Format("2006-01-02 15:04:05")); assert.NoError(t, err) {
+			if v, err := column.Read(decoder, false); assert.NoError(t, err) {
+				assert.Equal(t, timeNow, v)
+			}
+		}
+		if err := column.Write(encoder, timeNow.In(time.Local).Format(time.RFC3339)); assert.NoError(t, err) {
 			if v, err := column.Read(decoder, false); assert.NoError(t, err) {
 				assert.Equal(t, timeNow, v)
 			}
@@ -472,18 +477,23 @@ func Test_Column_DateTime64(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "DateTime64(6)", time.UTC); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "DateTime64(7)", time.UTC); assert.NoError(t, err) {
 		if err := column.Write(encoder, timeNow); assert.NoError(t, err) {
 			if v, err := column.Read(decoder, false); assert.NoError(t, err) {
 				assert.Equal(t, timeNow, v)
 			}
 		}
-		if err := column.Write(encoder, timeNow.In(time.UTC).Format("2006-01-02 15:04:05.999999")); assert.NoError(t, err) {
+		if err := column.Write(encoder, timeNow.In(time.UTC).Format("2006-01-02 15:04:05.9999999")); assert.NoError(t, err) {
 			if v, err := column.Read(decoder, false); assert.NoError(t, err) {
 				assert.Equal(t, timeNow, v)
 			}
 		}
-		if assert.Equal(t, "column_name", column.Name()) && assert.Equal(t, "DateTime64(6)", column.CHType()) {
+		if err := column.Write(encoder, timeNow.In(time.Local).Format(time.RFC3339Nano)); assert.NoError(t, err) {
+			if v, err := column.Read(decoder, false); assert.NoError(t, err) {
+				assert.Equal(t, timeNow, v)
+			}
+		}
+		if assert.Equal(t, "column_name", column.Name()) && assert.Equal(t, "DateTime64(7)", column.CHType()) {
 			assert.Equal(t, reflect.TypeOf(time.Time{}).Kind(), column.ScanType().Kind())
 		}
 		if err := column.Write(encoder, int8(0)); assert.Error(t, err) {
@@ -517,7 +527,12 @@ func Test_Column_DateTimeWithTZ(t *testing.T) {
 				assert.Equal(t, timeNow, v)
 			}
 		}
-		if err := column.Write(encoder, timeNow.In(time.UTC).Format("2006-01-02 15:04:05")); assert.NoError(t, err) {
+		if err := column.Write(encoder, timeNow.In(time.Local).Format("2006-01-02 15:04:05")); assert.NoError(t, err) {
+			if v, err := column.Read(decoder, false); assert.NoError(t, err) {
+				assert.Equal(t, timeNow, v)
+			}
+		}
+		if err := column.Write(encoder, timeNow.In(time.Local).Format(time.RFC3339)); assert.NoError(t, err) {
 			if v, err := column.Read(decoder, false); assert.NoError(t, err) {
 				assert.Equal(t, timeNow, v)
 			}

--- a/lib/column/datetime.go
+++ b/lib/column/datetime.go
@@ -73,7 +73,10 @@ func (dt *DateTime) Write(encoder *binary.Encoder, v interface{}) error {
 func (dt *DateTime) parse(value string) (int64, error) {
 	tv, err := time.Parse("2006-01-02 15:04:05", value)
 	if err != nil {
-		return 0, err
+		tv, err = time.Parse(time.RFC3339, value)
+		if err != nil {
+			return 0, err
+		}
 	}
 	return time.Date(
 		time.Time(tv).Year(),
@@ -82,6 +85,6 @@ func (dt *DateTime) parse(value string) (int64, error) {
 		time.Time(tv).Hour(),
 		time.Time(tv).Minute(),
 		time.Time(tv).Second(),
-		0, time.Local,    //use local timzone when insert into clickhouse
+		0, time.Local, //use local timzone when insert into clickhouse
 	).Unix(), nil
 }

--- a/lib/column/datetime64.go
+++ b/lib/column/datetime64.go
@@ -85,7 +85,10 @@ func (dt *DateTime64) Write(encoder *binary.Encoder, v interface{}) error {
 func (dt *DateTime64) parse(value string) (int64, error) {
 	tv, err := time.Parse("2006-01-02 15:04:05.999", value)
 	if err != nil {
-		return 0, err
+		tv, err = time.Parse(time.RFC3339Nano, value)
+		if err != nil {
+			return 0, err
+		}
 	}
 	return tv.UnixNano(), nil
 }

--- a/query_settings.go
+++ b/query_settings.go
@@ -16,6 +16,7 @@ const (
 	intQS
 	boolQS
 	timeQS
+	stringQS
 )
 
 // description of single query setting
@@ -214,6 +215,8 @@ var querySettingList = []querySettingInfo{
 	{"http_receive_timeout", timeQS},
 	{"max_execution_time", timeQS},
 	{"timeout_before_checking_execution_speed", timeQS},
+
+	{"date_time_input_format", stringQS},
 }
 
 type querySettingValueEncoder func(enc *binary.Encoder) error
@@ -236,6 +239,9 @@ func makeQuerySettings(query url.Values) (*querySettings, error) {
 		}
 
 		switch info.qsType {
+		case stringQS:
+			qs.settings[info.name] = func(enc *binary.Encoder) error { return enc.String(valueStr) }
+
 		case uintQS, intQS, timeQS:
 			value, err := strconv.ParseUint(valueStr, 10, 64)
 			if err != nil {


### PR DESCRIPTION
- Add support for https://clickhouse.tech/docs/en/operations/settings/settings/#settings-date_time_input_format in DSN
- Add support for Go time.RFC3339 format