### PR TITLE
rename external/ package to ext to avoid name conflict in repos managed by bazel

### DIFF
--- a/context.go
+++ b/context.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2/external"
+	"github.com/ClickHouse/clickhouse-go/v2/ext"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -49,7 +49,7 @@ type (
 			profileEvents func([]ProfileEvent)
 		}
 		settings Settings
-		external []*external.Table
+		external []*ext.Table
 	}
 )
 
@@ -109,7 +109,7 @@ func WithProfileEvents(fn func([]ProfileEvent)) QueryOption {
 	}
 }
 
-func WithExternalTable(t ...*external.Table) QueryOption {
+func WithExternalTable(t ...*ext.Table) QueryOption {
 	return func(o *QueryOptions) error {
 		o.external = append(o.external, t...)
 		return nil

--- a/ext/external/external.go
+++ b/ext/external/external.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package external
+package ext
 
 import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/column"

--- a/tests/external_table_test.go
+++ b/tests/external_table_test.go
@@ -24,25 +24,25 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/external"
+	"github.com/ClickHouse/clickhouse-go/v2/ext"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestExternalTable(t *testing.T) {
-	table1, err := external.NewTable("external_table_1",
-		external.Column("col1", "UInt8"),
-		external.Column("col2", "String"),
-		external.Column("col3", "DateTime"),
+	table1, err := ext.NewTable("external_table_1",
+		ext.Column("col1", "UInt8"),
+		ext.Column("col2", "String"),
+		ext.Column("col3", "DateTime"),
 	)
 	if assert.NoError(t, err) {
 		for i := 0; i < 10; i++ {
 			assert.NoError(t, table1.Append(uint8(i), fmt.Sprintf("value_%d", i), time.Now()))
 		}
 	}
-	table2, err := external.NewTable("external_table_2",
-		external.Column("col1", "UInt8"),
-		external.Column("col2", "String"),
-		external.Column("col3", "DateTime"),
+	table2, err := ext.NewTable("external_table_2",
+		ext.Column("col1", "UInt8"),
+		ext.Column("col2", "String"),
+		ext.Column("col3", "DateTime"),
 	)
 	if assert.NoError(t, err) {
 		for i := 0; i < 10; i++ {

--- a/tests/std/external_table_test.go
+++ b/tests/std/external_table_test.go
@@ -25,25 +25,25 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/external"
+	"github.com/ClickHouse/clickhouse-go/v2/ext"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestStdExternalTable(t *testing.T) {
-	table1, err := external.NewTable("external_table_1",
-		external.Column("col1", "UInt8"),
-		external.Column("col2", "String"),
-		external.Column("col3", "DateTime"),
+	table1, err := ext.NewTable("external_table_1",
+		ext.Column("col1", "UInt8"),
+		ext.Column("col2", "String"),
+		ext.Column("col3", "DateTime"),
 	)
 	if assert.NoError(t, err) {
 		for i := 0; i < 10; i++ {
 			assert.NoError(t, table1.Append(uint8(i), fmt.Sprintf("value_%d", i), time.Now()))
 		}
 	}
-	table2, err := external.NewTable("external_table_2",
-		external.Column("col1", "UInt8"),
-		external.Column("col2", "String"),
-		external.Column("col3", "DateTime"),
+	table2, err := ext.NewTable("external_table_2",
+		ext.Column("col1", "UInt8"),
+		ext.Column("col2", "String"),
+		ext.Column("col3", "DateTime"),
 	)
 	if assert.NoError(t, err) {
 		for i := 0; i < 10; i++ {


### PR DESCRIPTION
This is a fairly ridiculous issue, but nevertheless - some (usually big) golang projects are managed by the tool named bazel ([link](https://bazel.build/)), which uses some sort of urls (looking like "//path/to/some/package:some_item") to refer entities like packages etc.  

The problem is that in bazel there is a special entity "//external" for external packages (for example, if you import clickhouse-go to your bazel-managed repo, you can refer it as "//external:com_github_clickhouse_clickhouse_go"), and this name ("external") conflicts with "external" subpackage of clickhouse-go.

I understand that renaming library is a breaking change, but unfortunately I don't see any other way to allow projects managed by bazel to use clickhouse-go. 