### PR TITLE
Return nil for batch if PrepareBatch fails

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -143,7 +143,11 @@ func (ch *clickhouse) PrepareBatch(ctx context.Context, query string) (driver.Ba
 	if err != nil {
 		return nil, err
 	}
-	return conn.prepareBatch(ctx, query, ch.release)
+	batch, err := conn.prepareBatch(ctx, query, ch.release)
+	if err != nil {
+		return nil, err
+	}
+	return batch, nil
 }
 
 func (ch *clickhouse) AsyncInsert(ctx context.Context, query string, wait bool) error {

--- a/tests/issues/578_test.go
+++ b/tests/issues/578_test.go
@@ -1,0 +1,24 @@
+package issues
+
+import (
+	"context"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test578(t *testing.T) {
+	ctx := context.Background()
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Addr:  []string{"127.0.0.1:9000"},
+		Debug: true,
+	})
+	assert.NoError(t, err)
+
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO non_existent_table")
+	assert.Error(t, err)
+
+	if batch != nil {
+		batch.Abort()
+	}
+}


### PR DESCRIPTION
Closes https://github.com/ClickHouse/clickhouse-go/issues/578

PrepareBatch was returning interface holding a nil value - hence its not actually nil. For it to be nil, the type also needs to be nil. This was inconsistent behaviour and made nil checks on the batch impossible.