### PR TITLE
Allow ipv4 to be passed in ipv6

### DIFF
--- a/lib/column/ipv6.go
+++ b/lib/column/ipv6.go
@@ -72,10 +72,7 @@ func (col *IPv6) Append(v interface{}) (nulls []uint8, err error) {
 		nulls = make([]uint8, len(v))
 		for _, v := range v {
 			if len(v) != net.IPv6len {
-				return nil, &Error{
-					ColumnType: string(col.Type()),
-					Err:        fmt.Errorf("invalid size. expected %d got %d", net.IPv6len, len(v)),
-				}
+				v = v.To16()
 			}
 			col.data = append(col.data, v[:]...)
 		}
@@ -84,13 +81,11 @@ func (col *IPv6) Append(v interface{}) (nulls []uint8, err error) {
 		for i, v := range v {
 			switch {
 			case v != nil:
-				if len(*v) != net.IPv6len {
-					return nil, &Error{
-						ColumnType: string(col.Type()),
-						Err:        fmt.Errorf("invalid size. expected %d got %d", net.IPv6len, len(*v)),
-					}
-				}
+				//copy so we don't modify original value
 				tmp := *v
+				if len(tmp) != net.IPv6len {
+					tmp = tmp.To16()
+				}
 				col.data = append(col.data, tmp[:]...)
 			default:
 				col.data, nulls[i] = append(col.data, make([]byte, net.IPv6len)...), 1
@@ -128,10 +123,7 @@ func (col *IPv6) AppendRow(v interface{}) error {
 		}
 	}
 	if len(ip) != net.IPv6len {
-		return &Error{
-			ColumnType: string(col.Type()),
-			Err:        fmt.Errorf("invalid size. expected %d got %d", net.IPv6len, len(ip)),
-		}
+		ip = ip.To16()
 	}
 	col.data = append(col.data, ip[:]...)
 	return nil


### PR DESCRIPTION
Closes https://github.com/ClickHouse/clickhouse-go/issues/599

@genzgd i'm not conviced we need to allow this level of flexibility but its part of the wider casting discussion - i.e. does the driver allow this flexibility or defer to the user? v1 did the former, v2 the latter. We broadly agreed to align with v1 where there is no loss of precision.