### PR TITLE
Increase row limit in block to 1b

### DIFF
--- a/lib/proto/block.go
+++ b/lib/proto/block.go
@@ -138,10 +138,10 @@ func (b *Block) Decode(decoder *binary.Decoder, revision uint64) (err error) {
 	if numRows, err = decoder.Uvarint(); err != nil {
 		return err
 	}
-	if numRows > 1_000_000 {
+	if numRows > 1_000_000_000 {
 		return &BlockError{
 			Op:  "Decode",
-			Err: errors.New("more then 1 000 000 rows in block"),
+			Err: errors.New("more then 1 billion rows in block"),
 		}
 	}
 	b.Columns = make([]column.Interface, 0, numCols)

--- a/tests/issues/546_test.go
+++ b/tests/issues/546_test.go
@@ -1,0 +1,63 @@
+package issues
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test546(t *testing.T) {
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Addr: []string{"127.0.0.1:9000"},
+		Auth: clickhouse.Auth{
+			Database: "default",
+			Username: "default",
+			Password: "",
+		},
+		Debug:           true,
+		DialTimeout:     time.Second,
+		MaxOpenConns:    10,
+		MaxIdleConns:    5,
+		ConnMaxLifetime: time.Hour,
+		Compression: &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		},
+	})
+	if err != nil {
+		assert.NoError(t, err)
+	}
+	ctx := clickhouse.Context(context.Background(), clickhouse.WithSettings(clickhouse.Settings{
+		"max_block_size": 2000000,
+	}),
+		clickhouse.WithProgress(func(p *clickhouse.Progress) {
+			fmt.Println("progress: ", p)
+		}), clickhouse.WithProfileInfo(func(p *clickhouse.ProfileInfo) {
+			fmt.Println("profile info: ", p)
+		}))
+	if err := conn.Ping(ctx); err != nil {
+		if exception, ok := err.(*clickhouse.Exception); ok {
+			fmt.Printf("Catch exception [%d] %s \n%s\n", exception.Code, exception.Message, exception.StackTrace)
+		}
+		assert.NoError(t, err)
+	}
+
+	rows, err := conn.Query(ctx, "SELECT * FROM system.numbers LIMIT 2000000", time.Now())
+	assert.NoError(t, err)
+	i := 0
+	for rows.Next() {
+		var (
+			col1 uint64
+		)
+		if err := rows.Scan(&col1); err != nil {
+			assert.NoError(t, err)
+		}
+		i += 1
+	}
+	assert.NoError(t, rows.Err())
+	assert.Equal(t, 2000000, i)
+	rows.Close()
+}


### PR DESCRIPTION
Closes https://github.com/ClickHouse/clickhouse-go/issues/546