### PR TITLE
Move from github.com/cloudflare/golz4 to github.com/DataDog/golz4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/ClickHouse/clickhouse-go
 go 1.12
 
 require (
+	github.com/DataDog/golz4 v1.1.1
 	github.com/bkaradzic/go-lz4 v1.0.0
-	github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/pierrec/lz4 v2.0.5+incompatible
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
+github.com/DataDog/golz4 v1.1.1 h1:cb5SN72LQ+7tjNT5DEfVC0K32gd1wBzzCoWhatYDNMU=
+github.com/DataDog/golz4 v1.1.1/go.mod h1:ZvrBUPTzHg+qfkvO1odLwv+Wlnkqr4Q2MTsnDpOeLkg=
 github.com/bkaradzic/go-lz4 v1.0.0 h1:RXc4wYsyz985CkXXeX04y4VnZFGG8Rd43pRaHsOXAKk=
 github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwjwegp5jy4=
-github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58 h1:F1EaeKL/ta07PY/k9Os/UFtwERei2/XzGemhpGnBKNg=
-github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=

--- a/lib/binary/compress_reader_clz4.go
+++ b/lib/binary/compress_reader_clz4.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 
-	lz4 "github.com/cloudflare/golz4"
+	lz4 "github.com/DataDog/golz4"
 )
 
 type compressReader struct {
@@ -95,7 +95,7 @@ func (cr *compressReader) readCompressedData() (err error) {
 			return fmt.Errorf("Decompress read size not match")
 		}
 
-		err = lz4.Uncompress(cr.zdata, cr.data)
+		err = lz4.Uncompress(cr.data, cr.zdata)
 		if err != nil {
 			return
 		}

--- a/lib/binary/compress_test.go
+++ b/lib/binary/compress_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	bklz4 "github.com/bkaradzic/go-lz4"
-	cflz4 "github.com/cloudflare/golz4"
+	cflz4 "github.com/DataDog/golz4"
 	ownlz4 "github.com/ClickHouse/clickhouse-go/lib/lz4"
 	pilz4 "github.com/pierrec/lz4"
 )
@@ -64,7 +64,7 @@ func genBytes(n int) []byte {
 func GetCfEncode(in []byte) []byte {
 	b := cflz4.CompressBound(in)
 	out := make([]byte, b)
-	compressedSize, err := cflz4.Compress(in, out)
+	compressedSize, err := cflz4.Compress(out, in)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/lib/binary/compress_writer_clz4.go
+++ b/lib/binary/compress_writer_clz4.go
@@ -6,7 +6,7 @@ import (
 	"encoding/binary"
 	"io"
 
-	lz4 "github.com/cloudflare/golz4"
+	lz4 "github.com/DataDog/golz4"
 	"github.com/ClickHouse/clickhouse-go/lib/cityhash102"
 )
 
@@ -54,7 +54,7 @@ func (cw *compressWriter) Flush() (err error) {
 		return
 	}
 	// write the headers
-	compressedSize, err := lz4.Compress(cw.data[:cw.pos], cw.zdata[HeaderSize:])
+	compressedSize, err := lz4.Compress(cw.zdata[:cw.pos], cw.data[HeaderSize:])
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
github.com/cloudflare/golz4 is pretty much abandoned and bundles an obsolete copy of lz4 affected by several CVEs. Move this over to github.com/DataDog/golz4 which is an actively maintained fork of the original project.