### PR TITLE
Fix nullable column for batch insertion

### DIFF
--- a/lib/column/nullable.go
+++ b/lib/column/nullable.go
@@ -93,10 +93,9 @@ func (col *Nullable) Append(v interface{}) ([]uint8, error) {
 }
 
 func (col *Nullable) AppendRow(v interface{}) error {
-	switch {
-	case v == nil:
+	if v == nil || reflect.ValueOf(v).IsNil() {
 		col.nulls = append(col.nulls, 1)
-	default:
+	} else {
 		col.nulls = append(col.nulls, 0)
 	}
 	return col.base.AppendRow(v)

--- a/tests/struct_map_test.go
+++ b/tests/struct_map_test.go
@@ -49,9 +49,11 @@ func TestAppendStruct(t *testing.T) {
 			  HCol1 UInt8
 			, HCol2 String
 			, HCol3 Array(Nullable(String))
+			, HCol4 Nullable(UInt8)
 			, Col1  UInt8
 			, Col2  String
 			, Col3  Array(String)
+			, Col4  Nullable(UInt8)
 		) Engine Memory
 		`
 		defer func() {
@@ -63,12 +65,14 @@ func TestAppendStruct(t *testing.T) {
 					Col1 uint8     `ch:"HCol1"`
 					Col2 *string   `ch:"HCol2"`
 					Col3 []*string `ch:"HCol3"`
+					Col4 *uint8    `ch:"HCol4"`
 				}
 				type data struct {
 					header
 					Col1 uint8
 					Col2 string
 					Col3 []string
+					Col4 *uint8
 				}
 				for i := 0; i < 100; i++ {
 					str := fmt.Sprintf("Str_%d", i)
@@ -77,6 +81,7 @@ func TestAppendStruct(t *testing.T) {
 							Col1: uint8(i),
 							Col2: &str,
 							Col3: []*string{&str, nil, &str},
+							Col4: nil,
 						},
 						Col1: uint8(i + 1),
 						Col3: []string{"A", "B", "C", fmt.Sprint(i)},
@@ -95,11 +100,13 @@ func TestAppendStruct(t *testing.T) {
 								Col1: uint8(i),
 								Col2: &str,
 								Col3: []*string{&str, nil, &str},
+								Col4: nil,
 							}
 							assert.Equal(t, h, result.header)
 							if assert.Empty(t, result.Col2) {
 								assert.Equal(t, uint8(i+1), result.Col1)
 								assert.Equal(t, []string{"A", "B", "C", fmt.Sprint(i)}, result.Col3)
+								assert.Nil(t, result.Col4)
 							}
 						}
 					}


### PR DESCRIPTION
When using `batch.AppendStruct` with a nullable int field, the insertion does not insert `null` but `0`.

This commit fixes the logic, so it will correctly insert `null` and updates the test ensuring the behavior.