### PR TITLE
Fix decimal encoding to allow writing Nullable Decimal32

### DIFF
--- a/lib/column/decimal.go
+++ b/lib/column/decimal.go
@@ -3,6 +3,7 @@ package column
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -68,16 +69,25 @@ func (d *Decimal) write32(encoder *binary.Encoder, v interface{}) error {
 	case int32:
 		return encoder.Int32(int32(v))
 	case int64:
-		return errors.New("narrowing type conversion from int64 to int32")
+		if v > math.MaxInt32 {
+			return errors.New("overflow when narrowing type conversion from int64 to int32")
+		}
+		return encoder.Int32(int32(v))
 
 	case uint8:
 		return encoder.Int32(int32(v))
 	case uint16:
 		return encoder.Int32(int32(v))
 	case uint32:
-		return errors.New("narrowing type conversion from uint32 to int32")
+		if v > math.MaxInt32 {
+			return errors.New("overflow when narrowing type conversion from uint32 to int32")
+		}
+		return encoder.Int32(int32(v))
 	case uint64:
-		return errors.New("narrowing type conversion from uint64 to int32")
+		if v > math.MaxInt32 {
+			return errors.New("overflow when narrowing type conversion from uint64 to int32")
+		}
+		return encoder.Int32(int32(v))
 
 	case float32:
 		fixed := d.float2int32(float64(v))
@@ -94,16 +104,25 @@ func (d *Decimal) write32(encoder *binary.Encoder, v interface{}) error {
 	case *int32:
 		return encoder.Int32(int32(*v))
 	case *int64:
-		return errors.New("narrowing type conversion from int64 to int32")
+		if *v > math.MaxInt32 {
+			return errors.New("overflow when narrowing type conversion from int64 to int32")
+		}
+		return encoder.Int32(int32(*v))
 
 	case *uint8:
 		return encoder.Int32(int32(*v))
 	case *uint16:
 		return encoder.Int32(int32(*v))
 	case *uint32:
-		return errors.New("narrowing type conversion from uint32 to int32")
+		if *v > math.MaxInt32 {
+			return errors.New("overflow when narrowing type conversion from uint34 to int32")
+		}
+		return encoder.Int32(int32(*v))
 	case *uint64:
-		return errors.New("narrowing type conversion from uint64 to int32")
+		if *v > math.MaxInt32 {
+			return errors.New("overflow when narrowing type conversion from uint64 to int32")
+		}
+		return encoder.Int32(int32(*v))
 
 	case *float32:
 		fixed := d.float2int32(float64(*v))
@@ -139,7 +158,10 @@ func (d *Decimal) write64(encoder *binary.Encoder, v interface{}) error {
 	case uint32:
 		return encoder.Int64(int64(v))
 	case uint64:
-		return errors.New("narrowing type conversion from uint64 to int64")
+		if v > math.MaxInt64 {
+			return errors.New("overflow when narrowing type conversion from uint64 to int64")
+		}
+		return encoder.Int64(int64(v))
 
 	case float32:
 		fixed := d.float2int64(float64(v))
@@ -167,7 +189,10 @@ func (d *Decimal) write64(encoder *binary.Encoder, v interface{}) error {
 	case *uint32:
 		return encoder.Int64(int64(*v))
 	case *uint64:
-		return errors.New("narrowing type conversion from uint64 to int64")
+		if *v > math.MaxInt64 {
+			return errors.New("overflow when narrowing type conversion from uint64 to int64")
+		}
+		return encoder.Int64(int64(*v))
 
 	case *float32:
 		fixed := d.float2int64(float64(*v))

--- a/lib/column/decimal.go
+++ b/lib/column/decimal.go
@@ -69,7 +69,7 @@ func (d *Decimal) write32(encoder *binary.Encoder, v interface{}) error {
 	case int32:
 		return encoder.Int32(int32(v))
 	case int64:
-		if v > math.MaxInt32 {
+		if v > math.MaxInt32 || v < math.MinInt32 {
 			return errors.New("overflow when narrowing type conversion from int64 to int32")
 		}
 		return encoder.Int32(int32(v))
@@ -104,7 +104,7 @@ func (d *Decimal) write32(encoder *binary.Encoder, v interface{}) error {
 	case *int32:
 		return encoder.Int32(int32(*v))
 	case *int64:
-		if *v > math.MaxInt32 {
+		if *v > math.MaxInt32 || *v < math.MinInt32 {
 			return errors.New("overflow when narrowing type conversion from int64 to int32")
 		}
 		return encoder.Int32(int32(*v))

--- a/lib/column/decimal_test.go
+++ b/lib/column/decimal_test.go
@@ -2,6 +2,7 @@ package column
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/binary"
 	"testing"
 
@@ -18,6 +19,151 @@ func TestDecimal_Write32(t *testing.T) {
 		0,
 		1,
 		-1,
+		10,
+		123,
+		1234567,
+		1234567890,
+		-1234567890,
+	}
+
+	for _, attempt := range data {
+		buff.Reset()
+
+		d := &Decimal{
+			base: base{
+				name:   "testcolumn",
+				chType: "Decimal(5,3)",
+			},
+			nobits:    32,
+			precision: 5,
+			scale:     3,
+		}
+
+		err := d.Write(encoder, attempt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = encoder.Flush()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		value := int32(binary.LittleEndian.Uint32(buff.Bytes()))
+		if value != attempt {
+			t.Errorf("Expecting: %d; Got: %d", attempt, value)
+		}
+	}
+}
+
+func TestDecimal_WriteNullable32(t *testing.T) {
+	t.Parallel()
+
+	buff := &bytes.Buffer{}
+	encoder := chbin.NewEncoder(buff)
+
+	data := []sql.NullInt32{
+		{Valid: true, Int32: 0},
+		{Valid: true, Int32: 1},
+		{Valid: true, Int32: -1},
+		{Valid: true, Int32: 10},
+		{Valid: true, Int32: 123},
+		{Valid: true, Int32: 1234567},
+		{Valid: true, Int32: 1234567890},
+		{Valid: true, Int32: -1234567890},
+	}
+
+	for _, attempt := range data {
+		buff.Reset()
+
+		d := &Decimal{
+			base: base{
+				name:   "testcolumn",
+				chType: "Decimal(5,3)",
+			},
+			nobits:    32,
+			precision: 5,
+			scale:     3,
+		}
+
+		attemptValue, err := attempt.Value()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = d.Write(encoder, attemptValue)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = encoder.Flush()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		value := int32(binary.LittleEndian.Uint32(buff.Bytes()))
+		if value != int32(attemptValue.(int64)) {
+			t.Errorf("Expecting: %v; Got: %d", attemptValue, value)
+		}
+	}
+}
+
+func TestDecimal_Write32_WithInt64(t *testing.T) {
+	t.Parallel()
+
+	buff := &bytes.Buffer{}
+	encoder := chbin.NewEncoder(buff)
+
+	data := []int64{
+		0,
+		1,
+		-1,
+		10,
+		123,
+		1234567,
+		1234567890,
+		-1234567890,
+	}
+
+	for _, attempt := range data {
+		buff.Reset()
+
+		d := &Decimal{
+			base: base{
+				name:   "testcolumn",
+				chType: "Decimal(5,3)",
+			},
+			nobits:    32,
+			precision: 5,
+			scale:     3,
+		}
+
+		err := d.Write(encoder, attempt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = encoder.Flush()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		value := int32(binary.LittleEndian.Uint32(buff.Bytes()))
+		if value != int32(attempt) {
+			t.Errorf("Expecting: %d; Got: %d", attempt, value)
+		}
+	}
+}
+
+func TestDecimal_Write32_WithUint64(t *testing.T) {
+	t.Parallel()
+
+	buff := &bytes.Buffer{}
+	encoder := chbin.NewEncoder(buff)
+
+	data := []uint64{
+		0,
+		1,
 		10,
 		123,
 		1234567,
@@ -48,8 +194,157 @@ func TestDecimal_Write32(t *testing.T) {
 		}
 
 		value := int32(binary.LittleEndian.Uint32(buff.Bytes()))
+		if value != int32(attempt) {
+			t.Errorf("Expecting: %d; Got: %d", attempt, value)
+		}
+	}
+}
+
+func TestDecimal_Write64(t *testing.T) {
+	t.Parallel()
+
+	buff := &bytes.Buffer{}
+	encoder := chbin.NewEncoder(buff)
+
+	data := []int64{
+		0,
+		1,
+		-1,
+		10,
+		123,
+		1234567,
+		1234567890,
+		-1234567890,
+		12345678901234,
+		-12345678901234,
+	}
+
+	for _, attempt := range data {
+		buff.Reset()
+
+		d := &Decimal{
+			base: base{
+				name:   "testcolumn",
+				chType: "Decimal(10,3)",
+			},
+			nobits:    64,
+			precision: 10,
+			scale:     3,
+		}
+
+		err := d.Write(encoder, attempt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = encoder.Flush()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		value := int64(binary.LittleEndian.Uint64(buff.Bytes()))
 		if value != attempt {
-			t.Errorf("Expecting: %d; Got: %d", value, attempt)
+			t.Errorf("Expecting: %d; Got: %d", attempt, value)
+		}
+	}
+}
+
+func TestDecimal_WriteNullable64(t *testing.T) {
+	t.Parallel()
+
+	buff := &bytes.Buffer{}
+	encoder := chbin.NewEncoder(buff)
+
+	data := []sql.NullInt64{
+		{Valid: true, Int64: 0},
+		{Valid: true, Int64: 1},
+		{Valid: true, Int64: -1},
+		{Valid: true, Int64: 10},
+		{Valid: true, Int64: 123},
+		{Valid: true, Int64: 1234567},
+		{Valid: true, Int64: 1234567890},
+		{Valid: true, Int64: -1234567890},
+		{Valid: true, Int64: 12345678901234},
+		{Valid: true, Int64: -12345678901234},
+	}
+
+	for _, attempt := range data {
+		buff.Reset()
+
+		d := &Decimal{
+			base: base{
+				name:   "testcolumn",
+				chType: "Decimal(10,3)",
+			},
+			nobits:    64,
+			precision: 10,
+			scale:     3,
+		}
+
+		attemptValue, err := attempt.Value()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = d.Write(encoder, attemptValue)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = encoder.Flush()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		value := int64(binary.LittleEndian.Uint64(buff.Bytes()))
+		if value != attemptValue.(int64) {
+			t.Errorf("Expecting: %v; Got: %d", attemptValue, value)
+		}
+	}
+}
+
+func TestDecimal_Write64_WithUint64(t *testing.T) {
+	t.Parallel()
+
+	buff := &bytes.Buffer{}
+	encoder := chbin.NewEncoder(buff)
+
+	data := []uint64{
+		0,
+		1,
+		10,
+		123,
+		1234567,
+		1234567890,
+		12345678901234,
+	}
+
+	for _, attempt := range data {
+		buff.Reset()
+
+		d := &Decimal{
+			base: base{
+				name:   "testcolumn",
+				chType: "Decimal(10,3)",
+			},
+			nobits:    64,
+			precision: 10,
+			scale:     3,
+		}
+
+		err := d.Write(encoder, attempt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = encoder.Flush()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		value := int64(binary.LittleEndian.Uint64(buff.Bytes()))
+		if value != int64(attempt) {
+			t.Errorf("Expecting: %d; Got: %d", attempt, value)
 		}
 	}
 }

--- a/lib/column/decimal_test.go
+++ b/lib/column/decimal_test.go
@@ -1,0 +1,55 @@
+package column
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	chbin "github.com/ClickHouse/clickhouse-go/lib/binary"
+)
+
+func TestDecimal_Write32(t *testing.T) {
+	t.Parallel()
+
+	buff := &bytes.Buffer{}
+	encoder := chbin.NewEncoder(buff)
+
+	data := []int32{
+		0,
+		1,
+		-1,
+		10,
+		123,
+		1234567,
+		1234567890,
+	}
+
+	for _, attempt := range data {
+		buff.Reset()
+
+		d := &Decimal{
+			base: base{
+				name:   "testcolumn",
+				chType: "Decimal(5,3)",
+			},
+			nobits:    32,
+			precision: 5,
+			scale:     3,
+		}
+
+		err := d.Write(encoder, attempt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = encoder.Flush()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		value := int32(binary.LittleEndian.Uint32(buff.Bytes()))
+		if value != attempt {
+			t.Errorf("Expecting: %d; Got: %d", value, attempt)
+		}
+	}
+}


### PR DESCRIPTION
This is a major bug we've run into: Clickhouse does not allow writing a `sql.NullInt32` to a `Nullable(Decimal32(x))` field.

The error you get is: `narrowing type conversion from int64 to int32`

Why? Because `sql.NullInt32.Value()` returns an `int64`, like so:
```golang
func (n NullInt32) Value() (driver.Value, error) {
	if !n.Valid {
		return nil, nil
	}
	return int64(n.Int32), nil
}
```

And clickhouse's golang driver won't let you write an int64 to a Decimal32 field:
```golang

func (d *Decimal) write32(encoder *binary.Encoder, v interface{}) error {
	switch v := v.(type) {
	// lots of other cases...
	case int64:
		return errors.New("narrowing type conversion from int64 to int32")
	}
}
```

The answer is to allow writing it, so long as it doesn't actually overflow.
This is what my PR does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clickhouse/clickhouse-go/373)
<!-- Reviewable:end -->
