### PR TITLE
Include column name in "unhandled type" message

### DIFF
--- a/lib/column/column.go
+++ b/lib/column/column.go
@@ -183,7 +183,7 @@ func Factory(name, chType string, timezone *time.Location) (Column, error) {
 	case strings.HasPrefix(chType, "Tuple"):
 		return parseTuple(name, chType, timezone)
 	}
-	return nil, fmt.Errorf("column: unhandled type %v", chType)
+	return nil, fmt.Errorf("column %s: unhandled type %v", name, chType)
 }
 
 func getNestedType(chType string, wrapType string) (string, error) {


### PR DESCRIPTION
This PR includes the column name in the "unhandled type" message for easier debugging.

Before: `Error: Nullable(T): column: unhandled type Nothing`

After: Before: `Error: Nullable(T): column opp_record_type_name: unhandled type Nothing`