### PR TITLE
make it possible to use bool type instead of uint8

### DIFF
--- a/lib/column/codegen/column.tpl
+++ b/lib/column/codegen/column.tpl
@@ -228,6 +228,14 @@ func (col *{{ .ChType }}) AppendRow(v interface{}) error {
 		}
 	case nil:
 		*col = append(*col, 0)
+	{{- if eq .ChType "UInt8" }}
+	case bool:
+		var t uint8
+		if v {
+			t = 1
+		}
+		*col = append(*col, t)
+	{{- end }}
 	default:
 		return &ColumnConverterError{
 			Op:   "AppendRow",

--- a/lib/column/column_gen.go
+++ b/lib/column/column_gen.go
@@ -796,6 +796,12 @@ func (col *UInt8) AppendRow(v interface{}) error {
 		}
 	case nil:
 		*col = append(*col, 0)
+	case bool:
+		var t uint8
+		if v {
+			t = 1
+		}
+		*col = append(*col, t)
 	default:
 		return &ColumnConverterError{
 			Op:   "AppendRow",


### PR DESCRIPTION
To mek it possible to use `bool`  instead of `uint8` when a read bool is needed.