### PR TITLE
Implement `SessionResetter` on `*clickhouse` (#433)

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -117,6 +117,21 @@ type txOptions struct {
 	ReadOnly  bool
 }
 
+func (ch *clickhouse) ResetSession(ctx context.Context) error {
+	ch.logf("[ResetSession] tx=%t, data=%t", ch.inTransaction, ch.block != nil)
+	switch {
+	case ch.inTransaction:
+		return sql.ErrTxDone
+	case ch.conn.closed:
+		return driver.ErrBadConn
+	}
+	if ch.block != nil {
+		ch.block.Reset()
+		ch.block = nil
+	}
+	return nil
+}
+
 func (ch *clickhouse) beginTx(ctx context.Context, opts txOptions) (*clickhouse, error) {
 	ch.logf("[begin] tx=%t, data=%t", ch.inTransaction, ch.block != nil)
 	switch {

--- a/clickhouse_test.go
+++ b/clickhouse_test.go
@@ -1268,7 +1268,10 @@ func Test_Context_Timeout(t *testing.T) {
 			defer cancel()
 			if row := connect.QueryRowContext(ctx, "SELECT 1, sleep(2)"); assert.NotNil(t, row) {
 				var a, b int
-				assert.Equal(t, driver.ErrBadConn, row.Scan(&a, &b))
+				if err := row.Scan(&a, &b); assert.Error(t, err) {
+					assert.Contains(t, err.Error(),
+						"use of closed network connection")
+				}
 			}
 		}
 		{
@@ -1298,7 +1301,10 @@ func Test_Ping_Context_Timeout(t *testing.T) {
 			defer cancel()
 			if row := connect.QueryRowContext(ctx, "SELECT 1, sleep(2)"); assert.NotNil(t, row) {
 				var a, b int
-				assert.Equal(t, driver.ErrBadConn, row.Scan(&a, &b))
+				if err := row.Scan(&a, &b); assert.Error(t, err) {
+					assert.Contains(t, err.Error(),
+						"use of closed network connection")
+				}
 			}
 		}
 		{
@@ -1319,7 +1325,10 @@ func Test_Timeout(t *testing.T) {
 		{
 			if row := connect.QueryRow("SELECT 1, sleep(2)"); assert.NotNil(t, row) {
 				var a, b int
-				assert.Equal(t, driver.ErrBadConn, row.Scan(&a, &b))
+				if err := row.Scan(&a, &b); assert.Error(t, err) {
+					assert.Contains(t, err.Error(),
+						"i/o timeout")
+				}
 			}
 		}
 		{

--- a/connect.go
+++ b/connect.go
@@ -3,7 +3,6 @@ package clickhouse
 import (
 	"bufio"
 	"crypto/tls"
-	"database/sql/driver"
 	"net"
 	"sync/atomic"
 	"time"
@@ -153,7 +152,7 @@ func (conn *connect) Read(b []byte) (int, error) {
 		if n, err = conn.buffer.Read(b[total:]); err != nil {
 			conn.logf("[connect] read error: %v", err)
 			conn.Close()
-			return n, driver.ErrBadConn
+			return n, err
 		}
 		total += n
 	}
@@ -175,7 +174,7 @@ func (conn *connect) Write(b []byte) (int, error) {
 		if n, err = conn.Conn.Write(b[total:]); err != nil {
 			conn.logf("[connect] write error: %v", err)
 			conn.Close()
-			return n, driver.ErrBadConn
+			return n, err
 		}
 		total += n
 	}


### PR DESCRIPTION
This allows returning a more helpful error when the connection `Read`
and `Write` fail, while still maintaining the connection pool properly.
(See also issue #433.)

`Test_ConnCheckNegative`, `Test_Context_Timeout`,
`Test_Ping_Context_Timeout`, and `Test_Timeout` have been updated to
check against the new expected error rather than `ErrBadConn`.

I've marked this as a draft because I'm still having issues with three tests, but the failures appear both before and after my changes so I'm not sure I affected them in any way (my testing procedure is `docker-compose up; make test; docker-compose down`).

### `Test_Negative_OpenConnectAndPing`

I'm a little worried about this since what error type is returned is directly related to my changes, but in this case it doesn't seem related; it's `ErrBadConn` before my changes, `EOF` after, but the test isn't expecting either of those:

```
    clickhouse_negative_test.go:34: 
                Error Trace:    clickhouse_negative_test.go:34
                Error:          Should be true
                Test:           Test_Negative_OpenConnectAndPing
--- FAIL: Test_Negative_OpenConnectAndPing (0.00s)
```

### `Test_ArrayT`
Here, I've got no idea, this test seems to just be broken in general:

```
    clickhouse_test.go:724: 
                Error Trace:    clickhouse_test.go:724
                Error:          Received unexpected error:
                                sql: Scan error on column index 14, name "ipv4": unsupported Scan, storing driver.Value type []net.IP into type *[]column.IP
                Test:           Test_ArrayT
--- FAIL: Test_ArrayT (0.02s)
```

### `TestQuerySettings`

This sometimes stalls and times out. As with the other two, this happens both before and after my changes. However, my changes do deal with connection lifetimes and based on frequency I may have made the stalls more likely. Maybe there is some indeterminism leading to a leaked connection in an earlier test?