### PR TITLE
v1: fix tz formatting

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -142,5 +142,5 @@ func quote(v driver.Value) string {
 }
 
 func formatTime(v time.Time) string {
-	return v.Format("toDateTime('2006-01-02 15:04:05', '" + v.Location().String() + "')")
+	return fmt.Sprintf("toDateTime('%s', '%s')", v.Format("2006-01-02 15:04:05"), v.Location().String())
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -59,16 +59,20 @@ type SupperString string
 type SupperSupperString string
 
 func Test_Quote(t *testing.T) {
+	tzGmtPlus2, _ := time.LoadLocation("Etc/GMT+2")
 	datetime, _ := time.Parse("2006-01-02 15:04:05", "2022-01-12 15:00:00")
+	datetimeInEtc := datetime.In(tzGmtPlus2)
+
 	for expected, value := range map[string]interface{}{
 		"'a'":           "a",
 		"1":             1,
 		"'a', 'b', 'c'": []string{"a", "b", "c"},
 		"1, 2, 3, 4, 5": []int{1, 2, 3, 4, 5},
-		`toDateTime('2022-01-12 15:00:00', 'UTC')`: datetime,
-		`'1\'', '2', '3'`:                          []SupperString{"1'", "2", "3"},
-		`'1'`:                                      SupperString("1"),
-		`'2'`:                                      SupperSupperString("2"),
+		`toDateTime('2022-01-12 15:00:00', 'UTC')`:       datetime,
+		`toDateTime('2022-01-12 13:00:00', 'Etc/GMT+2')`: datetimeInEtc,
+		`'1\'', '2', '3'`: []SupperString{"1'", "2", "3"},
+		`'1'`:             SupperString("1"),
+		`'2'`:             SupperSupperString("2"),
 	} {
 		assert.Equal(t, expected, quote(value))
 	}


### PR DESCRIPTION
current formatting helper passes timezone name to time.Format which is leading to query corruption for timezones like Etc/GMT+2, fix that by formatting only time and passing timezone as the string