### PR TITLE
Unify Nested, JSON and Tuple

### DIFF
--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -346,7 +346,6 @@ func (r *stdRows) Next(dest []driver.Value) error {
 	if r.rows.Next() {
 		for i := range dest {
 			nullable, ok := r.ColumnTypeNullable(i)
-			// maybe call ScanRow
 			switch value := r.rows.block.Columns[i].Row(r.rows.row-1, nullable && ok).(type) {
 			case driver.Valuer:
 				v, err := value.Value()

--- a/lib/column/array.go
+++ b/lib/column/array.go
@@ -133,7 +133,7 @@ func (col *Array) AppendRow(v interface{}) error {
 	default:
 		elem = reflect.Indirect(reflect.ValueOf(v))
 	}
-	if !elem.IsValid() || elem.Type() != col.scanType {
+	if !elem.IsValid() {
 		from := fmt.Sprintf("%T", v)
 		if !elem.IsValid() {
 			from = fmt.Sprintf("%v", v)

--- a/lib/column/array.go
+++ b/lib/column/array.go
@@ -254,13 +254,13 @@ func (col *Array) scanSlice(sliceType reflect.Type, row int, level int) (reflect
 	base := offset.scanType.Elem()
 	isPtr := base.Kind() == reflect.Ptr
 
-	var jsonSlice reflect.Value
+	var rSlice reflect.Value
 	switch sliceType.Kind() {
 	case reflect.Interface:
 		sliceType = offset.scanType
-		jsonSlice = reflect.MakeSlice(sliceType, 0, int(end-start))
+		rSlice = reflect.MakeSlice(sliceType, 0, int(end-start))
 	case reflect.Slice:
-		jsonSlice = reflect.MakeSlice(sliceType, 0, int(end-start))
+		rSlice = reflect.MakeSlice(sliceType, 0, int(end-start))
 	default:
 		return reflect.Value{}, &Error{
 			ColumnType: fmt.Sprint(sliceType.Kind()),
@@ -284,6 +284,12 @@ func (col *Array) scanSlice(sliceType reflect.Type, row int, level int) (reflect
 			case *Array:
 				//Array(Array
 				value, err = dcol.scanSlice(sliceType.Elem(), int(i), 0)
+				if err != nil {
+					return reflect.Value{}, err
+				}
+			case *Tuple:
+				// Array(Tuple possible outside JSON object cases e.g. if the user defines a  Array(Array( Tuple(String, Int64) ))
+				value, err = dcol.scan(sliceType.Elem(), int(i))
 				if err != nil {
 					return reflect.Value{}, err
 				}
@@ -311,9 +317,9 @@ func (col *Array) scanSlice(sliceType reflect.Type, row int, level int) (reflect
 				return reflect.Value{}, err
 			}
 		}
-		jsonSlice = reflect.Append(jsonSlice, value)
+		rSlice = reflect.Append(rSlice, value)
 	}
-	return jsonSlice, nil
+	return rSlice, nil
 }
 
 func (col *Array) scanSliceOfObjects(sliceType reflect.Type, row int) (reflect.Value, error) {
@@ -375,15 +381,15 @@ func (col *Array) scanSliceOfMaps(sliceType reflect.Type, row int) (reflect.Valu
 		start = offset.values.data[row-1]
 	}
 	if end-start > 0 {
-		jsonSlice := reflect.MakeSlice(sliceType, 0, int(end-start))
+		rSlice := reflect.MakeSlice(sliceType, 0, int(end-start))
 		for i := start; i < end; i++ {
 			sMap := reflect.MakeMap(sliceType.Elem())
-			if err := tCol.scanJSONMap(sMap, int(i)); err != nil {
+			if err := tCol.scanMap(sMap, int(i)); err != nil {
 				return reflect.Value{}, err
 			}
-			jsonSlice = reflect.Append(jsonSlice, sMap)
+			rSlice = reflect.Append(rSlice, sMap)
 		}
-		return jsonSlice, nil
+		return rSlice, nil
 	}
 	return reflect.MakeSlice(sliceType, 0, 0), nil
 }
@@ -413,16 +419,16 @@ func (col *Array) scanSliceOfStructs(sliceType reflect.Type, row int) (reflect.V
 		start = offset.values.data[row-1]
 	}
 	if end-start > 0 {
-		// create a slice of the type from the jsonSlice - if this might be interface{} as its driven by the target datastructure
-		jsonSlice := reflect.MakeSlice(sliceType, 0, int(end-start))
+		// create a slice of the type from the sliceType - if this might be interface{} as its driven by the target datastructure
+		rSlice := reflect.MakeSlice(sliceType, 0, int(end-start))
 		for i := start; i < end; i++ {
 			sStruct := reflect.New(sliceType.Elem()).Elem()
-			if err := tCol.scanJSONStruct(sStruct, int(i)); err != nil {
+			if err := tCol.scanStruct(sStruct, int(i)); err != nil {
 				return reflect.Value{}, err
 			}
-			jsonSlice = reflect.Append(jsonSlice, sStruct)
+			rSlice = reflect.Append(rSlice, sStruct)
 		}
-		return jsonSlice, nil
+		return rSlice, nil
 	}
 	return reflect.MakeSlice(sliceType, 0, 0), nil
 }

--- a/lib/column/codegen/column.tpl
+++ b/lib/column/codegen/column.tpl
@@ -77,38 +77,35 @@ func (t Type) Column(name string) (Interface, error) {
 	case "Nothing":
 		return &Nothing{name: name}, nil
 	case "Ring":
-		v, err := (&Array{name: name}).parse("Array(Point)")
-		if err != nil{
-			return nil, err
-		}
-		set := v.(*Array)
-		set.chType = "Ring"
-		return &Ring{
-			set: set,
-			name: name,
-		}, nil
+		set, err := (&Array{name: name}).parse("Array(Point)")
+        if err != nil {
+            return nil, err
+        }
+        set.chType = "Ring"
+        return &Ring{
+            set:  set,
+            name: name,
+        }, nil
 	case "Polygon":
-		v, err := (&Array{name: name}).parse("Array(Ring)")
-		if err != nil{
-			return nil, err
-		}
-		set := v.(*Array)
-		set.chType = "Polygon"
-		return &Polygon{
-			set: set,
-			name: name,
-		}, nil
+		set, err := (&Array{name: name}).parse("Array(Ring)")
+        if err != nil {
+            return nil, err
+        }
+        set.chType = "Polygon"
+        return &Polygon{
+            set:  set,
+            name: name,
+        }, nil
 	case "MultiPolygon":
-		v, err := (&Array{name: name}).parse("Array(Polygon)")
-		if err != nil{
-			return nil, err
-		}
-		set := v.(*Array)
-		set.chType = "MultiPolygon"
-		return &MultiPolygon{
-			set: set,
-			name: name,
-		}, nil
+		set, err := (&Array{name: name}).parse("Array(Polygon)")
+        if err != nil {
+            return nil, err
+        }
+        set.chType = "MultiPolygon"
+        return &MultiPolygon{
+            set:  set,
+            name: name,
+        }, nil
 	case "Point":
 		return &Point{name: name}, nil
 	case "String":
@@ -177,6 +174,7 @@ var (
 		scanTypeRing    = reflect.TypeOf(orb.Ring{})
 		scanTypePoint   = reflect.TypeOf(orb.Point{})
 		scanTypeSlice   = reflect.TypeOf([]interface{}{})
+		scanTypeMap	    = reflect.TypeOf(map[string]interface{}{})
 		scanTypeBigInt  = reflect.TypeOf(&big.Int{})
 		scanTypeString  = reflect.TypeOf("")
 		scanTypePolygon = reflect.TypeOf(orb.Polygon{})

--- a/lib/column/column_gen.go
+++ b/lib/column/column_gen.go
@@ -238,6 +238,7 @@ var (
 	scanTypeRing         = reflect.TypeOf(orb.Ring{})
 	scanTypePoint        = reflect.TypeOf(orb.Point{})
 	scanTypeSlice        = reflect.TypeOf([]interface{}{})
+	scanTypeMap          = reflect.TypeOf(map[string]interface{}{})
 	scanTypeBigInt       = reflect.TypeOf(&big.Int{})
 	scanTypeString       = reflect.TypeOf("")
 	scanTypePolygon      = reflect.TypeOf(orb.Polygon{})

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -546,7 +546,7 @@ func createJSONList(name string) (jCol *JSONList) {
 	lCol.values = &JSONObject{}
 	// depth should always be one as nested arrays aren't possible
 	lCol.depth = 1
-	lCol.scanType = reflect.SliceOf(lCol.values.ScanType())
+	lCol.scanType = scanTypeSlice
 	offsetScanTypes := []reflect.Type{lCol.scanType}
 	lCol.offsets = []*offset{{
 		scanType: offsetScanTypes[0],
@@ -802,7 +802,7 @@ func (jCol *JSONObject) FullType() Type {
 }
 
 func (jCol *JSONObject) ScanType() reflect.Type {
-	return scanTypeSlice
+	return scanTypeMap
 }
 
 func (jCol *JSONObject) Rows() int {

--- a/lib/column/tuple.go
+++ b/lib/column/tuple.go
@@ -33,6 +33,7 @@ type Tuple struct {
 	chType  Type
 	columns []Interface
 	name    string
+	isNamed bool // true if all columns are named
 }
 
 func (col *Tuple) Name() string {
@@ -83,13 +84,18 @@ func (col *Tuple) parse(t Type) (_ Interface, err error) {
 		element = append(element, r)
 	}
 	appendElement()
+	isNamed := true
 	for _, ct := range elements {
+		if ct.name == "" {
+			isNamed = false
+		}
 		column, err := ct.colType.Column(ct.name)
 		if err != nil {
 			return nil, err
 		}
 		col.columns = append(col.columns, column)
 	}
+	col.isNamed = isNamed
 	if len(col.columns) != 0 {
 		return col, nil
 	}
@@ -102,7 +108,10 @@ func (col *Tuple) Type() Type {
 	return col.chType
 }
 
-func (Tuple) ScanType() reflect.Type {
+func (col Tuple) ScanType() reflect.Type {
+	if col.isNamed {
+		return scanTypeMap
+	}
 	return scanTypeSlice
 }
 
@@ -114,11 +123,13 @@ func (col *Tuple) Rows() int {
 }
 
 func (col *Tuple) Row(i int, ptr bool) interface{} {
-	tuple := make([]interface{}, 0, len(col.columns))
-	for _, c := range col.columns {
-		tuple = append(tuple, c.Row(i, ptr))
+	tuple := reflect.New(col.ScanType())
+	value := tuple.Interface()
+	if err := col.ScanRow(value, i); err != nil {
+		// if this happens we have an unexplained problem
+		return nil
 	}
-	return tuple
+	return value
 }
 
 func setJSONFieldValue(field reflect.Value, value reflect.Value) error {
@@ -204,73 +215,73 @@ func getStructFieldValue(field reflect.Value, name string) (reflect.Value, bool)
 	return sField, sField.IsValid()
 }
 
-func (col *Tuple) scanJSONMap(json reflect.Value, row int) error {
-	if json.Type().Key().Kind() != reflect.String {
+func (col *Tuple) scanMap(targetMap reflect.Value, row int) error {
+	if targetMap.Type().Key().Kind() != reflect.String {
 		return &Error{
-			ColumnType: fmt.Sprint(json.Type().Key().Kind()),
+			ColumnType: fmt.Sprint(targetMap.Type().Key().Kind()),
 			Err:        fmt.Errorf("column %s - map keys must be a string", col.Name()),
 		}
 	}
 	for _, c := range col.columns {
 		switch dCol := c.(type) {
 		case *Tuple:
-			switch json.Type().Elem().Kind() {
+			switch targetMap.Type().Elem().Kind() {
 			case reflect.Struct:
-				rStruct := reflect.New(json.Type().Elem()).Elem()
-				if err := dCol.scanJSONStruct(rStruct, row); err != nil {
+				rStruct := reflect.New(targetMap.Type().Elem()).Elem()
+				if err := dCol.scanStruct(rStruct, row); err != nil {
 					return err
 				}
-				json.SetMapIndex(reflect.ValueOf(c.Name()), rStruct)
+				targetMap.SetMapIndex(reflect.ValueOf(c.Name()), rStruct)
 			case reflect.Map:
 				// get a typed map
-				newMap := reflect.MakeMap(json.Type().Elem())
-				if err := dCol.scanJSONMap(newMap, row); err != nil {
+				newMap := reflect.MakeMap(targetMap.Type().Elem())
+				if err := dCol.scanMap(newMap, row); err != nil {
 					return err
 				}
-				json.SetMapIndex(reflect.ValueOf(c.Name()), newMap)
+				targetMap.SetMapIndex(reflect.ValueOf(c.Name()), newMap)
 			case reflect.Interface:
 				// catches interface{} - Note this swallows custom interfaces to which maps couldn't conform
 				newMap := reflect.ValueOf(make(map[string]interface{}))
-				if err := dCol.scanJSONMap(newMap, row); err != nil {
+				if err := dCol.scanMap(newMap, row); err != nil {
 					return err
 				}
-				json.SetMapIndex(reflect.ValueOf(c.Name()), newMap)
+				targetMap.SetMapIndex(reflect.ValueOf(c.Name()), newMap)
 			default:
 				return &Error{
-					ColumnType: fmt.Sprint(json.Type().Elem().Kind()),
+					ColumnType: fmt.Sprint(targetMap.Type().Elem().Kind()),
 					Err:        fmt.Errorf("column %s - needs a map/struct or interface{}", col.Name()),
 				}
 			}
 		case *Nested:
 			aCol := dCol.Interface.(*Array)
-			subSlice, err := aCol.scanSliceOfObjects(json.Type().Elem(), row)
+			subSlice, err := aCol.scan(targetMap.Type().Elem(), row)
 			if err != nil {
 				return err
 			}
-			// this wont work if json is a map[string][]interface{} and we try to set a typed slice
-			json.SetMapIndex(reflect.ValueOf(c.Name()), subSlice)
+			// this wont work if targetMap is a map[string][]interface{} and we try to set a typed slice
+			targetMap.SetMapIndex(reflect.ValueOf(c.Name()), subSlice)
 		case *Array:
-			subSlice, err := dCol.scan(json.Type().Elem(), row)
+			subSlice, err := dCol.scan(targetMap.Type().Elem(), row)
 			if err != nil {
 				return err
 			}
-			json.SetMapIndex(reflect.ValueOf(c.Name()), subSlice)
+			targetMap.SetMapIndex(reflect.ValueOf(c.Name()), subSlice)
 		default:
 			field := reflect.New(reflect.TypeOf(c.Row(0, false))).Elem()
 			value := reflect.ValueOf(c.Row(row, false))
 			if err := setJSONFieldValue(field, value); err != nil {
 				return err
 			}
-			json.SetMapIndex(reflect.ValueOf(c.Name()), field)
+			targetMap.SetMapIndex(reflect.ValueOf(c.Name()), field)
 		}
 	}
 	return nil
 }
 
-func (col *Tuple) scanJSONStruct(json reflect.Value, row int) error {
+func (col *Tuple) scanStruct(targetStruct reflect.Value, row int) error {
 	for _, c := range col.columns {
-		// the column may be serialized using a different name due to a struct "json" tag
-		sField, ok := getStructFieldValue(json, c.Name())
+		// the column may be serialized using a different name due to a struct "targetStruct" tag
+		sField, ok := getStructFieldValue(targetStruct, c.Name())
 		// test if map
 		if !ok {
 			continue
@@ -279,31 +290,31 @@ func (col *Tuple) scanJSONStruct(json reflect.Value, row int) error {
 		case *Tuple:
 			switch sField.Kind() {
 			case reflect.Struct:
-				if err := dCol.scanJSONStruct(sField, row); err != nil {
+				if err := dCol.scanStruct(sField, row); err != nil {
 					return err
 				}
 			case reflect.Map:
 				newMap := reflect.MakeMap(sField.Type())
-				if err := dCol.scanJSONMap(newMap, row); err != nil {
+				if err := dCol.scanMap(newMap, row); err != nil {
 					return err
 				}
 				sField.Set(newMap)
 			case reflect.Interface:
 				// catches []interface{} -Note this swallows custom interfaces to which maps couldn't conform
 				newMap := reflect.ValueOf(make(map[string]interface{}))
-				if err := dCol.scanJSONMap(newMap, row); err != nil {
+				if err := dCol.scanMap(newMap, row); err != nil {
 					return err
 				}
 				sField.Set(newMap)
 			default:
 				return &Error{
 					ColumnType: fmt.Sprint(sField.Kind()),
-					Err:        fmt.Errorf("column %s - needs a map/struct or interface{}", col.Name()),
+					Err:        fmt.Errorf("column %s - needs a map/struct/slice or interface{}", col.Name()),
 				}
 			}
 		case *Nested:
 			aCol := dCol.Interface.(*Array)
-			subSlice, err := aCol.scanSliceOfObjects(sField.Type(), row)
+			subSlice, err := aCol.scan(sField.Type(), row)
 			if err != nil {
 				return err
 			}
@@ -324,47 +335,91 @@ func (col *Tuple) scanJSONStruct(json reflect.Value, row int) error {
 	return nil
 }
 
-func (col *Tuple) ScanRow(dest interface{}, row int) error {
-	switch d := dest.(type) {
-	case *[]interface{}:
-		tuple := make([]interface{}, 0, len(col.columns))
-		for _, c := range col.columns {
-			tuple = append(tuple, c.Row(row, false))
-		}
-		*d = tuple
-	default:
-		jType := reflect.Indirect(reflect.ValueOf(dest))
-		kind := jType.Kind()
-		if kind == reflect.Struct {
-			rStruct := reflect.New(jType.Type()).Elem()
-			err := col.scanJSONStruct(rStruct, row)
+func (col *Tuple) scanSlice(targetType reflect.Type, row int) (reflect.Value, error) {
+	rSlice := reflect.MakeSlice(targetType, 0, len(col.columns))
+	for _, c := range col.columns {
+		switch dCol := c.(type) {
+		case *Tuple:
+			value, err := dCol.scan(rSlice.Type().Elem(), row)
 			if err != nil {
-				return err
+				return reflect.Value{}, err
 			}
-			jType.Set(rStruct)
-			return nil
-		}
-		if kind == reflect.Map {
-			//check if pointer
-			mapVal := reflect.Indirect(reflect.ValueOf(dest))
-			if mapVal.IsNil() {
-				//if not initialized
-				newMap := reflect.MakeMap(mapVal.Type())
-				if err := col.scanJSONMap(newMap, row); err != nil {
-					return err
-				}
-				mapVal.Set(newMap)
-				return nil
+			rSlice = reflect.Append(rSlice, value)
+		case *Nested:
+			aCol := dCol.Interface.(*Array)
+			subSlice, err := aCol.scan(rSlice.Type().Elem(), row)
+			if err != nil {
+				return reflect.Value{}, err
 			}
-			return col.scanJSONMap(mapVal, row)
-		}
-		return &ColumnConverterError{
-			Op:   "ScanRow",
-			To:   fmt.Sprintf("%T", dest),
-			From: string(col.chType),
+			rSlice = reflect.Append(rSlice, subSlice)
+		case *Array:
+			subSlice, err := dCol.scan(rSlice.Type().Elem(), row)
+			if err != nil {
+				return reflect.Value{}, err
+			}
+			rSlice = reflect.Append(rSlice, subSlice)
+		default:
+			field := reflect.New(c.ScanType()).Elem()
+			value := reflect.ValueOf(c.Row(row, false))
+			if err := setJSONFieldValue(field, value); err != nil {
+				return reflect.Value{}, err
+			}
+			rSlice = reflect.Append(rSlice, field)
 		}
 	}
+	return rSlice, nil
+}
+
+func (col *Tuple) scan(targetType reflect.Type, row int) (reflect.Value, error) {
+	switch targetType.Kind() {
+	case reflect.Struct:
+		rStruct := reflect.New(targetType).Elem()
+		err := col.scanStruct(rStruct, row)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		return rStruct, nil
+	case reflect.Map:
+		rMap := reflect.MakeMap(targetType)
+		if err := col.scanMap(rMap, row); err != nil {
+			return reflect.Value{}, nil
+		}
+		return rMap, nil
+	case reflect.Slice:
+		//tuples can be scanned into slices - specifically default for unnamed tuples
+		rSlice, err := col.scanSlice(targetType, row)
+		if err != nil {
+			return reflect.Value{}, nil
+		}
+		return rSlice, nil
+	case reflect.Interface:
+		// catches interface{} -Note this swallows custom interfaces to which maps couldn't conform
+		rMap := reflect.ValueOf(make(map[string]interface{}))
+		if err := col.scanMap(rMap, row); err != nil {
+			return reflect.Value{}, err
+		}
+		return rMap, nil
+	}
+	return reflect.Value{}, &Error{
+		ColumnType: fmt.Sprint(targetType.Kind()),
+		Err:        fmt.Errorf("column %s - needs a map/struct/slice or interface{}", col.Name()),
+	}
+}
+
+func (col *Tuple) ScanRow(dest interface{}, row int) error {
+	value := reflect.Indirect(reflect.ValueOf(dest))
+	tuple, err := col.scan(value.Type(), row)
+	if err != nil {
+		return err
+	}
+	value.Set(tuple)
 	return nil
+	//case *[]interface{}:
+	//	tuple := make([]interface{}, 0, len(col.columns))
+	//	for _, c := range col.columns {
+	//		tuple = append(tuple, c.Row(row, false))
+	//	}
+	//	*d = tuple
 }
 
 func (col *Tuple) Append(v interface{}) (nulls []uint8, err error) {

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -218,7 +218,7 @@ func TestJSONUUID(t *testing.T) {
 	defer rows.Close()
 	require.NoError(t, err)
 	for rows.Next() {
-		require.NoError(t, rows.Scan(event))
+		assert.NoError(t, rows.Scan(&event))
 		if i == 0 {
 			assert.JSONEq(t, toJson(row1), toJson(event))
 		} else {
@@ -301,7 +301,7 @@ func TestJSONStructWithInterface(t *testing.T) {
 	require.NoError(t, batch.Append(login))
 	require.NoError(t, batch.Send())
 	event := make(map[string]string)
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(event))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(login), toJson(event))
 }
 
@@ -317,7 +317,7 @@ func TestJSONStructWithStructInterface(t *testing.T) {
 	require.NoError(t, batch.Append(nLogin))
 	require.NoError(t, batch.Send())
 	event := make(map[string]Login)
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(event))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(nLogin), toJson(event))
 }
 
@@ -508,7 +508,7 @@ func TestJSONSlicedInterfaceConsistentMapStruct(t *testing.T) {
 	require.NoError(t, batch.Append(logins))
 	require.NoError(t, batch.Send())
 	event := make(map[string]interface{})
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(event))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(event), toJson(logins))
 }
 
@@ -559,7 +559,7 @@ func TestJSONSlicedInterfaceCompatibleObjects(t *testing.T) {
 	require.NoError(t, batch.Append(logins))
 	require.NoError(t, batch.Send())
 	event := make(map[string]interface{})
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(event))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, `{"Values":[{"Random":[],"Values":[2.4,2.1,5.6]},{"Random":[3,65],"Values":[]}]}`, toJson(event))
 }
 
@@ -653,7 +653,7 @@ func TestJSONSlicedInterfaceSlice(t *testing.T) {
 	require.NoError(t, batch.Append(logins))
 	require.NoError(t, batch.Send())
 	event := make(map[string]interface{})
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(event))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(event), toJson(logins))
 }
 
@@ -730,7 +730,7 @@ func TestJSONTypedMapInsert(t *testing.T) {
 	require.NoError(t, batch.Append(logins))
 	require.NoError(t, batch.Send())
 	event := make(map[string]map[string]Login)
-	assert.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(event))
+	assert.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(event), toJson(logins))
 }
 
@@ -756,7 +756,7 @@ func TestJSONUnTypedMapInsert(t *testing.T) {
 	require.NoError(t, batch.Append(logins))
 	require.NoError(t, batch.Send())
 	event := make(map[string]Login)
-	assert.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(event))
+	assert.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(logins), toJson(event))
 }
 
@@ -884,7 +884,7 @@ func TestJSONMapInconsistentMapWithInterface(t *testing.T) {
 	require.NoError(t, batch.Append(logins))
 	require.NoError(t, batch.Send())
 	event := make(map[string]map[string][]Login)
-	if err := conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(event); assert.NoError(t, err) {
+	if err := conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event); assert.NoError(t, err) {
 		assert.JSONEq(t, `{
 							  "session": {
 								"user": [{
@@ -1230,7 +1230,7 @@ func TestJSONMapSimpleInconsistentRows(t *testing.T) {
 	require.NoError(t, err)
 	i := 0
 	for rows.Next() {
-		require.NoError(t, rows.Scan(event))
+		require.NoError(t, rows.Scan(&event))
 		if i == 0 {
 			// clickhouse fills in emptys
 			assert.JSONEq(t, `{"a":{"d":"test"},"c":{"e":"test"},"d":{"e":""},"g":{"h":{"IP":"","Row":0}},"i":{"row":0},"k":{"h":{"IP":"127.0.0.1","Row":0}},"z":{"c":[]}}`, toJson(event))
@@ -1297,7 +1297,7 @@ func TestJSONMapInconsistentRowsOfSlices(t *testing.T) {
 	i := 0
 	event := make(map[string][]map[string]interface{})
 	for rows.Next() {
-		require.NoError(t, rows.Scan(event))
+		require.NoError(t, rows.Scan(&event))
 		if i == 0 {
 			// clickhouse fills in empty values
 			assert.JSONEq(t, `{"a":[{"a":[],"d":["z","f"],"f":["x","f"],"g":[],"n":[],"z":[]},{"a":[],"d":["e","f"],"f":[],"g":["x","f"],"n":[],"z":[]}],"b":[],"i":[{"row":0}]}`, toJson(event))
@@ -1454,7 +1454,7 @@ func TestJSONMapInconsistentRows(t *testing.T) {
 	i := 0
 	event := make(map[string]map[string]interface{})
 	for rows.Next() {
-		require.NoError(t, rows.Scan(event))
+		require.NoError(t, rows.Scan(&event))
 		switch i {
 		case 0:
 			assert.JSONEq(t, `{"a":{"d":"test"},"c":{"e":[{"f":122.1}]},"d":{"now":"0001-01-01 00:00:00 +0000 UTC"},"f":{"k":[["a","b","c"],["d","e","f"]]},"i":{"row":0},"l":{"m":[]},"n":{"dates":[]},"t":{"uuid":"00000000-0000-0000-0000-000000000000"},"x":{"uuids":["61224334-0422-4864-830f-87b2bf2eedb0","21988fd4-0620-41ea-9202-729343ba9e88"]},"z":{"uuid":"71224334-0422-4864-830f-87b2bf2eedb0"}}`, toJson(event))
@@ -1485,17 +1485,17 @@ func TestJSONMapSliceOfSlices(t *testing.T) {
 	require.NoError(t, batch.Send())
 	//read into a typed map
 	event := make(map[string][][]uuid.UUID)
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(event))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(row1), toJson(event))
 
 	//read into a generic map
 	genEvent := make(map[string]interface{})
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(genEvent))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&genEvent))
 	assert.JSONEq(t, toJson(row1), toJson(genEvent))
 
 	//read into a slice of interface{}
 	genSliceEvent := make(map[string][]interface{})
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(genSliceEvent))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&genSliceEvent))
 	assert.JSONEq(t, toJson(row1), toJson(genSliceEvent))
 
 	///read into a struct
@@ -1552,11 +1552,11 @@ func TestJSONMapSliceOfSlicesWithStruct(t *testing.T) {
 	require.NoError(t, batch.Append(row1))
 	require.NoError(t, batch.Send())
 	event := make(map[string][][]Login)
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(event))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(row1), toJson(event))
 
 	mEvent := make(map[string][][]map[string]interface{})
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(mEvent))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&mEvent))
 	assert.JSONEq(t, toJson(row1), toJson(mEvent))
 
 }
@@ -1590,14 +1590,14 @@ func TestJSONMapSliceOfSlicesWithMap(t *testing.T) {
 	require.NoError(t, batch.Send())
 	//read into a typed map
 	event := make(map[string][][]map[string]interface{})
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(event))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(row1), toJson(event))
 	type Login struct {
 		IP  net.IP `json:"ip"`
 		Row uint8  `json:"row"`
 	}
 	sEvent := make(map[string][][]Login)
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(sEvent))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&sEvent))
 	assert.JSONEq(t, toJson(row1), toJson(sEvent))
 }
 
@@ -1619,7 +1619,7 @@ func TestMapSliceOfInterface(t *testing.T) {
 	require.NoError(t, batch.Send())
 	event := make(map[string][]interface{})
 	// currently this fails cannot set []map[string][]string into []interface{} - maybe we can handle in future
-	require.Panics(t, func() { conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(event) })
+	require.Panics(t, func() { conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event) })
 }
 
 func TestStructSliceOfInterface(t *testing.T) {
@@ -1658,7 +1658,7 @@ func TestStructSliceOfInterface(t *testing.T) {
 	require.NoError(t, batch.Send())
 	event := make(map[string][]interface{})
 	// currently this fails cannot set []map[string][]string into []interface{} - maybe we can handle in future
-	require.Panics(t, func() { conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(event) })
+	require.Panics(t, func() { conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event) })
 }
 
 func TestStructSliceInInterface(t *testing.T) {
@@ -1674,7 +1674,7 @@ func TestStructSliceInInterface(t *testing.T) {
 	require.NoError(t, batch.Append(row1))
 	require.NoError(t, batch.Send())
 	event := make(map[string][]interface{})
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(event))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(row1), toJson(event))
 }
 
@@ -1697,7 +1697,7 @@ func TestInsertMarshaledJSON(t *testing.T) {
 	require.NoError(t, err)
 	i := 0
 	for rows.Next() {
-		require.NoError(t, rows.Scan(event))
+		require.NoError(t, rows.Scan(&event))
 		if i == 0 {
 			// clickhouse fills in empty values
 			assert.JSONEq(t, `{"a":{"d":"test"},"c":{"e":"test"},"d":{"e":""},"g":{"h":{"IP":"","Row":0}},"i":{"row":0},"k":{"h":{"IP":"127.0.0.1","Row":0}},"z":{"c":0}}`, toJson(event))
@@ -1731,7 +1731,7 @@ func TestJSONEmbeddedStruct(t *testing.T) {
 	require.NoError(t, batch.Append(row1))
 	require.NoError(t, batch.Send())
 	event := make(map[string]interface{})
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(event))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(row1), toJson(row1))
 
 }
@@ -2112,7 +2112,7 @@ func TestInconsistentCompatibleTypesInBatch(t *testing.T) {
 	event := make(map[string]interface{})
 	i := 0
 	for rows.Next() {
-		require.NoError(t, rows.Scan(event))
+		require.NoError(t, rows.Scan(&event))
 		if i == 0 {
 			// clickhouse fills in empty values and nil slices to []
 			assert.JSONEq(t, `{"assignee":{"id":0,"name":"Dale","organizations":[],"repositories":[]},"contributors":[{"Id":2244,"Name":"Dale","Repositories":[{"Releases":[{"Version":"2.0.0"},{"Version":"2.1.0"}],"url":"https://github.com/ClickHouse/clickhouse-go"},{"Releases":[],"url":"https://github.com/grafana/clickhouse"}],"orgs":["Support Engineer","Consulting","PM","Integrations"]}],"labels":[],"title":"Document JSON support","type":"Issue"}`, toJson(event))

--- a/tests/nested_test.go
+++ b/tests/nested_test.go
@@ -19,6 +19,8 @@ package tests
 
 import (
 	"context"
+	"fmt"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -78,7 +80,8 @@ func TestSimpleNested(t *testing.T) {
 
 }
 
-func TestNested(t *testing.T) {
+// this isn't documented behaviour in ClickHouse - i.e. flatten_nested=1 with multiple Nested. Following does work however.
+func TestNestedUnFlattened(t *testing.T) {
 	var (
 		ctx       = context.Background()
 		conn, err = clickhouse.Open(&clickhouse.Options{
@@ -91,7 +94,9 @@ func TestNested(t *testing.T) {
 			Compression: &clickhouse.Compression{
 				Method: clickhouse.CompressionLZ4,
 			},
-			//	Debug: true,
+			Settings: clickhouse.Settings{
+				"flatten_nested": 1,
+			},
 		})
 	)
 	if assert.NoError(t, err) {
@@ -119,8 +124,10 @@ func TestNested(t *testing.T) {
 		}()
 		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
 			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_nested"); assert.NoError(t, err) {
+				fmt.Println(batch)
 				var (
 					col1Data = []uint8{1, 2, 3}
+
 					col2Data = []uint8{10, 20, 30}
 					col3Data = []uint8{101, 201, 230} // Col2.Col1_N2
 					col4Data = [][][]interface{}{
@@ -135,22 +142,116 @@ func TestNested(t *testing.T) {
 						},
 					}
 				)
-				if err := batch.Append(col1Data, col2Data, col3Data, col4Data); assert.NoError(t, err) {
-					if assert.NoError(t, batch.Send()) {
-						var (
-							col1 []uint8
-							col2 []uint8
-							col3 []uint8
-							col4 [][][]interface{}
-						)
-						if err := conn.QueryRow(ctx, "SELECT * FROM test_nested").Scan(&col1, &col2, &col3, &col4); assert.NoError(t, err) {
-							assert.Equal(t, col1Data, col1)
-							assert.Equal(t, col2Data, col2)
-							assert.Equal(t, col3Data, col3)
-							assert.Equal(t, col4Data, col4)
-						}
+				require.NoError(t, batch.Append(col1Data, col2Data, col3Data, col4Data))
+				require.NoError(t, batch.Send())
+				//var (
+				//	col1 []uint8
+				//	col2 []uint8
+				//	col3 []uint8
+				//	col4 [][][]interface{}
+				//)
+				//rows := conn.QueryRow(ctx, "SELECT * FROM test_nested")
+				//require.NoError(t, rows.Scan(&col1, &col2, &col3, &col4))
+				//assert.Equal(t, col1Data, col1)
+				//assert.Equal(t, col2Data, col2)
+				//assert.Equal(t, col3Data, col3)
+				//assert.Equal(t, col4Data, col4)
+			}
+		}
+	}
+}
+
+// nested with flatten_nested = 0
+func TestFlattenedNested(t *testing.T) {
+	var (
+		ctx       = context.Background()
+		conn, err = clickhouse.Open(&clickhouse.Options{
+			Addr: []string{"127.0.0.1:9000"},
+			Auth: clickhouse.Auth{
+				Database: "default",
+				Username: "default",
+				Password: "",
+			},
+			Compression: &clickhouse.Compression{
+				Method: clickhouse.CompressionLZ4,
+			},
+			Settings: clickhouse.Settings{
+				"flatten_nested": 0,
+			},
+		})
+	)
+	if assert.NoError(t, err) {
+		if err := checkMinServerVersion(conn, 22, 1, 0); err != nil {
+			t.Skip(err.Error())
+			return
+		}
+		const ddl = `
+			CREATE TABLE test_nested (
+				Col1 Nested(
+					  Col1_N1 UInt8
+					, Col2_N1 UInt8
+				)
+				, Col2 Nested(
+					  Col1_N2 UInt8
+					, Col2_N2 Nested(
+						  Col1_N2_N1 UInt8
+						, Col2_N2_N1 UInt8
+					)
+				)
+			) Engine Memory
+		`
+		defer func() {
+			conn.Exec(ctx, "DROP TABLE test_nested")
+		}()
+		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
+			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_nested"); assert.NoError(t, err) {
+				fmt.Println(batch)
+				var (
+					col1Data = []map[string]interface{}{
+						{
+							"Col1_N1": uint8(1),
+							"Col2_N1": uint8(20),
+						},
+						{
+							"Col1_N1": uint8(2),
+							"Col2_N1": uint8(20),
+						},
+						{
+							"Col1_N1": uint8(3),
+							"Col2_N1": uint8(20),
+						},
 					}
-				}
+					col2Data = []map[string]interface{}{
+						{
+							"Col1_N2": uint8(101),
+							"Col2_N2": []map[string]interface{}{
+								{
+									"Col1_N2_N1": uint8(1),
+									"Col2_N2_N1": uint8(2),
+								},
+							},
+						},
+						{
+							"Col1_N2": uint8(201),
+							"Col2_N2": []map[string]interface{}{
+								{
+									"Col1_N2_N1": uint8(3),
+									"Col2_N2_N1": uint8(4),
+								},
+							},
+						},
+					}
+				)
+				require.NoError(t, batch.Append(col1Data, col2Data))
+				require.NoError(t, batch.Send())
+				var (
+					col1 []map[string]interface{}
+					col2 []map[string]interface{}
+				)
+				rows := conn.QueryRow(ctx, "SELECT * FROM test_nested")
+				require.NoError(t, rows.Scan(&col1, &col2))
+				assert.Equal(t, col1Data, col1)
+				assert.Equal(t, col2Data, col2)
 			}
 		}
 	}

--- a/tests/std/json_test.go
+++ b/tests/std/json_test.go
@@ -20,6 +20,7 @@ package std
 import (
 	"encoding/json"
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
@@ -35,8 +36,7 @@ type Repository struct {
 }
 
 type Achievement struct {
-	Name        string
-	AwardedDate time.Time
+	Name string
 }
 type Account struct {
 	Id            uint32
@@ -102,22 +102,31 @@ func TestStdJson(t *testing.T) {
 		Assignee: Account{
 			Id:            1244,
 			Name:          "Geoff",
-			Achievement:   Achievement{Name: "Mars Star", AwardedDate: testDate.Truncate(time.Second)},
+			Achievement:   Achievement{Name: "Mars Star"},
 			Repositories:  []Repository{{URL: "https://github.com/ClickHouse/clickhouse-python", Releases: []Releases{{Version: "1.0.0"}, {Version: "1.1.0"}}}, {URL: "https://github.com/ClickHouse/clickhouse-go", Releases: []Releases{{Version: "2.0.0"}, {Version: "2.1.0"}}}},
 			Organizations: []string{"Support Engineer", "Integrations"},
 		},
 		Labels: []string{"Help wanted"},
 		Contributors: []Account{
-			{Id: 2244, Achievement: Achievement{Name: "Adding JSON to go driver", AwardedDate: testDate.Truncate(time.Second).Add(time.Hour * -500)}, Organizations: []string{"Support Engineer", "Consulting", "PM", "Integrations"}, Name: "Dale", Repositories: []Repository{{URL: "https://github.com/ClickHouse/clickhouse-go", Releases: []Releases{{Version: "2.0.0"}, {Version: "2.1.0"}}}, {URL: "https://github.com/grafana/clickhouse", Releases: []Releases{{Version: "1.2.0"}, {Version: "1.3.0"}}}}},
-			{Id: 2344, Achievement: Achievement{Name: "Managing S3 buckets", AwardedDate: testDate.Truncate(time.Second).Add(time.Hour * -700)}, Organizations: []string{"Support Engineer", "Consulting"}, Name: "Melyvn", Repositories: []Repository{{URL: "https://github.com/ClickHouse/support", Releases: []Releases{{Version: "1.0.0"}, {Version: "2.3.0"}, {Version: "2.4.0"}}}}},
+			{Id: 2244, Achievement: Achievement{Name: "Adding JSON to go driver"}, Organizations: []string{"Support Engineer", "Consulting", "PM", "Integrations"}, Name: "Dale", Repositories: []Repository{{URL: "https://github.com/ClickHouse/clickhouse-go", Releases: []Releases{{Version: "2.0.0"}, {Version: "2.1.0"}}}, {URL: "https://github.com/grafana/clickhouse", Releases: []Releases{{Version: "1.2.0"}, {Version: "1.3.0"}}}}},
+			{Id: 2344, Achievement: Achievement{Name: "Managing S3 buckets"}, Organizations: []string{"Support Engineer", "Consulting"}, Name: "Melyvn", Repositories: []Repository{{URL: "https://github.com/ClickHouse/support", Releases: []Releases{{Version: "1.0.0"}, {Version: "2.3.0"}, {Version: "2.4.0"}}}}},
 		},
 	}
 	_, err = batch.Exec(col1Data)
 	require.NoError(t, scope.Commit())
 	require.NoError(t, err)
-	// std. interface requires we read with slices as JSON is a tuple. Avoid and use native which is more natural.
-	var event []interface{}
+	// must pass interface{} - maps must be strongly typed so map[string]interface{} wont work - it wont convert
+	var event interface{}
 	rows := conn.QueryRow("SELECT * FROM json_std_test")
 	require.NoError(t, rows.Scan(&event))
-	require.JSONEq(t, `[[[["2022-05-04 21:20:57 +0100 WEST","Adding JSON to go driver"],2244,"Dale",[[[["2.0.0"],["2.1.0"]],"https://github.com/ClickHouse/clickhouse-go"],[[["1.2.0"],["1.3.0"]],"https://github.com/grafana/clickhouse"]],["Support Engineer","Consulting","PM","Integrations"]],[["2022-04-26 13:20:57 +0100 WEST","Managing S3 buckets"],2344,"Melyvn",[[[["1.0.0"],["2.3.0"],["2.4.0"]],"https://github.com/ClickHouse/support"]],["Support Engineer","Consulting"]]],"Document JSON support","Issue",[["2022-05-25 17:20:57 +0100 WEST","Mars Star"],1244,"Geoff",[[[["1.0.0"],["1.1.0"]],"https://github.com/ClickHouse/clickhouse-python"],[[["2.0.0"],["2.1.0"]],"https://github.com/ClickHouse/clickhouse-go"]],["Support Engineer","Integrations"]],["Help wanted"]]`, toJson(event))
+	assert.JSONEq(t, toJson(col1Data), toJson(event))
+	// again pass interface{} for anthing other than primitives
+	rows = conn.QueryRow("SELECT event.assignee.Achievement FROM json_std_test")
+	var achievement interface{}
+	require.NoError(t, rows.Scan(&achievement))
+	assert.JSONEq(t, toJson(col1Data.Assignee.Achievement), toJson(achievement))
+	rows = conn.QueryRow("SELECT event.assignee.Repositories FROM json_std_test")
+	var repositories interface{}
+	require.NoError(t, rows.Scan(&repositories))
+	assert.JSONEq(t, toJson(col1Data.Assignee.Repositories), toJson(repositories))
 }

--- a/tests/tuple_test.go
+++ b/tests/tuple_test.go
@@ -66,10 +66,18 @@ func TestTuple(t *testing.T) {
 			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_tuple"); assert.NoError(t, err) {
 				var (
 					col1Data = []interface{}{"A", int64(42)}
-					col2Data = []interface{}{"B", int8(1), time.Now().Truncate(time.Second)}
-					col3Data = []interface{}{time.Now().Truncate(time.Second), "CH", map[string]string{
-						"key": "value",
-					}}
+					col2Data = []interface{}{"B", int8(1), testDate.Truncate(time.Second)}
+					//col3Data = []interface{}{testDate.Truncate(time.Second), "CH", map[string]string{
+					//	"key": "value",
+					//}}
+					//TODO :  maps - not currently supported for named tuples
+					col3Data = map[string]interface{}{
+						"name1": testDate.Truncate(time.Second),
+						"name2": "CH",
+						"name3": map[string]string{
+							"key": "value",
+						},
+					}
 					col4Data = [][][]interface{}{
 						[][]interface{}{
 							[]interface{}{"Hi", int64(42)},
@@ -91,7 +99,8 @@ func TestTuple(t *testing.T) {
 						var (
 							col1 []interface{}
 							col2 []interface{}
-							col3 []interface{}
+							// col3 is a named tuple - we can use map
+							col3 map[string]interface{}
 							col4 [][][]interface{}
 							col5 []interface{}
 							col6 []interface{}
@@ -100,7 +109,7 @@ func TestTuple(t *testing.T) {
 						if err := conn.QueryRow(ctx, "SELECT * FROM test_tuple").Scan(&col1, &col2, &col3, &col4, &col5, &col6, &col7); assert.NoError(t, err) {
 							assert.Equal(t, col1Data, col1)
 							assert.Equal(t, col2Data, col2)
-							assert.Equal(t, col3Data, col3)
+							assert.JSONEq(t, `{"name1":"2022-05-25T17:20:57+01:00","name2":"CH","name3":{"key":"value"}}`, toJson(col3))
 							assert.Equal(t, col4Data, col4)
 							assert.Equal(t, col5Data, col5)
 							assert.Equal(t, col6Data, col6)


### PR DESCRIPTION
1. Restructure tuple logic - like array we use the same code paths for JSON and normal tuples - which means we handle tuples into arrays and maps in the same place. Cleans up the code and removes duplication - but means more flexibility for the user and consistency with JSON vs manual tuples. Cons mean the user has to pass the address to Scan when using JSON - however this is now consistent with all other Scans - and is only a change for JSON (which is experimental).

Results in more reflection but given the plan to expose ch-go this seems fine.

2. Scantype now dynamic for tuples - maps for named tuples and slices for unnamed if Row is called. This is important as it means std interface (which uses Row) can be used with JSON to get a map - unlocks the ability to do JSON in Grafana.
The downside is users using std interface with named tuples have a **breaking change** - consider acceptable after discussing with @genzgd (footprint likely small).

3. ClickHouse std has to have interface{} passed for named tuples (and thus JSON) - this is usually fine but feels odd you cant pass a map - this seems a limitation of golang SQL interface which refuses to covert these types. It allows the map returned to be set to the Interface{} however.


Note i wanted Scan for std interface to use ScanRow under the hood - so the type created is the same as that passed by the user - but this isn't possible as sql.Driver doesn't pass the destination to `Next`.

4. Row methods on tuple and array now simply use the ScanType to determine the type to return vs fixed types - important for tuples as this is now dynamic and based on named or unnamed.

5. We now need to support maps for named tuples as well at insert time - needed due to the scan type change. Note this is a result of (1) and (2) - nested are just Array(Tuple). This means we can use Nested with flatten_nested=0 for free! :partying_face:  The cost is as tuples are stored as []Interface{} a lookup is required to find each col by name, when passing a map[string]interface{} - for this we use a simple index mapping the column name to its offset.


