### PR TITLE
Add support for Nullable(IPv4) and Nullable(IPv6)

### DIFF
--- a/lib/column/common.go
+++ b/lib/column/common.go
@@ -29,8 +29,8 @@ var columnBaseTypes = map[interface{}]reflect.Value{
 	float64(0):  reflect.ValueOf(float64(0)),
 	string(""):  reflect.ValueOf(string("")),
 	time.Time{}: reflect.ValueOf(time.Time{}),
-	IPv4{}:      reflect.ValueOf(net.IP{}),
-	IPv6{}:      reflect.ValueOf(net.IP{}),
+	IPv4{}:      reflect.ValueOf(net.IPv4zero),
+	IPv6{}:      reflect.ValueOf(net.IPv6unspecified),
 }
 
 var arrayBaseTypes = map[interface{}]reflect.Type{
@@ -46,8 +46,8 @@ var arrayBaseTypes = map[interface{}]reflect.Type{
 	float64(0):  reflect.ValueOf(float64(0)).Type(),
 	string(""):  reflect.ValueOf(string("")).Type(),
 	time.Time{}: reflect.ValueOf(time.Time{}).Type(),
-	IPv4{}:      reflect.ValueOf(net.IP{}).Type(),
-	IPv6{}:      reflect.ValueOf(net.IP{}).Type(),
+	IPv4{}:      reflect.ValueOf(net.IPv4zero).Type(),
+	IPv6{}:      reflect.ValueOf(net.IPv6unspecified).Type(),
 }
 
 type base struct {

--- a/lib/column/nullable.go
+++ b/lib/column/nullable.go
@@ -51,7 +51,7 @@ func (null *Nullable) ReadNull(decoder *binary.Decoder, rows int) (_ []interface
 	return values, nil
 }
 func (null *Nullable) WriteNull(nulls, encoder *binary.Encoder, v interface{}) error {
-	if value := reflect.ValueOf(v); v == nil || (value.Kind() == reflect.Ptr && value.IsNil()) {
+	if isNil(v) {
 		if _, err := nulls.Write([]byte{1}); err != nil {
 			return err
 		}
@@ -82,4 +82,15 @@ func parseNullable(name, chType string, timezone *time.Location) (*Nullable, err
 
 func (null *Nullable) GetColumn() Column {
 	return null.column
+}
+
+func isNil(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	switch val := reflect.ValueOf(v); val.Type().Kind() {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Ptr, reflect.Slice:
+		return val.IsNil()
+	}
+	return false
 }


### PR DESCRIPTION
This PR fixes base values for types IPv4 and IPv6 as well as the Nullable nil check. This allows inserting ip address for fields of type `Nulllable(IPv4)` and `Nullable(IPv6)`. Please, see commits for more details.