### PR TITLE
Fix timezones and grouping sets

### DIFF
--- a/lib/driver/driver.go
+++ b/lib/driver/driver.go
@@ -20,6 +20,7 @@ package driver
 import (
 	"context"
 	"reflect"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
@@ -31,6 +32,13 @@ type (
 		Name  string
 		Value interface{}
 	}
+
+	NamedDateValue struct {
+		Name  string
+		Value time.Time
+		Scale uint8
+	}
+
 	Stats struct {
 		MaxOpenConns int
 		MaxIdleConns int

--- a/tests/issues/504_test.go
+++ b/tests/issues/504_test.go
@@ -43,12 +43,12 @@ func Test504(t *testing.T) {
 				LIMIT 5
 			)
 		)
-		WHERE (Col1, Col2) IN ($1)
+		WHERE (Col1, Col2) IN (@GS)
 		`
-		err := conn.Select(ctx, &result, query, [][]interface{}{
-			[]interface{}{"A", 2},
-			[]interface{}{"A", 4},
-		})
+		err := conn.Select(ctx, &result, query, clickhouse.Named("GS", []clickhouse.GroupSet{
+			{Value: []interface{}{"A", 2}},
+			{Value: []interface{}{"A", 4}},
+		}))
 
 		if assert.NoError(t, err) {
 			assert.Equal(t, []struct {

--- a/tests/issues/615_test.go
+++ b/tests/issues/615_test.go
@@ -19,6 +19,9 @@ func Test615(t *testing.T) {
 			"max_execution_time": 60,
 		},
 	})
+	if err := checkMinServerVersion(conn, 22, 0); err != nil {
+		t.Skip(err.Error())
+	}
 	if err != nil {
 		panic(err)
 	}
@@ -33,9 +36,9 @@ func Test615(t *testing.T) {
 	); err != nil {
 		require.NoError(t, err)
 	}
-	defer func() {
-		require.NoError(t, conn.Exec(context.Background(), "DROP TABLE issue_615"))
-	}()
+	//defer func() {
+	//	require.NoError(t, conn.Exec(context.Background(), "DROP TABLE issue_615"))
+	//}()
 	ts1 := time.Now().Round(time.Second)
 	ts2 := ts1.Add(time.Millisecond)
 	ts3 := ts1.Add(time.Second + time.Millisecond)
@@ -58,6 +61,7 @@ func Test615(t *testing.T) {
 	}
 	// loss of precision - should only get 1 result
 	assert.Equal(t, 2, i)
+	// use DateNamed to guarantee precision
 	rows, err = conn.Query(context.Background(), "SELECT id, ts from issue_615 where ts > @TS ORDER BY ts ASC", clickhouse.DateNamed("TS", ts2, clickhouse.NanoSeconds))
 	require.NoError(t, err)
 	i = 0
@@ -67,6 +71,7 @@ func Test615(t *testing.T) {
 			ts time.Time
 		)
 		require.NoError(t, rows.Scan(&id, &ts))
+		require.Equal(t, id, "third")
 		require.Equal(t, ts, ts3)
 		i += 1
 	}

--- a/tests/issues/615_test.go
+++ b/tests/issues/615_test.go
@@ -1,0 +1,62 @@
+package issues
+
+import (
+	"context"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func Test615(t *testing.T) {
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Addr: []string{"127.0.0.1:9000"},
+		Compression: &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		},
+		Settings: clickhouse.Settings{
+			"max_execution_time": 60,
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	if err := conn.Exec(
+		context.Background(),
+		`
+			CREATE TABLE IF NOT EXISTS issue_615
+			(id String, ts DateTime64(9))
+			ENGINE = MergeTree
+			ORDER BY (ts)
+			`,
+	); err != nil {
+		require.NoError(t, err)
+	}
+	defer func() {
+		require.NoError(t, conn.Exec(context.Background(), "DROP TABLE issue_615"))
+	}()
+	ts1 := time.Now().Round(time.Second)
+	ts2 := ts1.Add(time.Millisecond)
+	ts3 := ts1.Add(time.Second + time.Millisecond)
+	batch, err := conn.PrepareBatch(context.Background(), "INSERT INTO issue_615 (id, ts)")
+	require.NoError(t, err)
+	require.NoError(t, batch.Append("first", ts1))
+	require.NoError(t, batch.Append("second", ts2))
+	require.NoError(t, batch.Append("third", ts3))
+	require.NoError(t, batch.Send())
+	rows, err := conn.Query(context.Background(), "SELECT id, ts from issue_615 where ts > @TS ORDER BY ts ASC", clickhouse.Named("TS", ts2))
+	require.NoError(t, err)
+	i := 0
+	for rows.Next() {
+		var (
+			id string
+			ts time.Time
+		)
+		require.NoError(t, rows.Scan(&id, &ts))
+		require.Equal(t, ts, ts3)
+		i += 1
+	}
+	assert.Equal(t, 1, i)
+
+}


### PR DESCRIPTION
This closes #615  

To do this, we introduce a NamedDateValue for which the user must specify a precision. When we bind the parameters we have no idea of the column's precision, so the user must pass this. See [here](https://github.com/ClickHouse/clickhouse-go/compare/issue_615?expand=1#diff-7b11ab5f33239ba3ee3f04d7ad424022d24aad1b9785d0fd5f711a09b75da4ac) for example usage.

Furthemore, we fix tuples in parameters i.e. https://github.com/ClickHouse/clickhouse-go/issues/504. Previously, this relied on []interface{} - this was flaky and conflicted with reflect.Set. To solve we introduce GroupSet (tuple name makes no sense to me) - example [here](https://github.com/ClickHouse/clickhouse-go/compare/issue_615?expand=1#diff-57186ba5037d295076d4fc373a59c82561f5c07933ae37385704e91c30adc6f7). This is a breaking change.