### PR TITLE
v2: Add ability to pass custom type that has ToSQLArgument method as query argument.

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -28,6 +28,10 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
+type ToSqlArgumenter interface {
+	ToSQLArgument() string
+}
+
 func Named(name string, value interface{}) driver.NamedValue {
 	return driver.NamedValue{
 		Name:  name,
@@ -121,6 +125,10 @@ func bindNamed(tz *time.Location, query string, args ...interface{}) (_ string, 
 }
 
 func format(tz *time.Location, v interface{}) string {
+	if v, ok := v.(ToSqlArgumenter); ok {
+		return v.ToSQLArgument()
+	}
+
 	quote := func(v string) string {
 		return "'" + strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(v) + "'"
 	}

--- a/bind_test.go
+++ b/bind_test.go
@@ -18,10 +18,12 @@
 package clickhouse
 
 import (
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBindNumeric(t *testing.T) {
@@ -129,6 +131,21 @@ func TestFormatTime(t *testing.T) {
 			assert.Equal(t, "toDateTime('2022-01-12 15:00:00', 'UTC')", format(tz, t1))
 		}
 	}
+}
+
+type SupperSliceOfStrings []string
+
+func (s SupperSliceOfStrings) ToSQLArgument() string {
+	return strings.Join(s, "|")
+}
+
+func TestFormatWithToSqlArgumenter(t *testing.T) {
+	var (
+		tz, err = time.LoadLocation("Europe/London")
+	)
+	require.NoError(t, err)
+	require.Equal(t, "1|2|3", format(tz, SupperSliceOfStrings{"1", "2", "3"}))
+	require.Equal(t, "b|d|e|a", format(tz, SupperSliceOfStrings{"b", "d", "e", "a"}))
 }
 
 func BenchmarkBindNumeric(b *testing.B) {


### PR DESCRIPTION
same as for v1 :)
Add ability to pass custom type that has `ToSQLArgument() string` method as a query argument.