### PR TITLE
Fix not supporting SimpleAggregateFunction types not working on types with more than one arguement

### DIFF
--- a/lib/column/column.go
+++ b/lib/column/column.go
@@ -195,6 +195,11 @@ func getNestedType(chType string, wrapType string) (string, error) {
 		if len(nested) == 2 {
 			return strings.TrimSpace(nested[1]), nil
 		}
+
+		if len(nested) == 3 {
+			return strings.TrimSpace(strings.Join(nested[1:], ",")), nil
+		}
 	}
+
 	return "", fmt.Errorf("column: invalid %s type (%s)", wrapType, chType)
 }

--- a/lib/column/column_test.go
+++ b/lib/column/column_test.go
@@ -632,6 +632,7 @@ func Test_Column_SimpleAggregateFunc(t *testing.T) {
 		"SimpleAggregateFunction(anyLast, UInt8)":          "UInt8",
 		"SimpleAggregateFunction(anyLast, Nullable(IPv4))": "Nullable(IPv4)",
 		"SimpleAggregateFunction(max, Nullable(DateTime))": "Nullable(DateTime)",
+		"SimpleAggregateFunction(sum, Decimal(38, 8))":     "Decimal(38, 8)",
 	}
 
 	for key, val := range data {


### PR DESCRIPTION
This change addresses any `SimpleAggregateFunction` which references a type that has more than one argument as outlined in #415 and #412.