### PR TITLE
Implement feature #92[Expose query progress in query context]

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -267,14 +267,15 @@ func (ch *clickhouse) process() error {
 			ch.logf("[process] <- exception")
 			return ch.exception()
 		case protocol.ServerProgress:
-			progress, err := ch.progress()
+			progress := &Progress{}
+			err := progress.update(ch)
 			if err != nil {
 				return err
 			}
 			ch.logf("[process] <- progress: rows=%d, bytes=%d, total rows=%d",
-				progress.rows,
-				progress.bytes,
-				progress.totalRows,
+				progress.Rows,
+				progress.Bytes,
+				progress.TotalRows,
 			)
 		case protocol.ServerProfileInfo:
 			profileInfo, err := ch.profileInfo()

--- a/clickhouse_progress.go
+++ b/clickhouse_progress.go
@@ -1,26 +1,26 @@
 package clickhouse
 
-type progress struct {
-	rows      uint64
-	bytes     uint64
-	totalRows uint64
+type Progress struct {
+	Rows      uint64
+	Bytes     uint64
+	TotalRows uint64
 }
 
-func (ch *clickhouse) progress() (*progress, error) {
-	var (
-		p   progress
-		err error
-	)
-	if p.rows, err = ch.decoder.Uvarint(); err != nil {
-		return nil, err
+func (p *Progress) update(ch *clickhouse) error {
+	if rows, err := ch.decoder.Uvarint(); err != nil {
+		return err
+	} else {
+		p.Rows = p.Rows + rows
 	}
-	if p.bytes, err = ch.decoder.Uvarint(); err != nil {
-		return nil, err
+	if bytes, err := ch.decoder.Uvarint(); err != nil {
+		return err
+	} else {
+		p.Bytes = p.Bytes + bytes
 	}
-
-	if p.totalRows, err = ch.decoder.Uvarint(); err != nil {
-		return nil, err
+	if totalRows, err := ch.decoder.Uvarint(); err != nil {
+		return err
+	} else {
+		p.TotalRows = p.TotalRows + totalRows
 	}
-
-	return &p, nil
+	return nil
 }

--- a/clickhouse_read_meta.go
+++ b/clickhouse_read_meta.go
@@ -19,14 +19,15 @@ func (ch *clickhouse) readMeta() (*data.Block, error) {
 			ch.logf("[read meta] <- exception")
 			return nil, ch.exception()
 		case protocol.ServerProgress:
-			progress, err := ch.progress()
+			progress := &Progress{}
+			err := progress.update(ch)
 			if err != nil {
 				return nil, err
 			}
 			ch.logf("[read meta] <- progress: rows=%d, bytes=%d, total rows=%d",
-				progress.rows,
-				progress.bytes,
-				progress.totalRows,
+				progress.Rows,
+				progress.Bytes,
+				progress.TotalRows,
 			)
 		case protocol.ServerProfileInfo:
 			profileInfo, err := ch.profileInfo()


### PR DESCRIPTION
This PR is for issue: [Expose progress metadata](https://github.com/ClickHouse/clickhouse-go/issues/92)
#https://github.com/ClickHouse/clickhouse-go/issues/92
Usage:
 ```
        ctx := clickhouse.WithQueryProgress(context.Background())
	rows, err :=connect.QueryContext(ctx, "select * from users limit 4")
        ......(handle rows)
	p:=clickhouse.QueryProgress(ctx)
```