### PR TITLE
Add DialContext option

### DIFF
--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -18,6 +18,7 @@
 package clickhouse
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -29,9 +30,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/compress"
 )
 
-var (
-	CompressionLZ4 compress.Method = compress.LZ4
-)
+var CompressionLZ4 compress.Method = compress.LZ4
 
 type Auth struct { // has_control_character
 	Database string
@@ -63,6 +62,7 @@ type Options struct {
 	Addr             []string
 	Auth             Auth
 	Dial             func(addr string) (net.Conn, error)
+	DialContext      func(ctx context.Context, addr string) (net.Conn, error)
 	Debug            bool
 	Settings         Settings
 	Compression      *Compression

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -61,7 +61,6 @@ type Options struct {
 	TLS              *tls.Config
 	Addr             []string
 	Auth             Auth
-	Dial             func(addr string) (net.Conn, error)
 	DialContext      func(ctx context.Context, addr string) (net.Conn, error)
 	Debug            bool
 	Settings         Settings

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -42,7 +42,7 @@ func (o *stdConnOpener) Driver() driver.Driver {
 	return &stdDriver{}
 }
 
-func (o *stdConnOpener) Connect(context.Context) (_ driver.Conn, err error) {
+func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) {
 	if o.err != nil {
 		return nil, o.err
 	}
@@ -54,7 +54,7 @@ func (o *stdConnOpener) Connect(context.Context) (_ driver.Conn, err error) {
 		if o.opt.ConnOpenStrategy == ConnOpenRoundRobin {
 			num = int(connID) % len(o.opt.Addr)
 		}
-		if conn, err = dial(o.opt.Addr[num], connID, o.opt); err == nil {
+		if conn, err = dial(ctx, o.opt.Addr[num], connID, o.opt); err == nil {
 			return &stdDriver{
 				conn: conn,
 			}, nil

--- a/conn.go
+++ b/conn.go
@@ -41,8 +41,6 @@ func dial(ctx context.Context, addr string, num int, opt *Options) (*connect, er
 	switch {
 	case opt.DialContext != nil:
 		conn, err = opt.DialContext(ctx, addr)
-	case opt.Dial != nil:
-		conn, err = opt.Dial(addr)
 	default:
 		switch {
 		case opt.TLS != nil:

--- a/conn.go
+++ b/conn.go
@@ -32,13 +32,15 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
-func dial(addr string, num int, opt *Options) (*connect, error) {
+func dial(ctx context.Context, addr string, num int, opt *Options) (*connect, error) {
 	var (
 		err    error
 		conn   net.Conn
 		debugf = func(format string, v ...interface{}) {}
 	)
 	switch {
+	case opt.DialContext != nil:
+		conn, err = opt.DialContext(ctx, addr)
 	case opt.Dial != nil:
 		conn, err = opt.Dial(addr)
 	default:

--- a/tests/custom_dial_test.go
+++ b/tests/custom_dial_test.go
@@ -26,30 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCustomDial(t *testing.T) {
-	var (
-		dialCount int
-		conn, err = clickhouse.Open(&clickhouse.Options{
-			Addr: []string{"127.0.0.1:9000"},
-			Auth: clickhouse.Auth{
-				Database: "default",
-				Username: "default",
-				Password: "",
-			},
-			Dial: func(addr string) (net.Conn, error) {
-				dialCount++
-				return net.Dial("tcp", addr)
-			},
-		})
-	)
-	if !assert.NoError(t, err) {
-		return
-	}
-	if err := conn.Ping(context.Background()); assert.NoError(t, err) {
-		assert.Equal(t, 1, dialCount)
-	}
-}
-
 func TestCustomDialContext(t *testing.T) {
 	var (
 		dialCount int


### PR DESCRIPTION
It allows for using a cancellable context in a connection. My particular use-case for this is cancelling a long running query when an HTTP-request has been aborted (ex. `ctrl-c` a curl). 

This implementation is backwards compatible and opt-in by using a `DialContext`-option. And since the context is always already provided this was very easy to implement.

Another approach I considered was to add a `*net.Dialer`-option, but it was a bit harder to test the re-dials with. Or using `(*net.Dialer).DialContext` by default but that would not be backwards compatible if code rely on the non-cancellable contexts. Let me know if you think that would be a better fit though and I'll be happy to update this PR.

Btw, I really like working with the new v2 client, thank you!