### PR TITLE
Add ability to pass custom type that has ToSQLArgument method as a query argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ tcp://host1:9000?username=user&password=qwerty&database=clicks&read_timeout=10&w
 * UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64
 * Float32, Float64
 * String
+* Any type that have `ToSQLArgument() string` method
 * FixedString(N)
 * Date
 * DateTime

--- a/helpers.go
+++ b/helpers.go
@@ -10,6 +10,10 @@ import (
 	"time"
 )
 
+type ToSqlArgumenter interface {
+	ToSQLArgument() string
+}
+
 func numInput(query string) int {
 
 	var (
@@ -120,6 +124,9 @@ func isInsert(query string) bool {
 }
 
 func quote(v driver.Value) string {
+	if v, ok := v.(ToSqlArgumenter); ok {
+		return v.ToSQLArgument()
+	}
 	switch v := reflect.ValueOf(v); v.Kind() {
 	case reflect.Slice:
 		values := make([]string, 0, v.Len())

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -54,6 +54,12 @@ func Benchmark_NumInput(b *testing.B) {
 	}
 }
 
+type SupperSliceOfStrings []string
+
+func (s SupperSliceOfStrings) ToSQLArgument() string {
+	return "---------"
+}
+
 func Test_Quote(t *testing.T) {
 	datetime, _ := time.Parse("2006-01-02 15:04:05", "2022-01-12 15:00:00")
 	for expected, value := range map[string]interface{}{
@@ -62,6 +68,7 @@ func Test_Quote(t *testing.T) {
 		"'a', 'b', 'c'": []string{"a", "b", "c"},
 		"1, 2, 3, 4, 5": []int{1, 2, 3, 4, 5},
 		`toDateTime('2022-01-12 15:00:00', 'UTC')`: datetime,
+		`---------`: SupperSliceOfStrings{"1", "2", "3"},
 	} {
 		assert.Equal(t, expected, quote(value))
 	}


### PR DESCRIPTION
Add ability to pass custom type that has `ToSQLArgument() string` method as a query argument.