### PR TITLE
Add joined_subquery_requires_alias setting

### DIFF
--- a/query_settings.go
+++ b/query_settings.go
@@ -196,6 +196,7 @@ var querySettingList = []querySettingInfo{
 	{"allow_experimental_data_skipping_indices", boolQS},
 	{"allow_hyperscan", boolQS},
 	{"allow_simdjson", boolQS},
+	{"joined_subquery_requires_alias", boolQS},
 
 	{"connect_timeout", timeQS},
 	{"connect_timeout_with_failover_ms", timeQS},


### PR DESCRIPTION
Hello everyone!

Clickhouse has joined_subquery_requires_alias setting(https://clickhouse.com/docs/en/whats-new/changelog/2019/#improvement-3)

In this PR add joined_subquery_requires_alias that can use in dsn
`connect, err := sql.Open("clickhouse", "tcp://127.0.0.1:9000?debug=true&joined_subquery_requires_alias=0")`