### PR TITLE
Correction of SELECT work

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -44,6 +44,11 @@ func (ch *clickhouse) Select(ctx context.Context, dest interface{}, query string
 	if direct.Kind() != reflect.Slice {
 		return fmt.Errorf("must pass a slice to Select destination")
 	}
+	if direct.Len() != 0 {
+		// dest should point to empty slice
+		// to make select result correct
+		direct.Set(reflect.MakeSlice(direct.Type(), 0, direct.Cap()))
+	}
 	var (
 		base      = direct.Type().Elem()
 		rows, err = ch.Query(ctx, query, args...)

--- a/tests/issues/517_test.go
+++ b/tests/issues/517_test.go
@@ -1,0 +1,57 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package issues
+
+import (
+	"context"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSelectTwoInRow(t *testing.T) {
+	var (
+		ctx       = context.Background()
+		conn, err = clickhouse.Open(&clickhouse.Options{
+			Addr: []string{"127.0.0.1:9000"},
+			Auth: clickhouse.Auth{
+				Database: "default",
+				Username: "default",
+				Password: "",
+			},
+			Compression: &clickhouse.Compression{
+				Method: clickhouse.CompressionLZ4,
+			},
+			//Debug: true,
+		})
+	)
+	if assert.NoError(t, err) {
+		var result []struct {
+			Col1 uint64 `ch:"number"`
+		}
+		err := conn.Select(ctx, &result, "SELECT number FROM system.numbers LIMIT 10")
+		if assert.NoError(t, err) && assert.Len(t, result, 10) {
+			err = conn.Select(ctx, &result, "SELECT number FROM system.numbers LIMIT 5")
+			if assert.NoError(t, err) && assert.Len(t, result, 5) {
+				for i, v := range result {
+					assert.Equal(t, uint64(i), v.Col1)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Issue #517

The problem was not in WATCH query. The problem can be reproduced with two consecutive SELECT queries with same `dest` parameter. 

In `Select`, a result is simply added to `dest`. Therefore, after the first selection, `dest` will be filled, then the second selection will write to the filled `dest`. In result, `dest` will be a union of the two results. 

 I have added a check for an empty slice. If the slice is not empty, then it is cleared.

сс @gingerwizard @genzgd 