### PR TITLE
Fixed panic when `nil` is present in arguments for column.Array type

### DIFF
--- a/lib/data/block.go
+++ b/lib/data/block.go
@@ -144,6 +144,9 @@ func (block *Block) AppendRow(args []driver.Value) error {
 	for num, c := range block.Columns {
 		switch column := c.(type) {
 		case *column.Array:
+			if args[num] == nil {
+				return fmt.Errorf("unsupported [nil] value is passed in argument %d, column is not Nullable", num)
+			}
 			value := reflect.ValueOf(args[num])
 			if value.Kind() != reflect.Slice {
 				return fmt.Errorf("unsupported Array(T) type [%T]", value.Interface())


### PR DESCRIPTION
**Bug:** When I pass NIL as an argument to insert an Array(T) type column without Nullable, a Panic occurs which returns the execution thread up the stack. If the insertion was performed in a transaction, one of the Mutex is not Unlocked, resulting in an **inability to free resources** when the job is finished

**Fix:** Added checking Nil values for column.Array arguments in func (block *Block) AppendRow

**Investigation**

Panic occurs when trying to retrieve an Interface() from an reflex.Value{}

this is where panic happens: clickhouse-go/lib/data/block.go 149
```
	if value.Kind() != reflect.Slice {
		return fmt.Errorf("unsupported Array(T) type [%T]", value.Interface()) // PANIC!
	}
```

And this mutex is not Unlocked: Tx.closemu (`database/sql`)

Let's look at the code from the sql library: database/sql/sql.go 2594
```
		res, err = resultFromStatement(ctx, dc.ci, ds, args...) // PANIC!
		releaseConn(err) // unreachable
		if err != driver.ErrBadConn {
			return res, err
		}
```

obviously this code was not designed to panic, although this may simply be a mistake

we can fix this in the `clickhouse-go` code - just check arguments to nil