### PR TITLE
Gzip compression

### DIFF
--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -192,9 +192,14 @@ func (o *Options) fromDSN(in string) error {
 	}
 	o.scheme = dsn.Scheme
 	switch dsn.Scheme {
-	case "http", "https":
+	case "http":
 		if secure {
 			return fmt.Errorf("clickhouse [dsn parse]: http with TLS specify")
+		}
+		o.Protocol = HTTP
+	case "https":
+		if !secure {
+			return fmt.Errorf("clickhouse [dsn parse]: https without TLS")
 		}
 		o.Protocol = HTTP
 	default:

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -75,7 +75,6 @@ type Protocol int
 const (
 	Native Protocol = iota
 	HTTP
-	HTTPS
 )
 
 func (p Protocol) String() string {
@@ -84,8 +83,6 @@ func (p Protocol) String() string {
 		return "native"
 	case HTTP:
 		return "http"
-	case HTTPS:
-		return "https"
 	default:
 		return ""
 	}
@@ -195,16 +192,11 @@ func (o *Options) fromDSN(in string) error {
 	}
 	o.scheme = dsn.Scheme
 	switch dsn.Scheme {
-	case HTTP.String():
+	case "http", "https":
 		if secure {
 			return fmt.Errorf("clickhouse [dsn parse]: http with TLS specify")
 		}
 		o.Protocol = HTTP
-	case HTTPS.String():
-		if !secure {
-			return fmt.Errorf("clickhouse [dsn parse]: https without TLS specify")
-		}
-		o.Protocol = HTTPS
 	default:
 		o.Protocol = Native
 	}

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -29,12 +29,28 @@ import (
 	"time"
 )
 
-type CompressionMethod compress.Method
+type CompressionMethod byte
+
+func (c CompressionMethod) String() string {
+	switch c {
+	case CompressionNone:
+		return "None"
+	case CompressionZSTD:
+		return "zstd"
+	case CompressionLZ4:
+		return "lz4"
+	case CompressionGZIP:
+		return "gzip"
+	default:
+		return ""
+	}
+}
 
 const (
 	CompressionNone = CompressionMethod(compress.None)
 	CompressionLZ4  = CompressionMethod(compress.LZ4)
 	CompressionZSTD = CompressionMethod(compress.ZSTD)
+	CompressionGZIP = CompressionMethod(0x99)
 )
 
 type Auth struct { // has_control_character
@@ -61,6 +77,19 @@ const (
 	HTTP
 	HTTPS
 )
+
+func (p Protocol) String() string {
+	switch p {
+	case Native:
+		return "native"
+	case HTTP:
+		return "http"
+	case HTTPS:
+		return "https"
+	default:
+		return ""
+	}
+}
 
 func ParseDSN(dsn string) (*Options, error) {
 	opt := &Options{}
@@ -166,12 +195,12 @@ func (o *Options) fromDSN(in string) error {
 	}
 	o.scheme = dsn.Scheme
 	switch dsn.Scheme {
-	case "http":
+	case HTTP.String():
 		if secure {
 			return fmt.Errorf("clickhouse [dsn parse]: http with TLS specify")
 		}
 		o.Protocol = HTTP
-	case "https":
+	case HTTPS.String():
 		if !secure {
 			return fmt.Errorf("clickhouse [dsn parse]: https without TLS specify")
 		}

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -54,7 +54,7 @@ func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) 
 	)
 
 	switch o.opt.Protocol {
-	case HTTP, HTTPS:
+	case HTTP:
 		dialFunc = func(ctx context.Context, addr string, num int, opt *Options) (stdConnect, error) {
 			return dialHttp(ctx, addr, num, opt)
 		}

--- a/conn.go
+++ b/conn.go
@@ -61,7 +61,12 @@ func dial(ctx context.Context, addr string, num int, opt *Options) (*connect, er
 	}
 	compression := CompressionNone
 	if opt.Compression != nil {
-		compression = opt.Compression.Method
+		switch opt.Compression.Method {
+		case CompressionLZ4, CompressionZSTD:
+			compression = opt.Compression.Method
+		default:
+			return nil, fmt.Errorf("unsupported compression method for native protocol")
+		}
 	}
 	var (
 		connect = &connect{

--- a/conn_http.go
+++ b/conn_http.go
@@ -66,8 +66,11 @@ type HTTPReaderWriter struct {
 func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpConnect, error) {
 	if opt.scheme == "" {
 		switch opt.Protocol {
-		case HTTP, HTTPS:
+		case HTTP:
 			opt.scheme = opt.Protocol.String()
+			if opt.TLS != nil {
+				opt.scheme = fmt.Sprintf("%ss", opt.scheme)
+			}
 		default:
 			return nil, errors.New("invalid interface type for http")
 		}

--- a/conn_http_async_insert.go
+++ b/conn_http_async_insert.go
@@ -34,9 +34,9 @@ func (h *httpConnect) asyncInsert(ctx context.Context, query string, wait bool) 
 	}
 	res, err := h.sendQuery(ctx, strings.NewReader(query), &options, nil)
 	if res != nil {
-		defer res.Close()
+		defer res.Body.Close()
 		// we don't care about result, so just discard it to reuse connection
-		_, _ = io.Copy(ioutil.Discard, res)
+		_, _ = io.Copy(ioutil.Discard, res.Body)
 	}
 
 	return err

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -18,6 +18,7 @@
 package clickhouse
 
 import (
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
@@ -147,12 +148,32 @@ func (b *httpBatch) Send() (err error) {
 	if b.err != nil {
 		return b.err
 	}
+	options := queryOptions(b.ctx)
 
-	r, w := io.Pipe()
+	headers := make(map[string]string)
+
+	var w io.Writer
+	r, pw := io.Pipe()
+	switch b.conn.compression {
+	case CompressionGZIP:
+		crw := b.conn.compressionPool.Get()
+		crw.writer.(*gzip.Writer).Reset(pw)
+		w = crw.writer
+		headers["Content-Encoding"] = b.conn.compression.String()
+		defer b.conn.compressionPool.Put(crw)
+	case CompressionZSTD, CompressionLZ4:
+		options.settings["decompress"] = "1"
+		w = pw
+	default:
+		w = pw
+	}
 
 	go func() {
 		var err error = nil
-		defer w.CloseWithError(err)
+		defer pw.CloseWithError(err)
+		if gw, ok := w.(*gzip.Writer); ok {
+			defer gw.Close()
+		}
 		b.conn.buffer.Reset()
 		if b.block.Rows() != 0 {
 			if err = b.conn.writeData(b.block); err != nil {
@@ -162,26 +183,19 @@ func (b *httpBatch) Send() (err error) {
 		if err = b.conn.writeData(&proto.Block{}); err != nil {
 			return
 		}
-		w.Write(b.conn.buffer.Buf)
 		if _, err = w.Write(b.conn.buffer.Buf); err != nil {
 			return
 		}
 	}()
 
-	options := queryOptions(b.ctx)
-	// only compress blocks
-	if b.conn.compression != CompressionNone {
-		options.settings["decompress"] = "1"
-	}
 	options.settings["query"] = b.query
-	res, err := b.conn.sendQuery(b.ctx, r, &options, map[string]string{
-		"Content-Type": "application/octet-stream",
-	})
+	headers["Content-Type"] = "application/octet-stream"
+	res, err := b.conn.sendQuery(b.ctx, r, &options, headers)
 
 	if res != nil {
-		defer res.Close()
+		defer res.Body.Close()
 		// we don't care about result, so just discard it to reuse connection
-		_, _ = io.Copy(ioutil.Discard, res)
+		_, _ = io.Copy(ioutil.Discard, res.Body)
 	}
 
 	return err

--- a/conn_http_exec.go
+++ b/conn_http_exec.go
@@ -34,9 +34,9 @@ func (h *httpConnect) exec(ctx context.Context, query string, args ...interface{
 
 	res, err := h.sendQuery(ctx, strings.NewReader(query), &options, nil)
 	if res != nil {
-		defer res.Close()
+		defer res.Body.Close()
 		// we don't care about result, so just discard it to reuse connection
-		_, _ = io.Copy(ioutil.Discard, res)
+		_, _ = io.Copy(ioutil.Discard, res.Body)
 	}
 
 	return err

--- a/conn_http_query.go
+++ b/conn_http_query.go
@@ -19,6 +19,7 @@ package clickhouse
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	chproto "github.com/ClickHouse/ch-go/proto"
@@ -35,18 +36,43 @@ func (h *httpConnect) query(ctx context.Context, release func(*connect, error), 
 		return nil, err
 	}
 	options := queryOptions(ctx)
-	if h.compression != CompressionNone {
+	headers := make(map[string]string)
+	switch h.compression {
+	case CompressionZSTD, CompressionLZ4:
 		options.settings["compress"] = "1"
+	case CompressionGZIP:
+		// request encoding
+		headers["Accept-Encoding"] = h.compression.String()
 	}
-	res, err := h.sendQuery(ctx, strings.NewReader(query), &options, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Close()
 
-	body, err := ioutil.ReadAll(res)
+	res, err := h.sendQuery(ctx, strings.NewReader(query), &options, headers)
 	if err != nil {
 		return nil, err
+	}
+	defer res.Body.Close()
+	// detect compression from http Content-Encoding header - note user will need to have set enable_http_compression
+	// for CH to respond with compressed data - we don't set this automatically as they might not have permissions
+	var body []byte
+	//adding Accept-Encoding:gzip on your request means response won’t be automatically decompressed per https://github.com/golang/go/blob/master/src/net/http/transport.go#L182-L190
+	switch res.Header.Get("Content-Encoding") {
+	case CompressionGZIP.String():
+		//decompress block first
+		if !res.Uncompressed {
+			gReader := h.compressionPool.Get().reader.(*gzip.Reader)
+			defer gReader.Close()
+			if err = gReader.Reset(res.Body); err != nil {
+				return nil, err
+			}
+			body, err = ioutil.ReadAll(gReader)
+			if err != nil {
+				return nil, err
+			}
+		}
+	default:
+		body, err = ioutil.ReadAll(res.Body)
+		if err != nil {
+			return nil, err
+		}
 	}
 	reader := chproto.NewReader(bytes.NewReader(body))
 	block, err := h.readData(reader)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ClickHouse/clickhouse-go/v2
 go 1.18
 
 require (
-	github.com/ClickHouse/ch-go v0.47.0
+	github.com/ClickHouse/ch-go v0.47.1
 	github.com/ClickHouse/clickhouse-go v1.5.4
 	github.com/google/uuid v1.3.0
 	github.com/mkevac/debugcharts v0.0.0-20191222103121-ae1c48aa8615
@@ -23,7 +23,7 @@ require (
 	github.com/go-faster/errors v0.6.1 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gorilla/websocket v1.4.1 // indirect
-	github.com/klauspost/compress v1.15.7 // indirect
+	github.com/klauspost/compress v1.15.8 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ClickHouse/ch-go v0.47.0 h1:D6XCoiqak0qU9LONDkS/CiRy/SqPGoLB9sd4fxod180=
-github.com/ClickHouse/ch-go v0.47.0/go.mod h1:955l5RPgmaIjsn2ollHFPPzMxVsnn7w0DF06qGRjbUU=
+github.com/ClickHouse/ch-go v0.47.1 h1:4epuZI30bZaozLxEVsb6zpZvVyE1x5Bv3bhQbU6uCKo=
+github.com/ClickHouse/ch-go v0.47.1/go.mod h1:CL1kjJVNy5dMz5lWS52fMvL7nQnLYxjn+qEaOViz/Js=
 github.com/ClickHouse/clickhouse-go v1.5.4 h1:cKjXeYLNWVJIx2J1K6H2CqyRmfwVJVY1OV1coaaFcI0=
 github.com/ClickHouse/clickhouse-go v1.5.4/go.mod h1:EaI/sW7Azgz9UATzd5ZdZHRUhHgv5+JMS9NSr2smCJI=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
@@ -30,8 +30,8 @@ github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.15.7 h1:7cgTQxJCU/vy+oP/E3B9RGbQTgbiVzIJWIKOLoAsPok=
-github.com/klauspost/compress v1.15.7/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/klauspost/compress v1.15.8 h1:JahtItbkWjf2jzm/T+qgMxkP9EMHsqEUA6vCMGmXvhA=
+github.com/klauspost/compress v1.15.8/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/tests/compression_test.go
+++ b/tests/compression_test.go
@@ -24,36 +24,35 @@ func TestZSTDCompression(t *testing.T) {
 			MaxOpenConns: 1,
 		})
 	)
-	if assert.NoError(t, err) {
-		const ddl = `
+	require.NoError(t, err)
+	const ddl = `
 		CREATE TABLE test_array (
 			  Col1 Array(String)
 		) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_array")
-		}()
-		require.NoError(t, conn.Exec(ctx, ddl))
-		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_array")
-		require.NoError(t, err)
-		var (
-			col1Data = []string{"A", "b", "c"}
-		)
-		for i := 0; i < 10; i++ {
-			require.NoError(t, batch.Append(col1Data))
-		}
-		require.NoError(t, batch.Send())
-		rows, err := conn.Query(ctx, "SELECT * FROM test_array")
-		require.NoError(t, err)
-		for rows.Next() {
-			var (
-				col1 []string
-			)
-			require.NoError(t, rows.Scan(&col1))
-			assert.Equal(t, col1Data, col1)
-		}
-		require.NoError(t, rows.Close())
-		require.NoError(t, rows.Err())
-
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_array")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_array")
+	require.NoError(t, err)
+	var (
+		col1Data = []string{"A", "b", "c"}
+	)
+	for i := 0; i < 10; i++ {
+		require.NoError(t, batch.Append(col1Data))
 	}
+	require.NoError(t, batch.Send())
+	rows, err := conn.Query(ctx, "SELECT * FROM test_array")
+	require.NoError(t, err)
+	for rows.Next() {
+		var (
+			col1 []string
+		)
+		require.NoError(t, rows.Scan(&col1))
+		assert.Equal(t, col1Data, col1)
+	}
+	require.NoError(t, rows.Close())
+	require.NoError(t, rows.Err())
+
 }

--- a/tests/std/array_test.go
+++ b/tests/std/array_test.go
@@ -20,6 +20,7 @@ package std
 import (
 	"database/sql"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
@@ -83,25 +84,24 @@ func TestStdArray(t *testing.T) {
 								return
 							}
 						}
-						if assert.NoError(t, scope.Commit()) {
-							if rows, err := conn.Query("SELECT * FROM test_array"); assert.NoError(t, err) {
-								for rows.Next() {
-									var (
-										col1 interface{}
-										col2 [][]uint32
-										col3 [][][]time.Time
-									)
-									if err := rows.Scan(&col1, &col2, &col3); assert.NoError(t, err) {
-										assert.Equal(t, col1Data, col1)
-										assert.Equal(t, col2Data, col2)
-										assert.Equal(t, col3Data, col3)
-									}
-								}
-								if assert.NoError(t, rows.Close()) {
-									assert.NoError(t, rows.Err())
+						require.NoError(t, scope.Commit())
+						if rows, err := conn.Query("SELECT * FROM test_array"); assert.NoError(t, err) {
+							for rows.Next() {
+								var (
+									col1 interface{}
+									col2 [][]uint32
+									col3 [][][]time.Time
+								)
+								if err := rows.Scan(&col1, &col2, &col3); assert.NoError(t, err) {
+									assert.Equal(t, col1Data, col1)
+									assert.Equal(t, col2Data, col2)
+									assert.Equal(t, col3Data, col3)
 								}
 							}
+							require.NoError(t, rows.Close())
+							require.NoError(t, rows.Err())
 						}
+
 					}
 				}
 			}

--- a/tests/std/compression_test.go
+++ b/tests/std/compression_test.go
@@ -11,118 +11,99 @@ import (
 )
 
 func TestCompressionStd(t *testing.T) {
-	protocols := map[clickhouse.Protocol]int{clickhouse.HTTP: 8123, clickhouse.Native: 9000}
-	for protocol, port := range protocols {
-		conn := clickhouse.OpenDB(&clickhouse.Options{
-			Addr: []string{fmt.Sprintf("127.0.0.1:%d", port)},
-			Auth: clickhouse.Auth{
-				Database: "default",
-				Username: "default",
-				Password: "",
-			},
-			Settings: clickhouse.Settings{
-				"max_execution_time": 60,
-			},
-			DialTimeout: 5 * time.Second,
-			Compression: &clickhouse.Compression{
-				Method: clickhouse.CompressionLZ4,
-			},
-			Protocol: protocol,
-		})
-		conn.Exec("DROP TABLE IF EXISTS test_array_compress")
-		const ddl = `
-		CREATE TABLE test_array_compress (
-			  Col1 Array(String)
-		) Engine Memory
-		`
-		defer func() {
-			conn.Exec("DROP TABLE test_array_compress")
-		}()
-		_, err := conn.Exec(ddl)
-		require.NoError(t, err)
-		scope, err := conn.Begin()
-		require.NoError(t, err)
-		batch, err := scope.Prepare("INSERT INTO test_array_compress")
-		require.NoError(t, err)
-		var (
-			col1Data = []string{"A", "b", "c"}
-		)
-		for i := 0; i < 100; i++ {
-			_, err := batch.Exec(col1Data)
-			require.NoError(t, err)
+	type compressionTest struct {
+		port               int
+		compressionMethods []clickhouse.CompressionMethod
+	}
+
+	protocols := map[clickhouse.Protocol]compressionTest{clickhouse.HTTP: {
+		port:               8123,
+		compressionMethods: []clickhouse.CompressionMethod{clickhouse.CompressionLZ4, clickhouse.CompressionZSTD, clickhouse.CompressionGZIP},
+	}, clickhouse.Native: {
+		port:               9000,
+		compressionMethods: []clickhouse.CompressionMethod{clickhouse.CompressionLZ4, clickhouse.CompressionZSTD},
+	}}
+	for protocol, compressionTest := range protocols {
+		for _, method := range compressionTest.compressionMethods {
+			t.Run(fmt.Sprintf("%s with %s", protocol, method), func(t *testing.T) {
+				conn := clickhouse.OpenDB(&clickhouse.Options{
+					Addr: []string{fmt.Sprintf("127.0.0.1:%d", compressionTest.port)},
+					Auth: clickhouse.Auth{
+						Database: "default",
+						Username: "default",
+						Password: "",
+					},
+					Settings: clickhouse.Settings{
+						"max_execution_time":      60,
+						"enable_http_compression": 1, // needed for http compression e.g. gzip
+					},
+					DialTimeout: 5 * time.Second,
+					Compression: &clickhouse.Compression{
+						Method: method,
+					},
+					Protocol: protocol,
+				})
+				conn.Exec("DROP TABLE IF EXISTS test_array_compress")
+				const ddl = `
+					CREATE TABLE test_array_compress (
+						  Col1 Array(Int32),
+					      Col2 Int32         
+					) Engine Memory
+					`
+				defer func() {
+					conn.Exec("DROP TABLE test_array_compress")
+				}()
+				_, err := conn.Exec(ddl)
+				require.NoError(t, err)
+				scope, err := conn.Begin()
+				require.NoError(t, err)
+				batch, err := scope.Prepare("INSERT INTO test_array_compress")
+				require.NoError(t, err)
+				for i := int32(0); i < 100; i++ {
+					_, err := batch.Exec([]int32{i, i + 1, i + 2}, i)
+					require.NoError(t, err)
+				}
+				require.NoError(t, scope.Commit())
+				rows, err := conn.Query("SELECT * FROM test_array_compress ORDER BY Col2 ASC")
+				require.NoError(t, err)
+				i := int32(0)
+				for rows.Next() {
+					var (
+						col1 interface{}
+						col2 int32
+					)
+					require.NoError(t, rows.Scan(&col1, &col2))
+					assert.Equal(t, i, col2)
+					assert.Equal(t, []int32{i, i + 1, i + 2}, col1)
+					i += 1
+				}
+				require.NoError(t, rows.Close())
+				require.NoError(t, rows.Err())
+				scope, err = conn.Begin()
+				require.NoError(t, err)
+				batch, err = scope.Prepare("INSERT INTO test_array_compress")
+				require.NoError(t, err)
+				for i := int32(100); i < 200; i++ {
+					_, err := batch.Exec([]int32{i, i + 1, i + 2}, i)
+					require.NoError(t, err)
+				}
+				require.NoError(t, scope.Commit())
+				require.NoError(t, err)
+				i = 0
+				for rows.Next() {
+					var (
+						col1 interface{}
+						col2 int32
+					)
+					require.NoError(t, rows.Scan(&col1, &col2))
+					assert.Equal(t, i, col2)
+					assert.Equal(t, []int32{i, i + 1, i + 2}, col1)
+					i += 1
+				}
+			})
 		}
-		require.NoError(t, scope.Commit())
-		rows, err := conn.Query("SELECT * FROM test_array_compress")
-		require.NoError(t, err)
-		for rows.Next() {
-			var (
-				col1 interface{}
-			)
-			require.NoError(t, rows.Scan(&col1))
-			assert.Equal(t, col1Data, col1)
-		}
-		require.NoError(t, rows.Close())
-		require.NoError(t, rows.Err())
 	}
 }
-
-func TestZSTDCompressionStd(t *testing.T) {
-	protocols := map[clickhouse.Protocol]int{clickhouse.HTTP: 8123, clickhouse.Native: 9000}
-	for protocol, port := range protocols {
-		conn := clickhouse.OpenDB(&clickhouse.Options{
-			Addr: []string{fmt.Sprintf("127.0.0.1:%d", port)},
-			Auth: clickhouse.Auth{
-				Database: "default",
-				Username: "default",
-				Password: "",
-			},
-			Settings: clickhouse.Settings{
-				"max_execution_time": 60,
-			},
-			DialTimeout: 5 * time.Second,
-			Compression: &clickhouse.Compression{
-				Method: clickhouse.CompressionZSTD,
-			},
-			Protocol: protocol,
-		})
-		conn.Exec("DROP TABLE IF EXISTS test_array_compress")
-		const ddl = `
-		CREATE TABLE test_array_compress (
-			  Col1 Array(String)
-		) Engine Memory
-		`
-		defer func() {
-			conn.Exec("DROP TABLE test_array_compress")
-		}()
-		_, err := conn.Exec(ddl)
-		require.NoError(t, err)
-		scope, err := conn.Begin()
-		require.NoError(t, err)
-		batch, err := scope.Prepare("INSERT INTO test_array_compress")
-		require.NoError(t, err)
-		var (
-			col1Data = []string{"A", "b", "c"}
-		)
-		for i := 0; i < 100; i++ {
-			_, err := batch.Exec(col1Data)
-			require.NoError(t, err)
-		}
-		require.NoError(t, scope.Commit())
-		rows, err := conn.Query("SELECT * FROM test_array_compress")
-		require.NoError(t, err)
-		for rows.Next() {
-			var (
-				col1 interface{}
-			)
-			require.NoError(t, rows.Scan(&col1))
-			assert.Equal(t, col1Data, col1)
-		}
-		require.NoError(t, rows.Close())
-		require.NoError(t, rows.Err())
-	}
-}
-
-//test compression over std with dsn and compress
 
 func TestCompressionStdDSN(t *testing.T) {
 	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000?compress=true", "Http": "http://127.0.0.1:8123?compress=true"}
@@ -167,5 +148,4 @@ func TestCompressionStdDSN(t *testing.T) {
 			require.NoError(t, rows.Err())
 		})
 	}
-
 }


### PR DESCRIPTION
This adds gzip compression to the http layer - this isn't supported for native.

If the user requests gzip we only compress blocks currently - compressing queries seems unnecessary. 
For decompression, we request ClickHouse only send for queries - again for inserts we are unlikely to benefit. This is subject to change but this aligns with ZSTD and LZ4.

To avoid creating readers and writers for each request, we utilize a pool. This pool creation, as well as the compression and decompression, can probably be abstracted away as we add other compression formats e.g. deflate.

Note to receive compressed responses the user needs to set `enable_http_compression` - either in the connection, via  the context or in the server config. I considered setting this automatically if gzip was requested but this will error if the user doesn't have permissions.

https://github.com/ClickHouse/clickhouse-go/issues/651