### PR TITLE
fix: add escape char support

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -17,6 +17,7 @@ func numInput(query string) int {
 		args          = make(map[string]struct{})
 		reader        = bytes.NewReader([]byte(query))
 		quote, gravis bool
+		escape        bool
 		keyword       bool
 		inBetween     bool
 		like          = newMatcher("like")
@@ -26,7 +27,15 @@ func numInput(query string) int {
 	)
 	for {
 		if char, _, err := reader.ReadRune(); err == nil {
+			if escape {
+				escape = false
+				continue
+			}
 			switch char {
+			case '\\':
+				if gravis || quote {
+					escape = true
+				}
 			case '\'':
 				if !gravis {
 					quote = !quote

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -37,6 +37,7 @@ func Test_NumInput(t *testing.T) {
 		"SELECT * FROM example WHERE a BETWEEN ? AND ? AND b = ?":             3,
 		"SELECT * FROM example WHERE a = ? AND b BETWEEN ? AND ?":             3,
 		"SELECT * FROM example WHERE a BETWEEN ? AND ? AND b BETWEEN ? AND ?": 4,
+		"SELECT replace(a, '\\'', '\"') FROM example WHERE b = ?":             1,
 	} {
 		assert.Equal(t, num, numInput(query), query)
 	}


### PR DESCRIPTION
## Problem
when query `SELECT replace(a, '\'', '"') FROM example WHERE b = ?` with args `1`. 
encounter error `panic: sql: expected 0 arguments, got 1`

## Change
add escape char check in `numInput` 