### PR TITLE
Improve DSN string parsing

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -80,13 +80,14 @@ func Open(dsn string) (driver.Conn, error) {
 }
 
 func open(dsn string) (*clickhouse, error) {
-	url, err := url.Parse(dsn)
+	parsedUrl, err := url.Parse(dsn)
 	if err != nil {
 		return nil, err
 	}
+
 	var (
-		hosts            = []string{url.Host}
-		query            = url.Query()
+		hosts            = []string{parsedUrl.Host}
+		query            = parsedUrl.Query()
 		secure           = false
 		skipVerify       = false
 		tlsConfigName    = query.Get("tls_config")
@@ -177,7 +178,7 @@ func open(dsn string) (*clickhouse, error) {
 		}
 		logger = log.New(logOutput, "[clickhouse]", 0)
 	)
-	if debug, err := strconv.ParseBool(url.Query().Get("debug")); err == nil && debug {
+	if debug, err := strconv.ParseBool(parsedUrl.Query().Get("debug")); err == nil && debug {
 		ch.logf = logger.Printf
 	}
 	ch.logf("host(s)=%s, database=%s, username=%s",

--- a/connect.go
+++ b/connect.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"database/sql/driver"
 	"net"
+	"net/url"
 	"sync/atomic"
 	"time"
 )
@@ -37,6 +38,25 @@ type connOptions struct {
 	noDelay                                bool
 	openStrategy                           openStrategy
 	logf                                   func(string, ...interface{})
+}
+
+type dsnQueryParams struct {
+	rawDsn      string
+	parsedUrl   *url.URL
+	hosts       []string
+	queryParams url.Values
+	settings    *querySettings
+
+	tlsConfigName string
+	database      string
+	username      string
+	password      string
+
+	compress  bool
+	blockSize int
+	poolSize  int
+
+	connOpts connOptions
 }
 
 func dial(options connOptions) (*connect, error) {


### PR DESCRIPTION
From #362: strings in the DSN passed to Open() were not correctly
URL-escaped; this caused some string fields containing values requiring
proper escaping to be passed to the new connection instance, causing
errors such as the one noted in the aforementioned issue.

This PR adds the parseDsn(string) method, as well as a few helper
methods for retrieving values from the DSN. parseDsn loads all necessary
variables from its parameter, using the same defaults that open() used.
parseDsn also ensures that query parameters such as `username` and
`password` are properly escaped using `url.QueryEscape`, ensuring that
url encoding errors don't occur.