### PR TITLE
Append empty bytes when string is empty in FixedString

### DIFF
--- a/lib/column/fixed_string.go
+++ b/lib/column/fixed_string.go
@@ -83,7 +83,11 @@ func (col *FixedString) Append(v interface{}) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []string:
 		for _, v := range v {
-			col.data = append(col.data, binary.Str2Bytes(v)...)
+			if v == "" {
+				col.data = append(col.data, make([]byte, col.size)...)
+			} else {
+				col.data = append(col.data, binary.Str2Bytes(v)...)
+			}
 		}
 		nulls = make([]uint8, len(v))
 	case []*string:
@@ -96,7 +100,11 @@ func (col *FixedString) Append(v interface{}) (nulls []uint8, err error) {
 			case v == nil:
 				col.data = append(col.data, make([]byte, col.size)...)
 			default:
-				col.data = append(col.data, binary.Str2Bytes(*v)...)
+				if *v == "" {
+					col.data = append(col.data, make([]byte, col.size)...)
+				} else {
+					col.data = append(col.data, binary.Str2Bytes(*v)...)
+				}
 			}
 		}
 	case encoding.BinaryMarshaler:
@@ -119,10 +127,14 @@ func (col *FixedString) AppendRow(v interface{}) (err error) {
 	data := make([]byte, col.size)
 	switch v := v.(type) {
 	case string:
-		data = binary.Str2Bytes(v)
+		if v != "" {
+			data = binary.Str2Bytes(v)
+		}
 	case *string:
 		if v != nil {
-			data = binary.Str2Bytes(*v)
+			if *v != "" {
+				data = binary.Str2Bytes(*v)
+			}
 		}
 	case nil:
 	case encoding.BinaryMarshaler:


### PR DESCRIPTION
Resolves #544, but I have doubts about my usage of FixedString.

Do we want to allow people to misuse FixedString in this fashion, whereas a Nullable(FixedString) makes more sense in the case where input can be empty? Should AppendRow when input is empty return an error?

ClickHouse via client INSERT does not care about empty FixedString, so should the batch inserts care as well? For example:

```
INSERT INTO test_fixed_string_empty VALUES ('', 'US');

INSERT INTO test_fixed_string_empty FORMAT Values

Query id: 8f4b3ff9-d750-4a9d-8938-7d1ba9ed1e5b

Ok.

1 rows in set. Elapsed: 0.011 sec.
```