### PR TITLE
fix crash bug when sending nil to array column

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -59,15 +59,15 @@ type clickhouse struct {
 	inTransaction bool
 }
 
-func (ch *clickhouse) Prepare(query string) (driver.Stmt, error) {
+func (ch *clickhouse) Prepare(query string) (Stmt, error) {
 	return ch.prepareContext(context.Background(), query)
 }
 
-func (ch *clickhouse) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+func (ch *clickhouse) PrepareContext(ctx context.Context, query string) (Stmt, error) {
 	return ch.prepareContext(ctx, query)
 }
 
-func (ch *clickhouse) prepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+func (ch *clickhouse) prepareContext(ctx context.Context, query string) (Stmt, error) {
 	ch.logf("[prepare] %s", query)
 	switch {
 	case ch.conn.closed:
@@ -87,7 +87,7 @@ func (ch *clickhouse) prepareContext(ctx context.Context, query string) (driver.
 	}, nil
 }
 
-func (ch *clickhouse) insert(ctx context.Context, query string) (_ driver.Stmt, err error) {
+func (ch *clickhouse) insert(ctx context.Context, query string) (_ Stmt, err error) {
 	if err := ch.sendQuery(ctx, splitInsertRe.Split(query, -1)[0]+" VALUES ", nil); err != nil {
 		return nil, err
 	}

--- a/lib/data/block.go
+++ b/lib/data/block.go
@@ -135,6 +135,10 @@ func (block *Block) AppendRow(args []driver.Value) error {
 		case *column.Array:
 			value := reflect.ValueOf(args[num])
 			if value.Kind() != reflect.Slice {
+				if args[num] == nil {
+					return fmt.Errorf("Array(T) type could not be nil, use empty array instead")
+				}
+
 				return fmt.Errorf("unsupported Array(T) type [%T]", value.Interface())
 			}
 			if err := block.writeArray(c, newValue(value), num, 1); err != nil {

--- a/stmt.go
+++ b/stmt.go
@@ -9,6 +9,12 @@ import (
 	"github.com/ClickHouse/clickhouse-go/lib/data"
 )
 
+type Stmt interface {
+	driver.Stmt
+	driver.StmtQueryContext
+	driver.StmtExecContext
+}
+
 type stmt struct {
 	ch       *clickhouse
 	query    string
@@ -20,7 +26,9 @@ type stmt struct {
 var emptyResult = &result{}
 
 type key string
+
 var queryIDKey key
+
 //Put query ID into context and use it in ExecContext or QueryContext
 func WithQueryID(ctx context.Context, queryID string) context.Context {
 	return context.WithValue(ctx, queryIDKey, queryID)

--- a/write_column.go
+++ b/write_column.go
@@ -1,6 +1,7 @@
 package clickhouse
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"time"
@@ -11,7 +12,8 @@ import (
 // Interface for Clickhouse driver
 type Clickhouse interface {
 	Block() (*data.Block, error)
-	Prepare(query string) (driver.Stmt, error)
+	Prepare(query string) (Stmt, error)
+	PrepareContext(ctx context.Context, query string) (Stmt, error)
 	Begin() (driver.Tx, error)
 	Commit() error
 	Rollback() error


### PR DESCRIPTION
fix: when inserting data, sending nil to array column, it will panic due to calling value.Interface() in block.AppendRow() function, this commit could avoid this