### PR TITLE
Correct failover retry with ConnOpenRoundRobin

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -187,9 +187,13 @@ func (ch *clickhouse) Stats() driver.Stats {
 
 func (ch *clickhouse) dial(ctx context.Context) (conn *connect, err error) {
 	connID := int(atomic.AddInt64(&ch.connID, 1))
-	for num := range ch.opt.Addr {
-		if ch.opt.ConnOpenStrategy == ConnOpenRoundRobin {
-			num = int(connID) % len(ch.opt.Addr)
+	for i := range ch.opt.Addr {
+		var num int
+		switch ch.opt.ConnOpenStrategy {
+		case ConnOpenInOrder:
+			num = i
+		case ConnOpenRoundRobin:
+			num = (int(connID) + i) % len(ch.opt.Addr)
 		}
 		if conn, err = dial(ctx, ch.opt.Addr[num], connID, ch.opt); err == nil {
 			return conn, nil

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -50,9 +50,13 @@ func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) 
 		conn   *connect
 		connID = int(atomic.AddInt64(&globalConnID, 1))
 	)
-	for num := range o.opt.Addr {
-		if o.opt.ConnOpenStrategy == ConnOpenRoundRobin {
-			num = int(connID) % len(o.opt.Addr)
+	for i := range o.opt.Addr {
+		var num int
+		switch o.opt.ConnOpenStrategy {
+		case ConnOpenInOrder:
+			num = i
+		case ConnOpenRoundRobin:
+			num = (int(connID) + i) % len(o.opt.Addr)
 		}
 		if conn, err = dial(ctx, o.opt.Addr[num], connID, o.opt); err == nil {
 			return &stdDriver{

--- a/tests/conn_test.go
+++ b/tests/conn_test.go
@@ -93,6 +93,31 @@ func TestConnFailover(t *testing.T) {
 		}
 	}
 }
+func TestConnFailoverConnOpenRoundRobin(t *testing.T) {
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Addr: []string{
+			"127.0.0.1:9001",
+			"127.0.0.1:9002",
+			"127.0.0.1:9000",
+		},
+		Auth: clickhouse.Auth{
+			Database: "default",
+			Username: "default",
+			Password: "",
+		},
+		Compression: &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		},
+		ConnOpenStrategy: clickhouse.ConnOpenRoundRobin,
+		//	Debug: true,
+	})
+	if assert.NoError(t, err) {
+		if err := conn.Ping(context.Background()); assert.NoError(t, err) {
+			t.Log(conn.ServerVersion())
+			t.Log(conn.Ping(context.Background()))
+		}
+	}
+}
 func TestPingDeadline(t *testing.T) {
 	conn, err := clickhouse.Open(&clickhouse.Options{
 		Addr: []string{"127.0.0.1:9000"},

--- a/tests/std/conn_test.go
+++ b/tests/std/conn_test.go
@@ -45,6 +45,13 @@ func TestStdConnFailover(t *testing.T) {
 		}
 	}
 }
+func TestStdConnFailoverConnOpenRoundRobin(t *testing.T) {
+	if conn, err := sql.Open("clickhouse", "clickhouse://127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9003,127.0.0.1:9004,127.0.0.1:9005,127.0.0.1:9006,127.0.0.1:9000/?connection_open_strategy=round_robin"); assert.NoError(t, err) {
+		if err := conn.PingContext(context.Background()); assert.NoError(t, err) {
+			t.Log(conn.PingContext(context.Background()))
+		}
+	}
+}
 func TestStdPingDeadline(t *testing.T) {
 	if conn, err := sql.Open("clickhouse", "clickhouse://127.0.0.1:9000"); assert.NoError(t, err) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))


### PR DESCRIPTION
If ConnId = 1
https://github.com/ClickHouse/clickhouse-go/blob/v2/clickhouse.go#L192
every iterate num is equal constant and don't change