### PR TITLE
Http compression

### DIFF
--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -49,12 +49,12 @@ const (
 	ConnOpenRoundRobin
 )
 
-type InterfaceType int
+type Protocol int
 
 const (
-	NativeInterface InterfaceType = iota
-	HttpInterface
-	HttpsInterface
+	Native Protocol = iota
+	Http
+	Https
 )
 
 func ParseDSN(dsn string) (*Options, error) {
@@ -66,7 +66,7 @@ func ParseDSN(dsn string) (*Options, error) {
 }
 
 type Options struct {
-	Interface InterfaceType
+	Protocol Protocol
 
 	TLS              *tls.Config
 	Addr             []string
@@ -165,14 +165,14 @@ func (o *Options) fromDSN(in string) error {
 		if secure {
 			return fmt.Errorf("clickhouse [dsn parse]: http with TLS specify")
 		}
-		o.Interface = HttpInterface
+		o.Protocol = Http
 	case "https":
 		if !secure {
 			return fmt.Errorf("clickhouse [dsn parse]: https without TLS specify")
 		}
-		o.Interface = HttpsInterface
+		o.Protocol = Https
 	default:
-		o.Interface = NativeInterface
+		o.Protocol = Native
 	}
 	return nil
 }

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -53,8 +53,8 @@ type Protocol int
 
 const (
 	Native Protocol = iota
-	Http
-	Https
+	HTTP
+	HTTPS
 )
 
 func ParseDSN(dsn string) (*Options, error) {
@@ -165,12 +165,12 @@ func (o *Options) fromDSN(in string) error {
 		if secure {
 			return fmt.Errorf("clickhouse [dsn parse]: http with TLS specify")
 		}
-		o.Protocol = Http
+		o.Protocol = HTTP
 	case "https":
 		if !secure {
 			return fmt.Errorf("clickhouse [dsn parse]: https without TLS specify")
 		}
-		o.Protocol = Https
+		o.Protocol = HTTPS
 	default:
 		o.Protocol = Native
 	}

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -54,6 +54,7 @@ type InterfaceType int
 const (
 	NativeInterface InterfaceType = iota
 	HttpInterface
+	HttpsInterface
 )
 
 func ParseDSN(dsn string) (*Options, error) {
@@ -81,7 +82,7 @@ type Options struct {
 	ConnMaxLifetime  time.Duration // default 1 hour
 	ConnOpenStrategy ConnOpenStrategy
 
-	Scheme      string
+	scheme      string
 	ReadTimeout time.Duration
 }
 
@@ -158,7 +159,7 @@ func (o *Options) fromDSN(in string) error {
 			InsecureSkipVerify: skipVerify,
 		}
 	}
-	o.Scheme = dsn.Scheme
+	o.scheme = dsn.Scheme
 	switch dsn.Scheme {
 	case "http":
 		if secure {
@@ -169,7 +170,7 @@ func (o *Options) fromDSN(in string) error {
 		if !secure {
 			return fmt.Errorf("clickhouse [dsn parse]: https without TLS specify")
 		}
-		o.Interface = HttpInterface
+		o.Interface = HttpsInterface
 	default:
 		o.Interface = NativeInterface
 	}

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -53,8 +53,8 @@ func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) 
 		dialFunc func(ctx context.Context, addr string, num int, opt *Options) (stdConnect, error)
 	)
 
-	switch o.opt.Interface {
-	case HttpInterface, HttpsInterface:
+	switch o.opt.Protocol {
+	case Http, Https:
 		dialFunc = func(ctx context.Context, addr string, num int, opt *Options) (stdConnect, error) {
 			return dialHttp(ctx, addr, num, opt)
 		}

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -54,7 +54,7 @@ func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) 
 	)
 
 	switch o.opt.Protocol {
-	case Http, Https:
+	case HTTP, HTTPS:
 		dialFunc = func(ctx context.Context, addr string, num int, opt *Options) (stdConnect, error) {
 			return dialHttp(ctx, addr, num, opt)
 		}

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -54,7 +54,7 @@ func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) 
 	)
 
 	switch o.opt.Interface {
-	case HttpInterface:
+	case HttpInterface, HttpsInterface:
 		dialFunc = func(ctx context.Context, addr string, num int, opt *Options) (stdConnect, error) {
 			return dialHttp(ctx, addr, num, opt)
 		}

--- a/conn_http.go
+++ b/conn_http.go
@@ -40,10 +40,10 @@ const (
 
 func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpConnect, error) {
 	if opt.scheme == "" {
-		switch opt.Interface {
-		case HttpInterface:
+		switch opt.Protocol {
+		case Http:
 			opt.scheme = "http"
-		case HttpsInterface:
+		case Https:
 			opt.scheme = "https"
 		default:
 			return nil, errors.New("invalid interface type for http")

--- a/conn_http.go
+++ b/conn_http.go
@@ -41,9 +41,9 @@ const (
 func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpConnect, error) {
 	if opt.scheme == "" {
 		switch opt.Protocol {
-		case Http:
+		case HTTP:
 			opt.scheme = "http"
-		case Https:
+		case HTTPS:
 			opt.scheme = "https"
 		default:
 			return nil, errors.New("invalid interface type for http")

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -169,6 +169,10 @@ func (b *httpBatch) Send() (err error) {
 	}()
 
 	options := queryOptions(b.ctx)
+	// only compress blocks
+	if b.conn.compression {
+		options.settings["decompress"] = "1"
+	}
 	options.settings["query"] = b.query
 	res, err := b.conn.sendQuery(b.ctx, r, &options, map[string]string{
 		"Content-Type": "application/octet-stream",

--- a/tests/compression_test.go
+++ b/tests/compression_test.go
@@ -1,0 +1,1 @@
+package tests

--- a/tests/compression_test.go
+++ b/tests/compression_test.go
@@ -1,1 +1,0 @@
-package tests

--- a/tests/std/array_test.go
+++ b/tests/std/array_test.go
@@ -30,7 +30,7 @@ func TestStdArray(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				const ddl = `
 		CREATE TABLE test_array (

--- a/tests/std/bigint_test.go
+++ b/tests/std/bigint_test.go
@@ -30,7 +30,7 @@ func TestStdBigInt(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				if err := checkMinServerVersion(conn, 21, 12, 0); err != nil {
 					t.Skip(err.Error())
@@ -106,7 +106,7 @@ func TestStdNullableBigInt(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				if err := checkMinServerVersion(conn, 21, 12, 0); err != nil {
 					t.Skip(err.Error())

--- a/tests/std/bool_test.go
+++ b/tests/std/bool_test.go
@@ -29,7 +29,7 @@ func TestStdBool(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				if err := checkMinServerVersion(conn, 21, 12, 0); err != nil {
 					t.Skip(err.Error())

--- a/tests/std/compression_test.go
+++ b/tests/std/compression_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCompressionHttpStd(t *testing.T) {
-	protocols := map[clickhouse.Protocol]int{clickhouse.Http: 8123, clickhouse.Native: 9000}
+	protocols := map[clickhouse.Protocol]int{clickhouse.HTTP: 8123, clickhouse.Native: 9000}
 	for protocol, port := range protocols {
 		conn := clickhouse.OpenDB(&clickhouse.Options{
 			Addr: []string{fmt.Sprintf("127.0.0.1:%d", port)},

--- a/tests/std/compression_test.go
+++ b/tests/std/compression_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestCompressionHttpStd(t *testing.T) {
-	interfaces := map[clickhouse.InterfaceType]int{clickhouse.HttpInterface: 8123, clickhouse.NativeInterface: 9000}
-	for interfaceType, port := range interfaces {
+	protocols := map[clickhouse.Protocol]int{clickhouse.Http: 8123, clickhouse.Native: 9000}
+	for protocol, port := range protocols {
 		conn := clickhouse.OpenDB(&clickhouse.Options{
 			Addr: []string{fmt.Sprintf("127.0.0.1:%d", port)},
 			Auth: clickhouse.Auth{
@@ -27,7 +27,7 @@ func TestCompressionHttpStd(t *testing.T) {
 			Compression: &clickhouse.Compression{
 				Method: clickhouse.CompressionLZ4,
 			},
-			Interface: interfaceType,
+			Protocol: protocol,
 		})
 		conn.Exec("DROP TABLE IF EXISTS test_array_compress")
 		const ddl = `
@@ -72,7 +72,7 @@ func TestCompressionHttpStdDSN(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000?compress=true", "Http": "http://127.0.0.1:8123?compress=true"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			conn, err := sql.Open("clickhouse", dsn)
 			require.NoError(t, err)
 			conn.Exec("DROP TABLE IF EXISTS  test_array_compress")

--- a/tests/std/compression_test.go
+++ b/tests/std/compression_test.go
@@ -1,0 +1,68 @@
+package std
+
+import (
+	"fmt"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestCompressionHttpStd(t *testing.T) {
+	interfaces := map[clickhouse.InterfaceType]int{clickhouse.HttpInterface: 8123, clickhouse.NativeInterface: 9000}
+	for interfaceType, port := range interfaces {
+		conn := clickhouse.OpenDB(&clickhouse.Options{
+			Addr: []string{fmt.Sprintf("127.0.0.1:%d", port)},
+			Auth: clickhouse.Auth{
+				Database: "default",
+				Username: "default",
+				Password: "",
+			},
+			Settings: clickhouse.Settings{
+				"max_execution_time": 60,
+			},
+			DialTimeout: 5 * time.Second,
+			Compression: &clickhouse.Compression{
+				Method: clickhouse.CompressionLZ4,
+			},
+			Interface: interfaceType,
+		})
+		conn.Exec("DROP TABLE test_array")
+		const ddl = `
+		CREATE TABLE test_array (
+			  Col1 Array(String)
+		) Engine Memory
+		`
+		defer func() {
+			conn.Exec("DROP TABLE test_array")
+		}()
+		_, err := conn.Exec(ddl)
+		require.NoError(t, err)
+		scope, err := conn.Begin()
+		require.NoError(t, err)
+		batch, err := scope.Prepare("INSERT INTO test_array")
+		require.NoError(t, err)
+		var (
+			col1Data = []string{"A", "b", "c"}
+		)
+		for i := 0; i < 100; i++ {
+			_, err := batch.Exec(col1Data)
+			require.NoError(t, err)
+		}
+		require.NoError(t, scope.Commit())
+		rows, err := conn.Query("SELECT * FROM test_array")
+		require.NoError(t, err)
+		for rows.Next() {
+			var (
+				col1 interface{}
+			)
+			require.NoError(t, rows.Scan(&col1))
+			assert.Equal(t, col1Data, col1)
+		}
+		require.NoError(t, rows.Close())
+		require.NoError(t, rows.Err())
+	}
+}
+
+//test compression over std with dsn and compress

--- a/tests/std/conn_test.go
+++ b/tests/std/conn_test.go
@@ -32,7 +32,7 @@ func TestStdConn(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				if assert.NoError(t, err) {
 					if err := conn.PingContext(context.Background()); assert.NoError(t, err) {
@@ -50,7 +50,7 @@ func TestStdConnFailover(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9000", "Http": "http://127.0.0.1:8124,127.0.0.1:8125,127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				if err := conn.PingContext(context.Background()); assert.NoError(t, err) {
@@ -67,7 +67,7 @@ func TestStdConnFailoverConnOpenRoundRobin(t *testing.T) {
 	}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				if err := conn.PingContext(context.Background()); assert.NoError(t, err) {
 					t.Log(conn.PingContext(context.Background()))
@@ -83,7 +83,7 @@ func TestStdPingDeadline(t *testing.T) {
 	}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 				defer cancel()

--- a/tests/std/connect_check_test.go
+++ b/tests/std/connect_check_test.go
@@ -40,7 +40,7 @@ func TestStdConnCheck(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123?session_id=session"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 
 			if connect, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				// We can only change the settings at the connection level.

--- a/tests/std/context_timeout_test.go
+++ b/tests/std/context_timeout_test.go
@@ -33,7 +33,7 @@ func TestStdContextStdTimeout(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if connect, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) && assert.NoError(t, connect.Ping()) {
 				{
 					ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*20)

--- a/tests/std/date32_test.go
+++ b/tests/std/date32_test.go
@@ -30,7 +30,7 @@ func TestStdDate32(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				if err := checkMinServerVersion(conn, 21, 9, 0); err != nil {
 					t.Skip(err.Error())

--- a/tests/std/date_test.go
+++ b/tests/std/date_test.go
@@ -30,7 +30,7 @@ func TestStdDate(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				const ddl = `
 			CREATE TABLE test_date (

--- a/tests/std/datetime64_test.go
+++ b/tests/std/datetime64_test.go
@@ -30,7 +30,7 @@ func TestStdDateTime64(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				if err := checkMinServerVersion(conn, 20, 3, 0); err != nil {
 					t.Skip(err.Error())

--- a/tests/std/datetime_test.go
+++ b/tests/std/datetime_test.go
@@ -30,7 +30,7 @@ func TestStdDateTime(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				const ddl = `
 			CREATE TABLE test_datetime (

--- a/tests/std/decimal_test.go
+++ b/tests/std/decimal_test.go
@@ -30,7 +30,7 @@ func TestStdDecimal(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				if err := checkMinServerVersion(conn, 21, 1, 0); err != nil {
 					t.Skip(err.Error())

--- a/tests/std/enum_test.go
+++ b/tests/std/enum_test.go
@@ -29,7 +29,7 @@ func TestStdEnum(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				const ddl = `
 			CREATE TABLE test_enum (

--- a/tests/std/fixed_string_test.go
+++ b/tests/std/fixed_string_test.go
@@ -47,7 +47,7 @@ func TestStdFixedString(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				const ddl = `
 		CREATE TABLE test_fixed_string (

--- a/tests/std/geo_multipolygon_test.go
+++ b/tests/std/geo_multipolygon_test.go
@@ -36,7 +36,7 @@ func TestStdGeoMultiPolygon(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				if err := checkMinServerVersion(conn, 21, 12, 0); err != nil {
 					t.Skip(err.Error())

--- a/tests/std/geo_point_test.go
+++ b/tests/std/geo_point_test.go
@@ -36,7 +36,7 @@ func TestStdGeoPoint(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				if err := checkMinServerVersion(conn, 21, 12, 0); err != nil {
 					t.Skip(err.Error())

--- a/tests/std/geo_polygon_test.go
+++ b/tests/std/geo_polygon_test.go
@@ -36,7 +36,7 @@ func TestStdGeoPolygon(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				if err := checkMinServerVersion(conn, 21, 12, 0); err != nil {
 					t.Skip(err.Error())

--- a/tests/std/geo_ring_test.go
+++ b/tests/std/geo_ring_test.go
@@ -35,7 +35,7 @@ func TestStdGeoRing(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				if err := checkMinServerVersion(conn, 21, 12, 0); err != nil {
 					t.Skip(err.Error())

--- a/tests/std/ipv4_test.go
+++ b/tests/std/ipv4_test.go
@@ -30,7 +30,7 @@ func TestStdIPv4(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				const ddl = `
 			CREATE TABLE test_ipv4 (

--- a/tests/std/lowcardinality_test.go
+++ b/tests/std/lowcardinality_test.go
@@ -37,7 +37,7 @@ func TestStdLowCardinality(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				if err := checkMinServerVersion(conn, 19, 11, 0); err != nil {
 					t.Skip(err.Error())

--- a/tests/std/map_test.go
+++ b/tests/std/map_test.go
@@ -29,7 +29,7 @@ func TestStdMap(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				if err := checkMinServerVersion(conn, 21, 9, 0); err != nil {
 					t.Skip(err.Error())

--- a/tests/std/string_test.go
+++ b/tests/std/string_test.go
@@ -28,7 +28,7 @@ import (
 func TestSimpleStdString(t *testing.T) {
 	dsns := map[string]string{"Http": "http://127.0.0.1:8123,127.0.0.1:8123/default?dial_timeout=200ms&max_execution_time=60"}
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				const ddl = `
 		CREATE TABLE test_array (

--- a/tests/std/string_test.go
+++ b/tests/std/string_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 )
 
-func TestSimpleHttpStdArray(t *testing.T) {
-	dsns := map[string]string{"Http": "http://127.0.0.1:8123"}
+func TestSimpleHttpStdString(t *testing.T) {
+	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 	for name, dsn := range dsns {
 		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {

--- a/tests/std/temporary_table_test.go
+++ b/tests/std/temporary_table_test.go
@@ -31,7 +31,7 @@ func TestStdTemporaryTable(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			ctx := context.Background()
 			if name == "Http" {
 				ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{

--- a/tests/std/uuid_test.go
+++ b/tests/std/uuid_test.go
@@ -30,7 +30,7 @@ func TestStdUUID(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123?session_id=test_session"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				const ddl = `
 			CREATE TEMPORARY TABLE test_uuid (
@@ -75,7 +75,7 @@ func TestStdNullableUUID(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000", "Http": "http://127.0.0.1:8123?session_id=test_session"}
 
 	for name, dsn := range dsns {
-		t.Run(fmt.Sprintf("%s Interface", name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
 				const ddl = `
 					CREATE TEMPORARY TABLE test_uuid (


### PR DESCRIPTION
Adds compression over http - currently using lz4 at block level only per https://clickhouse.com/docs/en/interfaces/http/#compression. Will add other compression options later - mainly zstd which ch-go supports as well as gzip etc for HTTP.

Note compression can be enabled via `OpenDb` with settings or via `compress=true` in the dsn.

We also introduce the `HttpsInterface` type and fix an issue with OpenDb not working @ortyomka i.e. it wasn't setting the scheme (which we no longer expose). I think needing to specify the interface in `OpenDb` is better than a scheme.
