### PR TITLE
Add a column handler for AggregatedFunction

### DIFF
--- a/lib/column/aggregate_function.go
+++ b/lib/column/aggregate_function.go
@@ -1,0 +1,47 @@
+package column
+
+import (
+	"fmt"
+	"github.com/ClickHouse/clickhouse-go/lib/binary"
+	"reflect"
+	"strings"
+	"time"
+)
+
+type AggregateFunction struct {
+	base
+	column   Column
+	function string
+}
+
+func (agg *AggregateFunction) ScanType() reflect.Type {
+	return agg.column.ScanType()
+}
+
+func (agg *AggregateFunction) Read(decoder *binary.Decoder, isNull bool) (interface{}, error) {
+	return agg.column.Read(decoder, isNull)
+}
+
+func (agg *AggregateFunction) Write(encoder *binary.Encoder, v interface{}) error {
+	return agg.column.Write(encoder, v)
+}
+
+func parseAggregateFunction(name, chType string, timezone *time.Location) (*AggregateFunction, error) {
+	parensContents := strings.Split(chType[18:len(chType)-1], ",")
+	if len(parensContents) != 2 {
+		return nil, fmt.Errorf("AggregateFunction: %v", "not enough arguments")
+	}
+
+	column, err := Factory(name, strings.TrimSpace(parensContents[1]), timezone)
+	if err != nil {
+		return nil, fmt.Errorf("AggregateFunction: %v", err)
+	}
+
+	return &AggregateFunction{
+		base: base{
+			name:   name,
+			chType: chType,
+		},
+		column: column,
+	}, nil
+}

--- a/lib/column/column.go
+++ b/lib/column/column.go
@@ -174,6 +174,8 @@ func Factory(name, chType string, timezone *time.Location) (Column, error) {
 		return parseEnum(name, chType)
 	case strings.HasPrefix(chType, "Decimal"):
 		return parseDecimal(name, chType)
+	case strings.HasPrefix(chType, "AggregateFunction"):
+		return parseAggregateFunction(name, chType, timezone)
 	case strings.HasPrefix(chType, "SimpleAggregateFunction"):
 		if nestedType, err := getNestedType(chType, "SimpleAggregateFunction"); err != nil {
 			return nil, err

--- a/lib/column/column_test.go
+++ b/lib/column/column_test.go
@@ -742,3 +742,11 @@ func Test_Column_NullableEnum8(t *testing.T) {
 		}
 	}
 }
+
+func Test_Column_AggregateFunction(t *testing.T) {
+	if column, err := columns.Factory("column_name", "AggregateFunction(max, UInt64)", time.Local); assert.NoError(t, err) {
+		if assert.Equal(t, "column_name", column.Name()) && assert.Equal(t, "AggregateFunction(max, UInt64)", column.CHType()) {
+			assert.Equal(t, reflect.Uint64, column.ScanType().Kind())
+		}
+	}
+}


### PR DESCRIPTION
Since I'm unable to get master to compile or run tests. Happy to move it over to master if that needs be.

Added an AggregateFunction type (implements Column) to a new file, function.go in the lib/column dir. This adds support for AggregateFunction columns in CH, holding the name of the aggregation function in a field named function and the type of its rvalue in base.valueOf.
Added a case clause to the Factory func that resolves chTypes to column types.
Added a (very) basic unit test.