### PR TITLE
Don't modify options

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -72,11 +72,11 @@ func (e *OpError) Error() string {
 }
 
 func Open(opt *Options) (driver.Conn, error) {
-	opt.setDefaults()
+	o := opt.setDefaults()
 	return &clickhouse{
-		opt:  opt,
-		idle: make(chan *connect, opt.MaxIdleConns),
-		open: make(chan struct{}, opt.MaxOpenConns),
+		opt:  o,
+		idle: make(chan *connect, o.MaxIdleConns),
+		open: make(chan struct{}, o.MaxOpenConns),
 	}, nil
 }
 

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -72,6 +72,9 @@ func (e *OpError) Error() string {
 }
 
 func Open(opt *Options) (driver.Conn, error) {
+	if opt == nil {
+		opt = &Options{}
+	}
 	o := opt.setDefaults()
 	return &clickhouse{
 		opt:  o,

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -248,7 +248,8 @@ func (o *Options) fromDSN(in string) error {
 	return nil
 }
 
-func (o *Options) setDefaults() {
+// receive copy of Options so we don't modify original - so its reusable
+func (o Options) setDefaults() *Options {
 	if len(o.Auth.Database) == 0 {
 		o.Auth.Database = "default"
 	}
@@ -267,4 +268,5 @@ func (o *Options) setDefaults() {
 	if o.ConnMaxLifetime == 0 {
 		o.ConnMaxLifetime = time.Hour
 	}
+	return &o
 }

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -101,9 +101,9 @@ func OpenDB(opt *Options) *sql.DB {
 			err: fmt.Errorf("cannot connect. invalid settings. use %s (see https://pkg.go.dev/database/sql)", strings.Join(settings, ",")),
 		})
 	}
-	opt.setDefaults()
+	o := opt.setDefaults()
 	return sql.OpenDB(&stdConnOpener{
-		opt: opt,
+		opt: o,
 	})
 }
 
@@ -127,8 +127,8 @@ func (std *stdDriver) Open(dsn string) (_ driver.Conn, err error) {
 	if err := opt.fromDSN(dsn); err != nil {
 		return nil, err
 	}
-	opt.setDefaults()
-	return (&stdConnOpener{opt: &opt}).Connect(context.Background())
+	o := opt.setDefaults()
+	return (&stdConnOpener{opt: o}).Connect(context.Background())
 }
 
 func (std *stdDriver) ResetSession(ctx context.Context) error {

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -64,6 +64,10 @@ func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) 
 		}
 	}
 
+	if o.opt.Addr == nil || len(o.opt.Addr) == 0 {
+		return nil, ErrAcquireConnNoAddress
+	}
+
 	for i := range o.opt.Addr {
 		var num int
 		switch o.opt.ConnOpenStrategy {
@@ -86,6 +90,9 @@ func init() {
 }
 
 func OpenDB(opt *Options) *sql.DB {
+	if opt == nil {
+		opt = &Options{}
+	}
 	var settings []string
 	if opt.MaxIdleConns > 0 {
 		settings = append(settings, "SetMaxIdleConns")

--- a/tests/issues/647_test.go
+++ b/tests/issues/647_test.go
@@ -1,0 +1,33 @@
+package issues
+
+import (
+	"context"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test647(t *testing.T) {
+	options := &clickhouse.Options{
+		Addr: []string{"127.0.0.1:9000"},
+	}
+	conn, err := clickhouse.Open(options)
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, conn.Ping(ctx))
+	//reuse options
+	conn2, err := clickhouse.Open(options)
+	require.NoError(t, err)
+	require.NoError(t, conn2.Ping(ctx))
+}
+
+func Test647_OpenDB(t *testing.T) {
+	options := &clickhouse.Options{
+		Addr: []string{"127.0.0.1:9000"},
+	}
+	conn := clickhouse.OpenDB(options)
+	require.NoError(t, conn.Ping())
+	//reuse options
+	conn2 := clickhouse.OpenDB(options)
+	require.NoError(t, conn2.Ping())
+}

--- a/tests/issues/647_test.go
+++ b/tests/issues/647_test.go
@@ -19,6 +19,9 @@ func Test647(t *testing.T) {
 	conn2, err := clickhouse.Open(options)
 	require.NoError(t, err)
 	require.NoError(t, conn2.Ping(ctx))
+	conn3, err := clickhouse.Open(nil)
+	require.NoError(t, err)
+	require.ErrorIs(t, conn3.Ping(ctx), clickhouse.ErrAcquireConnNoAddress)
 }
 
 func Test647_OpenDB(t *testing.T) {
@@ -30,4 +33,7 @@ func Test647_OpenDB(t *testing.T) {
 	//reuse options
 	conn2 := clickhouse.OpenDB(options)
 	require.NoError(t, conn2.Ping())
+	// allow nil to be parsed
+	conn3 := clickhouse.OpenDB(nil)
+	require.ErrorIs(t, conn3.Ping(), clickhouse.ErrAcquireConnNoAddress)
 }


### PR DESCRIPTION
closes https://github.com/ClickHouse/clickhouse-go/issues/647

Not completely happy with this - we pass options as a pointer and modify their contents, preventing reuse or at least leading to confusion.
To address we make the `setDefaults` receive a value instead of a pointer - the copy is lightweight as any internal structs are pointers themselves. This mixes semantics though - options methods sometimes have a pointer or value receiver.

@rolinh for thoughts