### PR TITLE
Examples to use memory tables

### DIFF
--- a/examples/native/batch/main.go
+++ b/examples/native/batch/main.go
@@ -60,7 +60,7 @@ func example() error {
 			, Col6 Array(String)
 			, Col7 Tuple(String, UInt8, Array(Map(String, String)))
 			, Col8 DateTime
-		) Engine = Null
+		) Engine = Memory
 	`)
 	if err != nil {
 		return err

--- a/examples/native/bind/main.go
+++ b/examples/native/bind/main.go
@@ -41,12 +41,16 @@ func example() error {
 	if err != nil {
 		return err
 	}
+
+	if err := conn.Exec(ctx, `DROP TABLE IF EXISTS example`); err != nil {
+		return err
+	}
 	const ddl = `
-	CREATE TEMPORARY TABLE example (
+	CREATE TABLE example (
 		  Col1 UInt8
 		, Col2 String
 		, Col3 DateTime
-	)
+	) ENGINE = Memory
 	`
 	if err := conn.Exec(ctx, ddl); err != nil {
 		return err

--- a/examples/native/write-async/main.go
+++ b/examples/native/write-async/main.go
@@ -27,12 +27,12 @@ import (
 )
 
 const ddl = `
-CREATE TEMPORARY TABLE example (
+CREATE TABLE example (
 	  Col1 UInt64
 	, Col2 String
 	, Col3 Array(UInt8)
 	, Col4 DateTime
-)
+) ENGINE = Memory
 `
 
 func main() {
@@ -53,6 +53,10 @@ func main() {
 		})
 	)
 	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := conn.Exec(ctx, `DROP TABLE IF EXISTS example`); err != nil {
 		log.Fatal(err)
 	}
 	if err := conn.Exec(ctx, ddl); err != nil {

--- a/examples/native/write-columnar/main.go
+++ b/examples/native/write-columnar/main.go
@@ -26,12 +26,12 @@ import (
 )
 
 const ddl = `
-CREATE TEMPORARY TABLE example (
+CREATE TABLE example (
 	  Col1 UInt64
 	, Col2 String
 	, Col3 Array(UInt8)
 	, Col4 DateTime
-)
+) ENGINE = Memory
 `
 
 func example(conn clickhouse.Conn) error {
@@ -84,6 +84,9 @@ func main() {
 		})
 	)
 	if err != nil {
+		log.Fatal(err)
+	}
+	if err := conn.Exec(ctx, `DROP TABLE IF EXISTS example`); err != nil {
 		log.Fatal(err)
 	}
 	if err := conn.Exec(ctx, ddl); err != nil {

--- a/examples/native/write-struct/main.go
+++ b/examples/native/write-struct/main.go
@@ -26,12 +26,12 @@ import (
 )
 
 const ddl = `
-CREATE TEMPORARY TABLE example (
+CREATE TABLE example (
 	  Col1 UInt64
 	, Col2 String
 	, Col3 Array(UInt8)
 	, Col4 DateTime
-)
+) Engine = Memory
 `
 
 type row struct {
@@ -78,6 +78,9 @@ func main() {
 		})
 	)
 	if err != nil {
+		log.Fatal(err)
+	}
+	if err := conn.Exec(ctx, `DROP TABLE IF EXISTS example`); err != nil {
 		log.Fatal(err)
 	}
 	if err := conn.Exec(ctx, ddl); err != nil {

--- a/examples/std/batch/main.go
+++ b/examples/std/batch/main.go
@@ -49,7 +49,7 @@ func example() error {
 			, Col6 Array(String)
 			, Col7 Tuple(String, UInt8, Array(Map(String, String)))
 			, Col8 DateTime
-		) Engine = Null
+		) Engine = Memory
 	`)
 	if err != nil {
 		return err

--- a/examples/std/bind/main.go
+++ b/examples/std/bind/main.go
@@ -32,12 +32,15 @@ func example() error {
 		return err
 	}
 	const ddl = `
-	CREATE TEMPORARY TABLE example (
+	CREATE TABLE example (
 		  Col1 UInt8
 		, Col2 String
 		, Col3 DateTime
-	)
+	) ENGINE = Memory
 	`
+	if _, err := conn.Exec(`DROP TABLE IF EXISTS example`); err != nil {
+		return err
+	}
 	if _, err := conn.Exec(ddl); err != nil {
 		return err
 	}

--- a/examples/std/write-async/main.go
+++ b/examples/std/write-async/main.go
@@ -27,17 +27,20 @@ import (
 )
 
 const ddl = `
-CREATE TEMPORARY TABLE example (
+CREATE TABLE example (
 	  Col1 UInt64
 	, Col2 String
 	, Col3 Array(UInt8)
 	, Col4 DateTime
-)
+) ENGINE = Memory
 `
 
 func main() {
 	conn, err := sql.Open("clickhouse", "clickhouse://127.0.0.1:9000")
 	if err != nil {
+		log.Fatal(err)
+	}
+	if _, err := conn.Exec(`DROP TABLE IF EXISTS example`); err != nil {
 		log.Fatal(err)
 	}
 	if _, err := conn.Exec(ddl); err != nil {


### PR DESCRIPTION
Previous examples used transitive tables - either temporary or null. This has led to some confusion for new users e.g. https://github.com/ClickHouse/clickhouse-go/issues/528

PR moves tables to Memory and consistently checks for existing (dropping if so) on execution. Most previous tests did this.