### PR TITLE
Add ability to pass as query arguments any type based on string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ tcp://host1:9000?username=user&password=qwerty&database=clicks&read_timeout=10&w
 * UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64
 * Float32, Float64
 * String
+* Any string based type
 * FixedString(N)
 * Date
 * DateTime

--- a/helpers.go
+++ b/helpers.go
@@ -127,6 +127,8 @@ func quote(v driver.Value) string {
 			values = append(values, quote(v.Index(i).Interface()))
 		}
 		return strings.Join(values, ", ")
+	case reflect.String:
+		return "'" + strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(v.String()) + "'"
 	}
 	switch v := v.(type) {
 	case string:

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -54,6 +54,10 @@ func Benchmark_NumInput(b *testing.B) {
 	}
 }
 
+type SupperString string
+
+type SupperSupperString string
+
 func Test_Quote(t *testing.T) {
 	datetime, _ := time.Parse("2006-01-02 15:04:05", "2022-01-12 15:00:00")
 	for expected, value := range map[string]interface{}{
@@ -62,6 +66,9 @@ func Test_Quote(t *testing.T) {
 		"'a', 'b', 'c'": []string{"a", "b", "c"},
 		"1, 2, 3, 4, 5": []int{1, 2, 3, 4, 5},
 		`toDateTime('2022-01-12 15:00:00', 'UTC')`: datetime,
+		`'1\'', '2', '3'`:                          []SupperString{"1'", "2", "3"},
+		`'1'`:                                      SupperString("1"),
+		`'2'`:                                      SupperSupperString("2"),
 	} {
 		assert.Equal(t, expected, quote(value))
 	}


### PR DESCRIPTION
I had a problem when I try to pass []StringBasedType type to arguments. As result, I got unquoted data in the query.
It is not a big deal to cast a single StringBasedType to string, but you have []StringBasedType it may lead to unnecessary code.