### PR TITLE
fix Read buffer in binary.Decoder

### DIFF
--- a/lib/binary/compress_reader.go
+++ b/lib/binary/compress_reader.go
@@ -1,3 +1,4 @@
+//go:build !clz4
 // +build !clz4
 
 package binary
@@ -63,7 +64,7 @@ func (cr *compressReader) Read(buf []byte) (n int, err error) {
 func (cr *compressReader) readCompressedData() (err error) {
 	cr.pos = 0
 	var n int
-	n, err = cr.reader.Read(cr.header)
+	n, err = io.ReadFull(cr.reader, cr.header)
 	if err != nil {
 		return
 	}
@@ -86,7 +87,7 @@ func (cr *compressReader) readCompressedData() (err error) {
 
 	// @TODO checksum
 	if cr.header[16] == LZ4 {
-		n, err = cr.reader.Read(cr.zdata)
+		n, err = io.ReadFull(cr.reader, cr.zdata)
 		if err != nil {
 			return
 		}

--- a/lib/binary/compress_reader_clz4.go
+++ b/lib/binary/compress_reader_clz4.go
@@ -1,3 +1,4 @@
+//go:build clz4
 // +build clz4
 
 package binary
@@ -63,7 +64,7 @@ func (cr *compressReader) Read(buf []byte) (n int, err error) {
 func (cr *compressReader) readCompressedData() (err error) {
 	cr.pos = 0
 	var n int
-	n, err = cr.reader.Read(cr.header)
+	n, err = io.ReadFull(cr.reader, cr.header)
 	if err != nil {
 		return
 	}
@@ -86,7 +87,7 @@ func (cr *compressReader) readCompressedData() (err error) {
 
 	// @TODO checksum
 	if cr.header[16] == LZ4 {
-		n, err = cr.reader.Read(cr.zdata)
+		n, err = io.ReadFull(cr.reader, cr.zdata)
 		if err != nil {
 			return
 		}

--- a/lib/binary/decoder.go
+++ b/lib/binary/decoder.go
@@ -90,14 +90,14 @@ func (decoder *Decoder) UInt8() (uint8, error) {
 }
 
 func (decoder *Decoder) UInt16() (uint16, error) {
-	if _, err := decoder.Get().Read(decoder.scratch[:2]); err != nil {
+	if _, err := io.ReadFull(decoder.Get(), decoder.scratch[:2]); err != nil {
 		return 0, err
 	}
 	return uint16(decoder.scratch[0]) | uint16(decoder.scratch[1])<<8, nil
 }
 
 func (decoder *Decoder) UInt32() (uint32, error) {
-	if _, err := decoder.Get().Read(decoder.scratch[:4]); err != nil {
+	if _, err := io.ReadFull(decoder.Get(), decoder.scratch[:4]); err != nil {
 		return 0, err
 	}
 	return uint32(decoder.scratch[0]) |
@@ -107,7 +107,7 @@ func (decoder *Decoder) UInt32() (uint32, error) {
 }
 
 func (decoder *Decoder) UInt64() (uint64, error) {
-	if _, err := decoder.Get().Read(decoder.scratch[:8]); err != nil {
+	if _, err := io.ReadFull(decoder.Get(), decoder.scratch[:8]); err != nil {
 		return 0, err
 	}
 	return uint64(decoder.scratch[0]) |
@@ -141,7 +141,7 @@ func (decoder *Decoder) Fixed(ln int) ([]byte, error) {
 		return reader.Fixed(ln)
 	}
 	buf := make([]byte, ln)
-	if _, err := decoder.Get().Read(buf); err != nil {
+	if _, err := io.ReadFull(decoder.Get(), buf); err != nil {
 		return nil, err
 	}
 	return buf, nil
@@ -161,12 +161,12 @@ func (decoder *Decoder) String() (string, error) {
 
 func (decoder *Decoder) Decimal128() ([]byte, error) {
 	bytes := make([]byte, 16)
-	_, err := decoder.Get().Read(bytes)
+	_, err := io.ReadFull(decoder.Get(), bytes)
 	return bytes, err
 }
 
 func (decoder *Decoder) ReadByte() (byte, error) {
-	if _, err := decoder.Get().Read(decoder.scratch[:1]); err != nil {
+	if _, err := decoder.Get().Read(decoder.scratch[:1]); err != nil { // one byte can be read without ReadFull
 		return 0x0, err
 	}
 	return decoder.scratch[0], nil


### PR DESCRIPTION
In decoder we expect full buffer was read, but in Go Read method can return successfully if it read less than buffer size. I've added io.ReadFull