### PR TITLE
HTTP Part 0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,6 +32,7 @@ jobs:
       clickhouse:
         image: clickhouse/clickhouse-server:${{ matrix.clickhouse }}
         ports:
+          - 8123:8123
           - 9000:9000
         options: --ulimit nofile=262144:262144
 

--- a/conn_http.go
+++ b/conn_http.go
@@ -1,0 +1,131 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package clickhouse
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpConnect, error) {
+	url := &url.URL{
+		Scheme: "http",
+		Host:   addr,
+	}
+
+	if opt.TLS != nil {
+		url.Scheme = "https"
+	}
+
+	connect := &httpConnect{
+		opt: opt,
+		transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:   opt.DialTimeout,
+				KeepAlive: opt.ConnMaxLifetime,
+			}).DialContext,
+			MaxIdleConns:          1,
+			IdleConnTimeout:       opt.ConnMaxLifetime,
+			ResponseHeaderTimeout: opt.ReadTimeout,
+			TLSClientConfig:       opt.TLS,
+		},
+		url:      url,
+		location: time.UTC, // TODO: make configurable
+	}
+
+	if err := connect.ping(ctx); err != nil {
+		return nil, err
+	}
+
+	return connect, nil
+}
+
+type httpConnect struct {
+	opt       *Options
+	url       *url.URL
+	transport *http.Transport
+	location  *time.Location
+}
+
+func (h *httpConnect) prepareRequest(ctx context.Context, query string, args ...interface{}) (*http.Request, error) {
+	query, err := bind(h.location, query, args)
+	if err != nil {
+		return nil, err
+	}
+
+	reader := strings.NewReader(query)
+
+	req, err := http.NewRequest(http.MethodPost, h.url.String(), reader)
+
+	return req, err
+}
+
+func (h *httpConnect) executeRequest(ctx context.Context, req *http.Request) (io.ReadCloser, error) {
+
+	if h.transport == nil {
+		return nil, driver.ErrBadConn
+	}
+
+	resp, err := h.transport.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("clickhouse [execute]:: got no 200 code('%d')", resp.StatusCode)
+	}
+
+	return resp.Body, nil
+}
+
+func (h *httpConnect) ping(ctx context.Context) error {
+	req, err := h.prepareRequest(ctx, "SELECT 1")
+	if err != nil {
+		return err
+	}
+
+	res, err := h.executeRequest(ctx, req)
+	if err != nil {
+		return err
+	}
+	s, err := io.ReadAll(res)
+	if err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(string(s)) != "1" {
+		return fmt.Errorf("clickhouse [ping]:: expected result (1), got '%s' instead", string(s))
+	}
+
+	return nil
+}
+
+func (h *httpConnect) close() error {
+	if h.transport == nil {
+		return nil
+	}
+	h.transport.CloseIdleConnections()
+	h.transport = nil
+	return nil
+}

--- a/tests/std/conn_test.go
+++ b/tests/std/conn_test.go
@@ -28,36 +28,54 @@ import (
 )
 
 func TestStdConn(t *testing.T) {
-	if conn, err := sql.Open("clickhouse", "clickhouse://127.0.0.1:9000"); assert.NoError(t, err) {
-		if assert.NoError(t, err) {
-			if err := conn.PingContext(context.Background()); assert.NoError(t, err) {
-				if assert.NoError(t, conn.Close()) {
-					t.Log(conn.Stats())
+	dsns := []string{"clickhouse://127.0.0.1:9000", "http://127.0.0.1:8123"}
+
+	for _, dsn := range dsns {
+		if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
+			if assert.NoError(t, err) {
+				if err := conn.PingContext(context.Background()); assert.NoError(t, err) {
+					if assert.NoError(t, conn.Close()) {
+						t.Log(conn.Stats())
+					}
 				}
 			}
 		}
 	}
 }
 func TestStdConnFailover(t *testing.T) {
-	if conn, err := sql.Open("clickhouse", "clickhouse://127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9000"); assert.NoError(t, err) {
-		if err := conn.PingContext(context.Background()); assert.NoError(t, err) {
-			t.Log(conn.PingContext(context.Background()))
+	dsns := []string{"clickhouse://127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9000",
+		"http://127.0.0.1:8124,127.0.0.1:8125,127.0.0.1:8123"}
+
+	for _, dsn := range dsns {
+		if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
+			if err := conn.PingContext(context.Background()); assert.NoError(t, err) {
+				t.Log(conn.PingContext(context.Background()))
+			}
 		}
 	}
 }
 func TestStdConnFailoverConnOpenRoundRobin(t *testing.T) {
-	if conn, err := sql.Open("clickhouse", "clickhouse://127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9003,127.0.0.1:9004,127.0.0.1:9005,127.0.0.1:9006,127.0.0.1:9000/?connection_open_strategy=round_robin"); assert.NoError(t, err) {
-		if err := conn.PingContext(context.Background()); assert.NoError(t, err) {
-			t.Log(conn.PingContext(context.Background()))
+	dsns := []string{"clickhouse://127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9003,127.0.0.1:9004,127.0.0.1:9005,127.0.0.1:9006,127.0.0.1:9000/?connection_open_strategy=round_robin",
+		"http://127.0.0.1:8124,127.0.0.1:8125,127.0.0.1:8126,127.0.0.1:8127,127.0.0.1:8128,127.0.0.1:8129,127.0.0.1:8123/?connection_open_strategy=round_robin"}
+
+	for _, dsn := range dsns {
+		if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
+			if err := conn.PingContext(context.Background()); assert.NoError(t, err) {
+				t.Log(conn.PingContext(context.Background()))
+			}
 		}
 	}
 }
 func TestStdPingDeadline(t *testing.T) {
-	if conn, err := sql.Open("clickhouse", "clickhouse://127.0.0.1:9000"); assert.NoError(t, err) {
-		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
-		defer cancel()
-		if err := conn.PingContext(ctx); assert.Error(t, err) {
-			assert.Equal(t, err, context.DeadlineExceeded)
+	dsns := []string{"clickhouse://127.0.0.1:9000", "http://127.0.0.1:8123"}
+
+	for _, dsn := range dsns {
+		if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
+			ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+			defer cancel()
+			if err := conn.PingContext(ctx); assert.Error(t, err) {
+				assert.Equal(t, err, context.DeadlineExceeded)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Issue #597 

### STD Driver Extension
STD driver haven't depended on specific implementation.
Interface will be chosen depends on `Options` in connect stage.

### New connection
HTTP connection was added with minimum functionality (Open, Ping, Close).
Other functions return `ErrHttpNotSupported` for now. Their implementation will be in the next PRs.

### Tests
Added tests for HTTP connection through STD interface.

### Breaking changes
None. All tests passed successfully.

cc @gingerwizard