### PR TITLE
conn: fix Close() on rows when a timeout during processing

### DIFF
--- a/conn_query.go
+++ b/conn_query.go
@@ -66,8 +66,8 @@ func (c *connect) query(ctx context.Context, release func(*connect, error), quer
 		if err != nil {
 			errors <- err
 		}
-		close(errors)
 		close(stream)
+		close(errors)
 		release(c, err)
 	}()
 


### PR DESCRIPTION
There is a race condition when calling rows.Close() after a query was
stopped due to an error (notably when hitting a timeout). The
goroutine processing the query result tries to send the error to the
error channel, before closing both the error and the stream channel
while the Close() method is trying to read from stream before
processing errors. This leads to a deadlock.

This could be fixed by closing the stream channel before sending the
error, but it seems more future-proof to drain both stream and errors
channel in parallel in the Close() method.