### PR TITLE
Make # of rows/bytes read available to user

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -83,23 +83,25 @@ func open(dsn string) (*clickhouse, error) {
 		return nil, err
 	}
 	var (
-		hosts             = []string{url.Host}
-		query             = url.Query()
-		secure            = false
-		skipVerify        = false
-		tlsConfigName     = query.Get("tls_config")
-		noDelay           = true
-		compress          = false
-		database          = query.Get("database")
-		username          = query.Get("username")
-		password          = query.Get("password")
-		blockSize         = 1000000
-		connTimeout       = DefaultConnTimeout
-		readTimeout       = DefaultReadTimeout
-		writeTimeout      = DefaultWriteTimeout
-		connOpenStrategy  = connOpenRandom
-		checkConnLiveness = true
+		hosts                = []string{url.Host}
+		query                = url.Query()
+		secure               = false
+		skipVerify           = false
+		tlsConfigName        = query.Get("tls_config")
+		noDelay              = true
+		compress             = false
+		database             = query.Get("database")
+		username             = query.Get("username")
+		password             = query.Get("password")
+		blockSize            = 1000000
+		connTimeout          = DefaultConnTimeout
+		readTimeout          = DefaultReadTimeout
+		writeTimeout         = DefaultWriteTimeout
+		connOpenStrategy     = connOpenRandom
+		checkConnLiveness    = true
+		profilingInfoEnabled = false
 	)
+
 	if len(database) == 0 {
 		database = DefaultDatabase
 	}
@@ -157,6 +159,10 @@ func open(dsn string) (*clickhouse, error) {
 		compress = v
 	}
 
+	if v, err := strconv.ParseBool(query.Get("profiling_info")); err == nil {
+		profilingInfoEnabled = v
+	}
+
 	if v, err := strconv.ParseBool(query.Get("check_connection_liveness")); err == nil {
 		checkConnLiveness = v
 	}
@@ -175,6 +181,7 @@ func open(dsn string) (*clickhouse, error) {
 			ServerInfo: data.ServerInfo{
 				Timezone: time.Local,
 			},
+			profilingInfo: profilingInfoEnabled,
 		}
 		logger = log.New(logOutput, "[clickhouse]", 0)
 	)

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -58,6 +58,7 @@ type clickhouse struct {
 	blockSize         int
 	inTransaction     bool
 	checkConnLiveness bool
+	profilingInfo     bool
 }
 
 func (ch *clickhouse) Prepare(query string) (driver.Stmt, error) {


### PR DESCRIPTION
This is kind of a strange way of exposing this information, but as it is very very useful to know the number of rows/bytes read during a query, I thought I'd put it up for the consideration of the maintainers.

Basically, I would love to be able to return the number of rows/bytes read to the callers of my service that sits in front of Clickhouse, in order to give them an idea of why their query might be slow. This information is returned in line as Clickhouse executes queries, but there's no good way to return it to users because of golang's `database/sql` interface.

This adds a flag, which is off by default, that allows a user to request that profiling information be returned before the first row. It's used like this:

```
    // First row will be profiling info
    rows.Next()
    var garbage float64
    pi := clickhouse.ProfilingInfo{}
    err = rows.Scan(&pi, &garbage)

    fmt.Printf("ProfilingInfo: %+v\n", pi)
    fmt.Printf("err: %+v\n", err)

    // rest of rows will be same as normal
    for rows.Next() {
        var timestamp time.Time
        var value float64
        if err := rows.Scan(&timestamp, &value); err != nil {
            return nil, nil, err
        }
        //etc
    }
```

So this is a case where only two columns are returned, but in general the `Scan` call needs to have the same number of columns as are actually returned, so the user will need to setup placeholders to hold those "garbage" values. (They're actually the same values as the first row, but the user would get those values in their regular `for rows.Next()` loop.)

I realize this is a super weird interface and would love suggestions for other ways to accomplish the same goal that don't require making additional queries. Since this data is already returned from CH it would be great to expose it.

Obviously docs and perhaps tests are required here but just looking for validation that there's some interest in taking such a PR, otherwise I will just maintain a patch for the library so I can get this functionality.