### PR TITLE
go 1.17 and 1.18 only

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,9 +19,8 @@ jobs:
       fail-fast: true
       matrix:
         go:
-          - 1.16
           - 1.17
-          - 1.18.0-beta2
+          - 1.18
         clickhouse:
           - 19.11
           - 20.1


### PR DESCRIPTION
Move inline with https://endoflife.date/go