### PR TITLE
Avoid the influence of timezone when parse time query conditions

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -134,8 +134,11 @@ func quote(v driver.Value) string {
 }
 
 func formatTime(value time.Time) string {
+	// Avoid the influence of timezone when parse midnight, because value.Hour() will be
+	// the hour under special timezone
+	utcMidnight := time.Date(value.Year(), value.Month(), value.Day(), 0, 0, 0, 0, time.UTC)
 	// toDate() overflows after 65535 days, but toDateTime() only overflows when time.Time overflows (after 9223372036854775807 seconds)
-	if days := value.Unix() / 24 / 3600; days <= math.MaxUint16 && (value.Hour()+value.Minute()+value.Second()+value.Nanosecond()) == 0 {
+	if days := utcMidnight.Unix() / 24 / 3600; days <= math.MaxUint16 && (value.Hour()+value.Minute()+value.Second()+value.Nanosecond()) == 0 {
 		return fmt.Sprintf("toDate(%d)", days)
 	}
 	return fmt.Sprintf("toDateTime(%d)", value.Unix())


### PR DESCRIPTION
Try to fix the issues [382](https://github.com/ClickHouse/clickhouse-go/issues/382).
When query condition is midnight with type of time.Time and non-zero timezone, the real sql exec in clickhouse is not expected.
For example:
```
action_time, err := time.ParseInLocation("2006-01-02 15:04:05", "2021-06-25 00:00:00", tz)
connect.Query("SELECT country_code, os_id, browser_id, categories, action_day, action_time FROM example where action_day >?",action_time)
```
then the sql's condition will looks like `action_day > toDate(18802)` with wrong days(SELECT toDate(18802) will be "2021-06-24 "). 