### PR TITLE
[fix-with-totals] Returns `WITH TOTALS` result row with all

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -126,6 +126,7 @@ func (rows *rows) receiveData() error {
 				rows.stream <- block
 			case protocol.ServerTotals:
 				rows.totals = block
+				rows.stream <- block
 			case protocol.ServerExtremes:
 				rows.extremes = block
 			}


### PR DESCRIPTION
We need the `WITH TOTALS` query results. This PR sends the totals row into the blocks stream. It seems that the row usually is last in CH response so we may expect it to be the last row in query result.