### PR TITLE
Compress options in DSN

### DIFF
--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -171,7 +171,7 @@ func (o *Options) fromDSN(in string) error {
 				}
 			}
 		case "compress_level":
-			if level, err := strconv.ParseInt(params.Get(v), 10, 8); err != nil {
+			if level, err := strconv.ParseInt(params.Get(v), 10, 8); err == nil {
 				if o.Compression == nil {
 					o.Compression = &Compression{
 						// a level alone doesn't enable compression

--- a/conn_http.go
+++ b/conn_http.go
@@ -230,7 +230,10 @@ func createCompressionPool(compression *Compression) (Pool[HTTPReaderWriter], er
 		switch compression.Method {
 		case CompressionGZIP:
 			// trick so we can init the reader to something to Reset when we reuse
-			writer := gzip.NewWriter(io.Discard)
+			writer, err := gzip.NewWriterLevel(io.Discard, compression.Level)
+			if err != nil {
+				return HTTPReaderWriter{err: err}
+			}
 			b := new(bytes.Buffer)
 			writer.Reset(b)
 			writer.Flush()

--- a/tests/std/compression_test.go
+++ b/tests/std/compression_test.go
@@ -112,7 +112,52 @@ func TestCompressionStdDSN(t *testing.T) {
 		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			conn, err := sql.Open("clickhouse", dsn)
 			require.NoError(t, err)
-			conn.Exec("DROP TABLE IF EXISTS  test_array_compress")
+			conn.Exec("DROP TABLE IF EXISTS test_array_compress")
+			const ddl = `
+				CREATE TABLE test_array_compress (
+					  Col1 Array(String)
+				) Engine Memory
+				`
+			defer func() {
+				conn.Exec("DROP TABLE test_array_compress")
+			}()
+			_, err = conn.Exec(ddl)
+			require.NoError(t, err)
+			scope, err := conn.Begin()
+			require.NoError(t, err)
+			batch, err := scope.Prepare("INSERT INTO test_array_compress")
+			require.NoError(t, err)
+			var (
+				col1Data = []string{"A", "b", "c"}
+			)
+			for i := 0; i < 100; i++ {
+				_, err := batch.Exec(col1Data)
+				require.NoError(t, err)
+			}
+			require.NoError(t, scope.Commit())
+			rows, err := conn.Query("SELECT * FROM test_array_compress")
+			require.NoError(t, err)
+			for rows.Next() {
+				var (
+					col1 interface{}
+				)
+				require.NoError(t, rows.Scan(&col1))
+				assert.Equal(t, col1Data, col1)
+			}
+			require.NoError(t, rows.Close())
+			require.NoError(t, rows.Err())
+		})
+	}
+}
+
+func TestCompressionStdDSNWithLevel(t *testing.T) {
+	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000?compress=deflate", "Http": "http://127.0.0.1:8123?compress=gzip"}
+
+	for name, dsn := range dsns {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
+			conn, err := sql.Open("clickhouse", dsn)
+			require.NoError(t, err)
+			conn.Exec("DROP TABLE IF EXISTS test_array_compress")
 			const ddl = `
 				CREATE TABLE test_array_compress (
 					  Col1 Array(String)


### PR DESCRIPTION
Allow us to specify `compress=<method>` and `compress_level=<level>` in the DSN. `compress` still accepts `true` which defaults to lz4. Compression level defaults to 3  - consistent with ClickHouse defaults.