### PR TITLE
Add RegisterDial function

### DIFF
--- a/clickhouse_test.go
+++ b/clickhouse_test.go
@@ -1555,3 +1555,13 @@ func Test_LikeQuery(t *testing.T) {
 		}
 	}
 }
+
+func Test_RegisterDial(t *testing.T) {
+	clickhouse.RegisterDial(func(network, address string, timeout time.Duration, config *tls.Config) (net.Conn, error) {
+		return net.DialTimeout(network, address, timeout)
+	})
+	if connect, err := sql.Open("clickhouse", "tcp://127.0.0.1:9000?debug=true"); assert.NoError(t, err) {
+		assert.NoError(t, connect.Ping())
+	}
+	clickhouse.DeregisterDial()
+}

--- a/connect.go
+++ b/connect.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"database/sql/driver"
 	"net"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -37,6 +38,29 @@ type connOptions struct {
 	noDelay                                bool
 	openStrategy                           openStrategy
 	logf                                   func(string, ...interface{})
+}
+
+// DialFunc is a function which can be used to establish the network connection.
+// Custom dial functions must be registered with RegisterDial
+type DialFunc func(network, address string, timeout time.Duration, config *tls.Config) (net.Conn, error)
+
+var (
+	customDialLock sync.RWMutex
+	customDial     DialFunc
+)
+
+// RegisterDial registers a custom dial function.
+func RegisterDial(dial DialFunc) {
+	customDialLock.Lock()
+	customDial = dial
+	customDialLock.Unlock()
+}
+
+// DeregisterDial deregisters the custom dial function.
+func DeregisterDial() {
+	customDialLock.Lock()
+	customDial = nil
+	customDialLock.Unlock()
 }
 
 func dial(options connOptions) (*connect, error) {
@@ -74,18 +98,29 @@ func dial(options connOptions) (*connect, error) {
 			}
 			checkedHosts[num] = struct{}{}
 		}
+		customDialLock.RLock()
+		cd := customDial
+		customDialLock.RUnlock()
 		switch {
 		case options.secure:
-			conn, err = tls.DialWithDialer(
-				&net.Dialer{
-					Timeout: options.connTimeout,
-				},
-				"tcp",
-				options.hosts[num],
-				tlsConfig,
-			)
+			if cd != nil {
+				conn, err = cd("tcp", options.hosts[num], options.connTimeout, tlsConfig)
+			} else {
+				conn, err = tls.DialWithDialer(
+					&net.Dialer{
+						Timeout: options.connTimeout,
+					},
+					"tcp",
+					options.hosts[num],
+					tlsConfig,
+				)
+			}
 		default:
-			conn, err = net.DialTimeout("tcp", options.hosts[num], options.connTimeout)
+			if cd != nil {
+				conn, err = cd("tcp", options.hosts[num], options.connTimeout, nil)
+			} else {
+				conn, err = net.DialTimeout("tcp", options.hosts[num], options.connTimeout)
+			}
 		}
 		if err == nil {
 			options.logf(


### PR DESCRIPTION
Add a function to enable the user to optionally register a custom dial function. Implementation mostly inspired by [mysql driver](https://github.com/go-sql-driver/mysql/blob/46351a8892976898935f653f5333782579a96fa5/driver.go#L49).