### PR TITLE
v2: Add ability to pass as query arguments any type based on string.

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -141,6 +141,8 @@ func format(tz *time.Location, v interface{}) string {
 		return quote(v.String())
 	}
 	switch v := reflect.ValueOf(v); v.Kind() {
+	case reflect.String:
+		return quote(v.String())
 	case reflect.Slice:
 		values := make([]string, 0, v.Len())
 		for i := 0; i < v.Len(); i++ {

--- a/bind_test.go
+++ b/bind_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBindNumeric(t *testing.T) {
@@ -129,6 +130,17 @@ func TestFormatTime(t *testing.T) {
 			assert.Equal(t, "toDateTime('2022-01-12 15:00:00', 'UTC')", format(tz, t1))
 		}
 	}
+}
+
+type SupperString string
+type SupperSupperString string
+
+func TestStringBasedType(t *testing.T) {
+	var tz, err = time.LoadLocation("Europe/London")
+	require.NoError(t, err)
+	require.Equal(t, "'a'", format(tz, SupperString("a")))
+	require.Equal(t, "'a'", format(tz, SupperSupperString("a")))
+	require.Equal(t, "'a', 'b', 'c'", format(tz, []SupperSupperString{"a", "b", "c"}))
 }
 
 func BenchmarkBindNumeric(b *testing.B) {


### PR DESCRIPTION
Same as v1 but for v2 :)
I had a problem when I try to pass []StringBasedType type to arguments. As result, I got unquoted data in the query.
It is not a big deal to cast a single StringBasedType to string, but you have []StringBasedType it may lead to unnecessary code.