### PR TITLE
adding new types makes it easier for other ORM to use

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -21,9 +21,14 @@ import (
 )
 
 type (
-	Date     = types.Date
-	DateTime = types.DateTime
-	UUID     = types.UUID
+	Date        = types.Date
+	DateTime    = types.DateTime
+	UUID        = types.UUID
+	ArrayInt    = types.ArrayInt
+	ArrayInt64  = types.ArrayInt64
+	ArrayUInt   = types.ArrayUInt
+	ArrayUInt64 = types.ArrayInt64
+	ArrayString = types.ArrayString
 )
 
 type ExternalTable struct {

--- a/lib/types/array.go
+++ b/lib/types/array.go
@@ -1,0 +1,46 @@
+package types
+
+import (
+	"database/sql/driver"
+)
+
+// some orm wrong with Array(T)
+// add arrays driver valuer
+
+type ArrayInt []int
+
+func (aInt ArrayInt) Value() (driver.Value, error) {
+	return aInt, nil
+}
+
+type ArrayInt64 []int64
+
+func (aInt64 ArrayInt64) Value() (driver.Value, error) {
+	return aInt64, nil
+}
+
+type ArrayUInt []uint
+
+func (aUInt ArrayUInt) Value() (driver.Value, error) {
+	return aUInt, nil
+}
+
+type ArrayUInt64 []uint64
+
+func (aUInt ArrayUInt64) Value() (driver.Value, error) {
+	return aUInt, nil
+}
+
+type ArrayString []string
+
+func (aString ArrayString) Value() (driver.Value, error) {
+	return aString, nil
+}
+
+var (
+	_ driver.Valuer = ArrayInt{}
+	_ driver.Valuer = ArrayInt64{}
+	_ driver.Valuer = ArrayUInt{}
+	_ driver.Valuer = ArrayUInt64{}
+	_ driver.Valuer = ArrayString{}
+)


### PR DESCRIPTION
Add partial array types to register in database/sql

type TestModel struct {
    TestArray ArrayInt64 `gorm:"type:Array(Int64)"`
}