### PR TITLE
fix: connCheck signature for unsupported OS

### DIFF
--- a/connect_check_dummy.go
+++ b/connect_check_dummy.go
@@ -2,8 +2,6 @@
 
 package clickhouse
 
-import "net"
-
-func connCheck(conn net.Conn) error {
+func (conn *connect) connCheck() error {
 	return nil
 }


### PR DESCRIPTION
Fix #422  - broken build for connCheck unsupported OS.
