### PR TITLE
Support maps in values

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -230,7 +230,10 @@ func format(tz *time.Location, v interface{}) (string, error) {
 	case reflect.Map: // map
 		values := make([]string, 0, len(v.MapKeys()))
 		for _, key := range v.MapKeys() {
-			name := key.Interface().(string)
+			name := fmt.Sprint(key.Interface())
+			if key.Kind() == reflect.String {
+				name = fmt.Sprintf("'%s'", name)
+			}
 			val, err := format(tz, v.MapIndex(key).Interface())
 			if err != nil {
 				return "", err
@@ -239,7 +242,7 @@ func format(tz *time.Location, v interface{}) (string, error) {
 				// assume slices in maps are arrays
 				val = fmt.Sprintf("[%s]", val)
 			}
-			values = append(values, fmt.Sprintf("'%s': %s", name, val))
+			values = append(values, fmt.Sprintf("%s: %s", name, val))
 		}
 		return "{" + strings.Join(values, ", ") + "}", nil
 

--- a/bind.go
+++ b/bind.go
@@ -242,7 +242,7 @@ func format(tz *time.Location, v interface{}) (string, error) {
 				// assume slices in maps are arrays
 				val = fmt.Sprintf("[%s]", val)
 			}
-			values = append(values, fmt.Sprintf("%s: %s", name, val))
+			values = append(values, fmt.Sprintf("%s : %s", name, val))
 		}
 		return "{" + strings.Join(values, ", ") + "}", nil
 

--- a/bind.go
+++ b/bind.go
@@ -84,7 +84,10 @@ func bindPositional(tz *time.Location, query string, args ...interface{}) (_ str
 				return "", nil
 			}
 		}
-		params[i] = format(tz, v)
+		params[i], err = format(tz, v)
+		if err != nil {
+			return "", err
+		}
 	}
 	i := 0
 	query = bindPositionalRe.ReplaceAllStringFunc(query, func(n string) string {
@@ -116,7 +119,11 @@ func bindNumeric(tz *time.Location, query string, args ...interface{}) (_ string
 				return "", nil
 			}
 		}
-		params[fmt.Sprintf("$%d", i+1)] = format(tz, v)
+		val, err := format(tz, v)
+		if err != nil {
+			return "", err
+		}
+		params[fmt.Sprintf("$%d", i+1)] = val
 	}
 	query = bindNumericRe.ReplaceAllStringFunc(query, func(n string) string {
 		if _, found := params[n]; !found {
@@ -147,7 +154,11 @@ func bindNamed(tz *time.Location, query string, args ...interface{}) (_ string, 
 					return "", err
 				}
 			}
-			params["@"+v.Name] = format(tz, value)
+			val, err := format(tz, value)
+			if err != nil {
+				return "", err
+			}
+			params["@"+v.Name] = val
 		}
 	}
 	query = bindNamedRe.ReplaceAllStringFunc(query, func(n string) string {
@@ -163,49 +174,73 @@ func bindNamed(tz *time.Location, query string, args ...interface{}) (_ string, 
 	return query, nil
 }
 
-func format(tz *time.Location, v interface{}) string {
+func format(tz *time.Location, v interface{}) (string, error) {
 	quote := func(v string) string {
 		return "'" + strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(v) + "'"
 	}
 	switch v := v.(type) {
 	case nil:
-		return "NULL"
+		return "NULL", nil
 	case string:
-		return quote(v)
+		return quote(v), nil
 	case time.Time:
 		switch v.Location().String() {
 		case "Local":
-			return fmt.Sprintf("toDateTime(%d)", v.Unix())
+			return fmt.Sprintf("toDateTime(%d)", v.Unix()), nil
 		case tz.String():
-			return v.Format("toDateTime('2006-01-02 15:04:05')")
+			return v.Format("toDateTime('2006-01-02 15:04:05')"), nil
 		}
-		return v.Format("toDateTime('2006-01-02 15:04:05', '" + v.Location().String() + "')")
+		return v.Format("toDateTime('2006-01-02 15:04:05', '" + v.Location().String() + "')"), nil
 	case []interface{}: // tuple
 		elements := make([]string, 0, len(v))
 		for _, e := range v {
-			elements = append(elements, format(tz, e))
+			val, err := format(tz, e)
+			if err != nil {
+				return "", err
+			}
+			elements = append(elements, val)
 		}
-		return "(" + strings.Join(elements, ", ") + ")"
+		return "(" + strings.Join(elements, ", ") + ")", nil
 	case [][]interface{}:
 		items := make([]string, 0, len(v))
 		for _, t := range v {
-			items = append(items, format(tz, t))
+			val, err := format(tz, t)
+			if err != nil {
+				return "", err
+			}
+			items = append(items, val)
 		}
-		return strings.Join(items, ", ")
+		return strings.Join(items, ", "), nil
 	case fmt.Stringer:
-		return quote(v.String())
+		return quote(v.String()), nil
 	}
 	switch v := reflect.ValueOf(v); v.Kind() {
 	case reflect.String:
-		return quote(v.String())
-	case reflect.Slice:
+		return quote(v.String()), nil
+	case reflect.Slice: // array
 		values := make([]string, 0, v.Len())
 		for i := 0; i < v.Len(); i++ {
-			values = append(values, format(tz, v.Index(i).Interface()))
+			val, err := format(tz, v.Index(i).Interface())
+			if err != nil {
+				return "", err
+			}
+			values = append(values, val)
 		}
-		return strings.Join(values, ", ")
+		return "[" + strings.Join(values, ", ") + "]", nil
+	case reflect.Map: // map
+		values := make([]string, 0, len(v.MapKeys()))
+		for _, key := range v.MapKeys() {
+			name := key.Interface().(string)
+			val, err := format(tz, v.MapIndex(key).Interface())
+			if err != nil {
+				return "", err
+			}
+			values = append(values, fmt.Sprintf("'%s': %s", name, val))
+		}
+		return "{" + strings.Join(values, ", ") + "}", nil
+
 	}
-	return fmt.Sprint(v)
+	return fmt.Sprint(v), nil
 }
 
 func rebind(in []std_driver.NamedValue) []interface{} {

--- a/bind.go
+++ b/bind.go
@@ -217,7 +217,7 @@ func format(tz *time.Location, v interface{}) (string, error) {
 	switch v := reflect.ValueOf(v); v.Kind() {
 	case reflect.String:
 		return quote(v.String()), nil
-	case reflect.Slice: // array
+	case reflect.Slice:
 		values := make([]string, 0, v.Len())
 		for i := 0; i < v.Len(); i++ {
 			val, err := format(tz, v.Index(i).Interface())
@@ -226,7 +226,7 @@ func format(tz *time.Location, v interface{}) (string, error) {
 			}
 			values = append(values, val)
 		}
-		return "[" + strings.Join(values, ", ") + "]", nil
+		return strings.Join(values, ", "), nil
 	case reflect.Map: // map
 		values := make([]string, 0, len(v.MapKeys()))
 		for _, key := range v.MapKeys() {
@@ -234,6 +234,10 @@ func format(tz *time.Location, v interface{}) (string, error) {
 			val, err := format(tz, v.MapIndex(key).Interface())
 			if err != nil {
 				return "", err
+			}
+			if v.MapIndex(key).Kind() == reflect.Slice {
+				// assume slices in maps are arrays
+				val = fmt.Sprintf("[%s]", val)
 			}
 			values = append(values, fmt.Sprintf("'%s': %s", name, val))
 		}

--- a/bind_test.go
+++ b/bind_test.go
@@ -186,8 +186,10 @@ func TestFormatTime(t *testing.T) {
 		tz, err = time.LoadLocation("Europe/London")
 	)
 	if assert.NoError(t, err) {
-		if assert.Equal(t, "toDateTime('2022-01-12 15:00:00')", format(t1.Location(), t1)) {
-			assert.Equal(t, "toDateTime('2022-01-12 15:00:00', 'UTC')", format(tz, t1))
+		val, _ := format(t1.Location(), t1)
+		if assert.Equal(t, "toDateTime('2022-01-12 15:00:00')", val) {
+			val, _ = format(tz, t1)
+			assert.Equal(t, "toDateTime('2022-01-12 15:00:00', 'UTC')", val)
 		}
 	}
 }
@@ -197,19 +199,24 @@ func TestStringBasedType(t *testing.T) {
 		SupperString       string
 		SupperSupperString string
 	)
-	require.Equal(t, "'a'", format(time.UTC, SupperString("a")))
-	require.Equal(t, "'a'", format(time.UTC, SupperSupperString("a")))
-	require.Equal(t, "'a', 'b', 'c'", format(time.UTC, []SupperSupperString{"a", "b", "c"}))
+	val, _ := format(time.UTC, SupperString("a"))
+	require.Equal(t, "'a'", val)
+	val, _ = format(time.UTC, SupperSupperString("a"))
+	require.Equal(t, "'a'", val)
+	val, _ = format(time.UTC, []SupperSupperString{"a", "b", "c"})
+	require.Equal(t, "'a', 'b', 'c'", val)
 }
 
 func TestFormatTuple(t *testing.T) {
-	assert.Equal(t, "('A', 1)", format(time.UTC, []interface{}{"A", 1}))
+	val, _ := format(time.UTC, []interface{}{"A", 1})
+	assert.Equal(t, "('A', 1)", val)
 	{
 		tuples := [][]interface{}{
 			[]interface{}{"A", 1},
 			[]interface{}{"B", 2},
 		}
-		assert.Equal(t, "('A', 1), ('B', 2)", format(time.UTC, tuples))
+		val, _ = format(time.UTC, tuples)
+		assert.Equal(t, "('A', 1), ('B', 2)", val)
 	}
 }
 

--- a/tests/issues/546_test.go
+++ b/tests/issues/546_test.go
@@ -18,7 +18,6 @@ func Test546(t *testing.T) {
 			Username: "default",
 			Password: "",
 		},
-		Debug:           true,
 		DialTimeout:     time.Second,
 		MaxOpenConns:    10,
 		MaxIdleConns:    5,

--- a/tests/issues/578_test.go
+++ b/tests/issues/578_test.go
@@ -10,8 +10,7 @@ import (
 func Test578(t *testing.T) {
 	ctx := context.Background()
 	conn, err := clickhouse.Open(&clickhouse.Options{
-		Addr:  []string{"127.0.0.1:9000"},
-		Debug: true,
+		Addr: []string{"127.0.0.1:9000"},
 	})
 	assert.NoError(t, err)
 

--- a/tests/issues/584_test.go
+++ b/tests/issues/584_test.go
@@ -20,7 +20,7 @@ func Test584(t *testing.T) {
 	})
 	require.NoError(t, err)
 	defer func() {
-		require.NoError(t, conn.Exec(context.Background(), "DROP TABLE issue_584_complex"))
+		require.NoError(t, conn.Exec(context.Background(), "DROP TABLE issue_584"))
 	}()
 
 	const ddl = `
@@ -57,22 +57,22 @@ func Test584Complex(t *testing.T) {
 
 	const ddl = `
 	CREATE TABLE issue_584_complex (
-		Col1 Map(String, Map(String, Array(UInt8)))
+		Col1 Map(String, Map(UInt8, Array(UInt8)))
 	) Engine Memory
 	`
 	require.NoError(t, conn.Exec(context.Background(), "DROP TABLE IF EXISTS issue_584_complex"))
 	require.NoError(t, conn.Exec(context.Background(), ddl))
-	col1 := map[string]map[string][]uint8{
+	col1 := map[string]map[uint8][]uint8{
 		"a": {
-			"b": []uint8{1, 2, 3, 4},
-			"c": []uint8{5, 6, 7, 8},
+			100: []uint8{1, 2, 3, 4},
+			99:  []uint8{5, 6, 7, 8},
 		},
 		"d": {
-			"e": []uint8{10, 11, 12, 13},
+			98: []uint8{10, 11, 12, 13},
 		},
 	}
 	require.NoError(t, conn.Exec(context.Background(), "INSERT INTO issue_584_complex values($1)", col1))
-	var event map[string]map[string][]uint8
+	var event map[string]map[uint8][]uint8
 	require.NoError(t, conn.QueryRow(context.Background(), "SELECT * FROM issue_584_complex").Scan(&event))
 	assert.Equal(t, col1, event)
 

--- a/tests/issues/584_test.go
+++ b/tests/issues/584_test.go
@@ -19,7 +19,9 @@ func Test584(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	defer require.NoError(t, conn.Exec(context.Background(), "DROP TABLE issue_584"))
+	defer func() {
+		require.NoError(t, conn.Exec(context.Background(), "DROP TABLE issue_584_complex"))
+	}()
 
 	const ddl = `
 	CREATE TABLE issue_584 (
@@ -49,14 +51,16 @@ func Test584Complex(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	defer require.NoError(t, conn.Exec(context.Background(), "DROP TABLE issue_584"))
+	defer func() {
+		require.NoError(t, conn.Exec(context.Background(), "DROP TABLE issue_584_complex"))
+	}()
 
 	const ddl = `
-	CREATE TABLE issue_584 (
+	CREATE TABLE issue_584_complex (
 		Col1 Map(String, Map(String, Array(UInt8)))
 	) Engine Memory
 	`
-	require.NoError(t, conn.Exec(context.Background(), "DROP TABLE IF EXISTS issue_584"))
+	require.NoError(t, conn.Exec(context.Background(), "DROP TABLE IF EXISTS issue_584_complex"))
 	require.NoError(t, conn.Exec(context.Background(), ddl))
 	col1 := map[string]map[string][]uint8{
 		"a": {
@@ -67,9 +71,9 @@ func Test584Complex(t *testing.T) {
 			"e": []uint8{10, 11, 12, 13},
 		},
 	}
-	require.NoError(t, conn.Exec(context.Background(), "INSERT INTO issue_584 values($1)", col1))
+	require.NoError(t, conn.Exec(context.Background(), "INSERT INTO issue_584_complex values($1)", col1))
 	var event map[string]map[string][]uint8
-	require.NoError(t, conn.QueryRow(context.Background(), "SELECT * FROM issue_584").Scan(&event))
+	require.NoError(t, conn.QueryRow(context.Background(), "SELECT * FROM issue_584_complex").Scan(&event))
 	assert.Equal(t, col1, event)
 
 }

--- a/tests/issues/584_test.go
+++ b/tests/issues/584_test.go
@@ -1,0 +1,75 @@
+package issues
+
+import (
+	"context"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test584(t *testing.T) {
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Addr: []string{"127.0.0.1:9000"},
+		Compression: &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		},
+		Settings: clickhouse.Settings{
+			"max_execution_time": 60,
+		},
+	})
+	require.NoError(t, err)
+	defer require.NoError(t, conn.Exec(context.Background(), "DROP TABLE issue_584"))
+
+	const ddl = `
+	CREATE TABLE issue_584 (
+		Col1 Map(String, String)
+	) Engine Memory
+	`
+	require.NoError(t, conn.Exec(context.Background(), "DROP TABLE IF EXISTS issue_584"))
+	require.NoError(t, conn.Exec(context.Background(), ddl))
+	require.NoError(t, conn.Exec(context.Background(), "INSERT INTO issue_584 values($1)", map[string]string{
+		"key": "value",
+	}))
+	var event map[string]string
+	require.NoError(t, conn.QueryRow(context.Background(), "SELECT * FROM issue_584").Scan(&event))
+	assert.Equal(t, map[string]string{
+		"key": "value",
+	}, event)
+}
+
+func Test584Complex(t *testing.T) {
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Addr: []string{"127.0.0.1:9000"},
+		Compression: &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		},
+		Settings: clickhouse.Settings{
+			"max_execution_time": 60,
+		},
+	})
+	require.NoError(t, err)
+	defer require.NoError(t, conn.Exec(context.Background(), "DROP TABLE issue_584"))
+
+	const ddl = `
+	CREATE TABLE issue_584 (
+		Col1 Map(String, Map(String, Array(UInt8)))
+	) Engine Memory
+	`
+	require.NoError(t, conn.Exec(context.Background(), "DROP TABLE IF EXISTS issue_584"))
+	require.NoError(t, conn.Exec(context.Background(), ddl))
+	col1 := map[string]map[string][]uint8{
+		"a": {
+			"b": []uint8{1, 2, 3, 4},
+			"c": []uint8{5, 6, 7, 8},
+		},
+		"d": {
+			"e": []uint8{10, 11, 12, 13},
+		},
+	}
+	require.NoError(t, conn.Exec(context.Background(), "INSERT INTO issue_584 values($1)", col1))
+	var event map[string]map[string][]uint8
+	require.NoError(t, conn.QueryRow(context.Background(), "SELECT * FROM issue_584").Scan(&event))
+	assert.Equal(t, col1, event)
+
+}


### PR DESCRIPTION
This closes https://github.com/ClickHouse/clickhouse-go/issues/584

I'm not sure this is something we want to support long term. This means user can send maps in params but it seems fragile - mainly as for more complex structures it can't tell the differences between tuples and arrays i.e. the existing code assumes []interface{} is a tuple.

For simple statements this is probably fine but its still susceptible to injection and users should use the new JSON feature.