### PR TITLE
support sql.nullables

### DIFF
--- a/lib/column/bool.go
+++ b/lib/column/bool.go
@@ -18,6 +18,7 @@
 package column
 
 import (
+	"database/sql"
 	"fmt"
 	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
@@ -59,6 +60,8 @@ func (col *Bool) ScanRow(dest interface{}, row int) error {
 	case **bool:
 		*d = new(bool)
 		**d = col.row(row)
+	case *sql.NullBool:
+		d.Scan(col.row(row))
 	default:
 		return &ColumnConverterError{
 			Op:   "ScanRow",
@@ -89,6 +92,19 @@ func (col *Bool) Append(v interface{}) (nulls []uint8, err error) {
 			}
 			col.col.Append(value)
 		}
+	case []sql.NullBool:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			col.Append(v[i])
+		}
+	case []*sql.NullBool:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			if v[i] == nil {
+				nulls[i] = 1
+			}
+			col.Append(v[i])
+		}
 	default:
 		return nil, &ColumnConverterError{
 			Op:   "Append",
@@ -107,6 +123,16 @@ func (col *Bool) AppendRow(v interface{}) error {
 	case *bool:
 		if v != nil {
 			value = *v
+		}
+	case sql.NullBool:
+		switch v.Valid {
+		case true:
+			value = v.Bool
+		}
+	case *sql.NullBool:
+		switch v.Valid {
+		case true:
+			value = v.Bool
 		}
 	case nil:
 	default:

--- a/lib/column/codegen/column.tpl
+++ b/lib/column/codegen/column.tpl
@@ -256,9 +256,9 @@ func (col *{{ .ChType }}) Append(v interface{}) (nulls []uint8,err error) {
 		for i := range v {
 			switch {
 			case v[i] != nil:
-				col.col.Append(*v[i])
+				col.col.AppendRow(*v[i])
 			default:
-				col.col.Append(0)
+				col.col.AppendRow(0)
 				nulls[i] = 1
 			}
 		}

--- a/lib/column/codegen/column.tpl
+++ b/lib/column/codegen/column.tpl
@@ -256,9 +256,9 @@ func (col *{{ .ChType }}) Append(v interface{}) (nulls []uint8,err error) {
 		for i := range v {
 			switch {
 			case v[i] != nil:
-				col.col.AppendRow(*v[i])
+				col.col.Append(*v[i])
 			default:
-				col.col.AppendRow(0)
+				col.col.Append(0)
 				nulls[i] = 1
 			}
 		}
@@ -266,7 +266,7 @@ func (col *{{ .ChType }}) Append(v interface{}) (nulls []uint8,err error) {
     case []sql.Null{{ .ChType }}:
         nulls = make([]uint8, len(v))
         for i := range v {
-            col.Append(v[i])
+            col.AppendRow(v[i])
         }
     case []*sql.Null{{ .ChType }}:
         nulls = make([]uint8, len(v))
@@ -274,7 +274,7 @@ func (col *{{ .ChType }}) Append(v interface{}) (nulls []uint8,err error) {
             if v[i] == nil {
                 nulls[i] = 1
             }
-            col.Append(v[i])
+            col.AppendRow(v[i])
         }
 	{{- end }}
 	default:

--- a/lib/column/column_gen.go
+++ b/lib/column/column_gen.go
@@ -424,7 +424,7 @@ func (col *Float64) Append(v interface{}) (nulls []uint8, err error) {
 	case []sql.NullFloat64:
 		nulls = make([]uint8, len(v))
 		for i := range v {
-			col.Append(v[i])
+			col.AppendRow(v[i])
 		}
 	case []*sql.NullFloat64:
 		nulls = make([]uint8, len(v))
@@ -432,7 +432,7 @@ func (col *Float64) Append(v interface{}) (nulls []uint8, err error) {
 			if v[i] == nil {
 				nulls[i] = 1
 			}
-			col.Append(v[i])
+			col.AppendRow(v[i])
 		}
 	default:
 		return nil, &ColumnConverterError{
@@ -657,7 +657,7 @@ func (col *Int16) Append(v interface{}) (nulls []uint8, err error) {
 	case []sql.NullInt16:
 		nulls = make([]uint8, len(v))
 		for i := range v {
-			col.Append(v[i])
+			col.AppendRow(v[i])
 		}
 	case []*sql.NullInt16:
 		nulls = make([]uint8, len(v))
@@ -665,7 +665,7 @@ func (col *Int16) Append(v interface{}) (nulls []uint8, err error) {
 			if v[i] == nil {
 				nulls[i] = 1
 			}
-			col.Append(v[i])
+			col.AppendRow(v[i])
 		}
 	default:
 		return nil, &ColumnConverterError{
@@ -788,7 +788,7 @@ func (col *Int32) Append(v interface{}) (nulls []uint8, err error) {
 	case []sql.NullInt32:
 		nulls = make([]uint8, len(v))
 		for i := range v {
-			col.Append(v[i])
+			col.AppendRow(v[i])
 		}
 	case []*sql.NullInt32:
 		nulls = make([]uint8, len(v))
@@ -796,7 +796,7 @@ func (col *Int32) Append(v interface{}) (nulls []uint8, err error) {
 			if v[i] == nil {
 				nulls[i] = 1
 			}
-			col.Append(v[i])
+			col.AppendRow(v[i])
 		}
 	default:
 		return nil, &ColumnConverterError{
@@ -921,7 +921,7 @@ func (col *Int64) Append(v interface{}) (nulls []uint8, err error) {
 	case []sql.NullInt64:
 		nulls = make([]uint8, len(v))
 		for i := range v {
-			col.Append(v[i])
+			col.AppendRow(v[i])
 		}
 	case []*sql.NullInt64:
 		nulls = make([]uint8, len(v))
@@ -929,7 +929,7 @@ func (col *Int64) Append(v interface{}) (nulls []uint8, err error) {
 			if v[i] == nil {
 				nulls[i] = 1
 			}
-			col.Append(v[i])
+			col.AppendRow(v[i])
 		}
 	default:
 		return nil, &ColumnConverterError{

--- a/lib/column/column_gen.go
+++ b/lib/column/column_gen.go
@@ -21,6 +21,7 @@
 package column
 
 import (
+	"database/sql"
 	"fmt"
 	"github.com/ClickHouse/ch-go/proto"
 	"github.com/google/uuid"
@@ -381,6 +382,8 @@ func (col *Float64) ScanRow(dest interface{}, row int) error {
 	case **float64:
 		*d = new(float64)
 		**d = value
+	case *sql.NullFloat64:
+		d.Scan(value)
 	default:
 		return &ColumnConverterError{
 			Op:   "ScanRow",
@@ -418,6 +421,19 @@ func (col *Float64) Append(v interface{}) (nulls []uint8, err error) {
 				nulls[i] = 1
 			}
 		}
+	case []sql.NullFloat64:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			col.Append(v[i])
+		}
+	case []*sql.NullFloat64:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			if v[i] == nil {
+				nulls[i] = 1
+			}
+			col.Append(v[i])
+		}
 	default:
 		return nil, &ColumnConverterError{
 			Op:   "Append",
@@ -441,6 +457,20 @@ func (col *Float64) AppendRow(v interface{}) error {
 		}
 	case nil:
 		col.col.Append(0)
+	case sql.NullFloat64:
+		switch v.Valid {
+		case true:
+			col.col.Append(v.Float64)
+		default:
+			col.col.Append(0)
+		}
+	case *sql.NullFloat64:
+		switch v.Valid {
+		case true:
+			col.col.Append(v.Float64)
+		default:
+			col.col.Append(0)
+		}
 	default:
 		return &ColumnConverterError{
 			Op:   "AppendRow",
@@ -585,6 +615,8 @@ func (col *Int16) ScanRow(dest interface{}, row int) error {
 	case **int16:
 		*d = new(int16)
 		**d = value
+	case *sql.NullInt16:
+		d.Scan(value)
 	default:
 		return &ColumnConverterError{
 			Op:   "ScanRow",
@@ -622,6 +654,19 @@ func (col *Int16) Append(v interface{}) (nulls []uint8, err error) {
 				nulls[i] = 1
 			}
 		}
+	case []sql.NullInt16:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			col.Append(v[i])
+		}
+	case []*sql.NullInt16:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			if v[i] == nil {
+				nulls[i] = 1
+			}
+			col.Append(v[i])
+		}
 	default:
 		return nil, &ColumnConverterError{
 			Op:   "Append",
@@ -645,6 +690,20 @@ func (col *Int16) AppendRow(v interface{}) error {
 		}
 	case nil:
 		col.col.Append(0)
+	case sql.NullInt16:
+		switch v.Valid {
+		case true:
+			col.col.Append(v.Int16)
+		default:
+			col.col.Append(0)
+		}
+	case *sql.NullInt16:
+		switch v.Valid {
+		case true:
+			col.col.Append(v.Int16)
+		default:
+			col.col.Append(0)
+		}
 	default:
 		return &ColumnConverterError{
 			Op:   "AppendRow",
@@ -687,6 +746,8 @@ func (col *Int32) ScanRow(dest interface{}, row int) error {
 	case **int32:
 		*d = new(int32)
 		**d = value
+	case *sql.NullInt32:
+		d.Scan(value)
 	default:
 		return &ColumnConverterError{
 			Op:   "ScanRow",
@@ -724,6 +785,19 @@ func (col *Int32) Append(v interface{}) (nulls []uint8, err error) {
 				nulls[i] = 1
 			}
 		}
+	case []sql.NullInt32:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			col.Append(v[i])
+		}
+	case []*sql.NullInt32:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			if v[i] == nil {
+				nulls[i] = 1
+			}
+			col.Append(v[i])
+		}
 	default:
 		return nil, &ColumnConverterError{
 			Op:   "Append",
@@ -747,6 +821,20 @@ func (col *Int32) AppendRow(v interface{}) error {
 		}
 	case nil:
 		col.col.Append(0)
+	case sql.NullInt32:
+		switch v.Valid {
+		case true:
+			col.col.Append(v.Int32)
+		default:
+			col.col.Append(0)
+		}
+	case *sql.NullInt32:
+		switch v.Valid {
+		case true:
+			col.col.Append(v.Int32)
+		default:
+			col.col.Append(0)
+		}
 	default:
 		return &ColumnConverterError{
 			Op:   "AppendRow",
@@ -791,6 +879,8 @@ func (col *Int64) ScanRow(dest interface{}, row int) error {
 		**d = value
 	case *time.Duration:
 		*d = time.Duration(value)
+	case *sql.NullInt64:
+		d.Scan(value)
 	default:
 		return &ColumnConverterError{
 			Op:   "ScanRow",
@@ -828,6 +918,19 @@ func (col *Int64) Append(v interface{}) (nulls []uint8, err error) {
 				nulls[i] = 1
 			}
 		}
+	case []sql.NullInt64:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			col.Append(v[i])
+		}
+	case []*sql.NullInt64:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			if v[i] == nil {
+				nulls[i] = 1
+			}
+			col.Append(v[i])
+		}
 	default:
 		return nil, &ColumnConverterError{
 			Op:   "Append",
@@ -851,6 +954,20 @@ func (col *Int64) AppendRow(v interface{}) error {
 		}
 	case nil:
 		col.col.Append(0)
+	case sql.NullInt64:
+		switch v.Valid {
+		case true:
+			col.col.Append(v.Int64)
+		default:
+			col.col.Append(0)
+		}
+	case *sql.NullInt64:
+		switch v.Valid {
+		case true:
+			col.col.Append(v.Int64)
+		default:
+			col.col.Append(0)
+		}
 	case time.Duration:
 		col.col.Append(int64(v))
 	case *time.Duration:

--- a/lib/column/date.go
+++ b/lib/column/date.go
@@ -18,6 +18,7 @@
 package column
 
 import (
+	"database/sql"
 	"fmt"
 	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
@@ -65,6 +66,8 @@ func (col *Date) ScanRow(dest interface{}, row int) error {
 	case **time.Time:
 		*d = new(time.Time)
 		**d = col.row(row)
+	case *sql.NullTime:
+		d.Scan(col.row(row))
 	default:
 		return &ColumnConverterError{
 			Op:   "ScanRow",
@@ -98,6 +101,19 @@ func (col *Date) Append(v interface{}) (nulls []uint8, err error) {
 				col.col.Append(time.Time{})
 			}
 		}
+	case []sql.NullTime:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			col.AppendRow(v[i])
+		}
+	case []*sql.NullTime:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			if v[i] == nil {
+				nulls[i] = 1
+			}
+			col.AppendRow(v[i])
+		}
 	default:
 		return nil, &ColumnConverterError{
 			Op:   "Append",
@@ -122,6 +138,20 @@ func (col *Date) AppendRow(v interface{}) error {
 				return err
 			}
 			col.col.Append(*v)
+		default:
+			col.col.Append(time.Time{})
+		}
+	case sql.NullTime:
+		switch v.Valid {
+		case true:
+			col.col.Append(v.Time)
+		default:
+			col.col.Append(time.Time{})
+		}
+	case *sql.NullTime:
+		switch v.Valid {
+		case true:
+			col.col.Append(v.Time)
 		default:
 			col.col.Append(time.Time{})
 		}

--- a/lib/column/datetime.go
+++ b/lib/column/datetime.go
@@ -18,6 +18,7 @@
 package column
 
 import (
+	"database/sql"
 	"fmt"
 	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
@@ -82,6 +83,8 @@ func (col *DateTime) ScanRow(dest interface{}, row int) error {
 	case **time.Time:
 		*d = new(time.Time)
 		**d = col.row(row)
+	case *sql.NullTime:
+		d.Scan(col.row(row))
 	default:
 		return &ColumnConverterError{
 			Op:   "ScanRow",
@@ -117,6 +120,19 @@ func (col *DateTime) Append(v interface{}) (nulls []uint8, err error) {
 				col.col.Append(time.Time{})
 			}
 		}
+	case []sql.NullTime:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			col.AppendRow(v[i])
+		}
+	case []*sql.NullTime:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			if v[i] == nil {
+				nulls[i] = 1
+			}
+			col.AppendRow(v[i])
+		}
 	default:
 		return nil, &ColumnConverterError{
 			Op:   "Append",
@@ -141,6 +157,20 @@ func (col *DateTime) AppendRow(v interface{}) error {
 				return err
 			}
 			col.col.Append(*v)
+		default:
+			col.col.Append(time.Time{})
+		}
+	case sql.NullTime:
+		switch v.Valid {
+		case true:
+			col.col.Append(v.Time)
+		default:
+			col.col.Append(time.Time{})
+		}
+	case *sql.NullTime:
+		switch v.Valid {
+		case true:
+			col.col.Append(v.Time)
 		default:
 			col.col.Append(time.Time{})
 		}

--- a/lib/column/nullable.go
+++ b/lib/column/nullable.go
@@ -18,6 +18,8 @@
 package column
 
 import (
+	"database/sql"
+	"database/sql/driver"
 	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
 )
@@ -80,7 +82,11 @@ func (col *Nullable) Row(i int, ptr bool) interface{} {
 
 func (col *Nullable) ScanRow(dest interface{}, row int) error {
 	if col.enable {
-		if col.nulls.Row(row) == 1 {
+		switch col.nulls.Row(row) {
+		case 1:
+			if scan, ok := dest.(sql.Scanner); ok {
+				return scan.Scan(nil)
+			}
 			return nil
 		}
 	}
@@ -101,6 +107,17 @@ func (col *Nullable) Append(v interface{}) ([]uint8, error) {
 func (col *Nullable) AppendRow(v interface{}) error {
 	if v == nil || (reflect.ValueOf(v).Kind() == reflect.Ptr && reflect.ValueOf(v).IsNil()) {
 		col.nulls.Append(1)
+		// used to detect sql.Null* types
+	} else if val, ok := v.(driver.Valuer); ok {
+		val, err := val.Value()
+		if err != nil {
+			return err
+		}
+		if val == nil {
+			col.nulls.Append(1)
+		} else {
+			col.nulls.Append(0)
+		}
 	} else {
 		col.nulls.Append(0)
 	}

--- a/lib/column/string.go
+++ b/lib/column/string.go
@@ -135,7 +135,7 @@ func (col *String) Append(v interface{}) (nulls []uint8, err error) {
 	case []sql.NullString:
 		nulls = make([]uint8, len(v))
 		for i := range v {
-			col.Append(v[i])
+			col.AppendRow(v[i])
 		}
 	case []*sql.NullString:
 		nulls = make([]uint8, len(v))
@@ -143,7 +143,7 @@ func (col *String) Append(v interface{}) (nulls []uint8, err error) {
 			if v[i] == nil {
 				nulls[i] = 1
 			}
-			col.Append(v[i])
+			col.AppendRow(v[i])
 		}
 	case [][]byte:
 		nulls = make([]uint8, len(v))

--- a/lib/column/string.go
+++ b/lib/column/string.go
@@ -144,6 +144,7 @@ func (col *String) Append(v interface{}) (nulls []uint8, err error) {
 				nulls[i] = 1
 			}
 			col.Append(v[i])
+		}
 	case [][]byte:
 		nulls = make([]uint8, len(v))
 		for i := range v {

--- a/tests/bool_test.go
+++ b/tests/bool_test.go
@@ -19,6 +19,8 @@ package tests
 
 import (
 	"context"
+	"database/sql"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -41,48 +43,60 @@ func TestBool(t *testing.T) {
 			MaxOpenConns: 1,
 		})
 	)
-	if assert.NoError(t, err) {
-		if err := checkMinServerVersion(conn, 21, 12, 0); err != nil {
-			t.Skip(err.Error())
-			return
-		}
-		const ddl = `
+	require.NoError(t, err)
+	if err := checkMinServerVersion(conn, 21, 12, 0); err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	const ddl = `
 			CREATE TABLE test_bool (
 				  Col1 Bool
 				, Col2 Bool
 				, Col3 Array(Bool)
 				, Col4 Nullable(Bool)
 				, Col5 Array(Nullable(Bool))
+				, Col6 Bool
+				, Col7 Nullable(Bool)
 			) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_bool")
-		}()
-		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
-			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_bool"); assert.NoError(t, err) {
-				var val bool
-				if err := batch.Append(true, false, []bool{true, false, true}, nil, []*bool{&val, nil, &val}); assert.NoError(t, err) {
-					if err := batch.Send(); assert.NoError(t, err) {
-						var (
-							col1 bool
-							col2 bool
-							col3 []bool
-							col4 *bool
-							col5 []*bool
-						)
-						if err := conn.QueryRow(ctx, "SELECT * FROM test_bool").Scan(&col1, &col2, &col3, &col4, &col5); assert.NoError(t, err) {
-							assert.Equal(t, true, col1)
-							assert.Equal(t, false, col2)
-							assert.Equal(t, []bool{true, false, true}, col3)
-							if assert.Nil(t, col4) {
-								assert.Equal(t, []*bool{&val, nil, &val}, col5)
-							}
-						}
-					}
-				}
-			}
-		}
-	}
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_bool")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_bool")
+	require.NoError(t, err)
+	var val bool
+	require.NoError(t, batch.Append(true, false, []bool{true, false, true}, nil, []*bool{&val, nil, &val}, sql.NullBool{
+		Bool:  true,
+		Valid: true,
+	}, sql.NullBool{
+		Bool:  false,
+		Valid: false,
+	}))
+	require.NoError(t, batch.Send())
+	var (
+		col1 bool
+		col2 bool
+		col3 []bool
+		col4 *bool
+		col5 []*bool
+		col6 sql.NullBool
+		col7 sql.NullBool
+	)
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_bool").Scan(&col1, &col2, &col3, &col4, &col5, &col6, &col7))
+	assert.Equal(t, true, col1)
+	assert.Equal(t, false, col2)
+	assert.Equal(t, []bool{true, false, true}, col3)
+	require.Nil(t, col4)
+	assert.Equal(t, []*bool{&val, nil, &val}, col5)
+	assert.Equal(t, sql.NullBool{
+		Bool:  true,
+		Valid: true,
+	}, col6)
+	assert.Equal(t, sql.NullBool{
+		Bool:  false,
+		Valid: false,
+	}, col7)
 }
 
 func TestColumnarBool(t *testing.T) {

--- a/tests/columnar_batch_test.go
+++ b/tests/columnar_batch_test.go
@@ -19,7 +19,9 @@ package tests
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
@@ -43,74 +45,78 @@ func TestColumnarInterface(t *testing.T) {
 			MaxOpenConns: 1,
 		})
 	)
-	if assert.NoError(t, err) {
-		const ddl = `
+	require.NoError(t, err)
+	const ddl = `
 			CREATE TABLE test_column_interface (
 				    Col1 UInt8
 				  , Col2 String
 				  , Col3 DateTime
+				  , Col4 String
+				  , Col5 DateTime
+				  , Col6 Int64	
 			) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_column_interface")
-		}()
-		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
-			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_column_interface"); assert.NoError(t, err) {
-				var (
-					col1Data    []uint8
-					col2Data    []string
-					col3Data    []time.Time
-					currentTime = time.Now().Truncate(time.Second)
-				)
-				for i := 0; i < 150; i++ {
-					col1Data = append(col1Data, uint8(i))
-					col2Data = append(col2Data, fmt.Sprintf("value_%d", i))
-					col3Data = append(col3Data, currentTime)
-				}
-				if err := batch.Column(0).Append(col1Data); !assert.NoError(t, err) {
-					return
-				}
-				if err := batch.Column(1).Append(col2Data); !assert.NoError(t, err) {
-					return
-				}
-				if err := batch.Column(2).Append(col3Data); !assert.NoError(t, err) {
-					return
-				}
-				if assert.NoError(t, batch.Send()) {
-					var count uint64
-					if err := conn.QueryRow(ctx, "SELECT COUNT() FROM test_column_interface").Scan(&count); assert.NoError(t, err) {
-						if assert.Equal(t, uint64(150), count) {
-							rows, err := conn.Query(ctx, "SELECT * FROM test_column_interface WHERE Col1 >= $1 AND Col1 < $2", 10, 30)
-							if assert.NoError(t, err) {
-								var (
-									row   uint8 = 10
-									count uint64
-								)
-								for rows.Next() {
-									var (
-										col1 uint8
-										col2 string
-										col3 time.Time
-									)
-									if assert.NoError(t, rows.Scan(&col1, &col2, &col3)) {
-										assert.Equal(t, row, col1)
-										assert.Equal(t, fmt.Sprintf("value_%d", row), col2)
-										assert.Equal(t, currentTime.Unix(), col3.Unix())
-									}
-									row++
-									count++
-								}
-								rows.Close()
-								if assert.NoError(t, rows.Err()) {
-									assert.Equal(t, uint64(20), count)
-								}
-							}
-						}
-					}
-				}
-			}
-		}
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_column_interface")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_column_interface")
+	require.NoError(t, err)
+	var (
+		col1Data    []uint8
+		col2Data    []string
+		col3Data    []time.Time
+		currentTime = time.Now().Truncate(time.Second)
+		col4Data    []sql.NullString
+		col5Data    []sql.NullTime
+		col6Data    []sql.NullInt64
+	)
+	for i := 0; i < 150; i++ {
+		col1Data = append(col1Data, uint8(i))
+		col2Data = append(col2Data, fmt.Sprintf("value_%d", i))
+		col3Data = append(col3Data, currentTime)
+		col4Data = append(col4Data, sql.NullString{String: fmt.Sprintf("value_%d", i), Valid: true})
+		col5Data = append(col5Data, sql.NullTime{Time: currentTime, Valid: true})
+		col6Data = append(col6Data, sql.NullInt64{Int64: int64(i), Valid: true})
 	}
+	require.NoError(t, batch.Column(0).Append(col1Data))
+	require.NoError(t, batch.Column(1).Append(col2Data))
+	require.NoError(t, batch.Column(2).Append(col3Data))
+	require.NoError(t, batch.Column(3).Append(col4Data))
+	require.NoError(t, batch.Column(4).Append(col5Data))
+	require.NoError(t, batch.Column(5).Append(col6Data))
+	require.NoError(t, batch.Send())
+	var count uint64
+	require.NoError(t, conn.QueryRow(ctx, "SELECT COUNT() FROM test_column_interface").Scan(&count))
+	require.Equal(t, uint64(150), count)
+	rows, err := conn.Query(ctx, "SELECT * FROM test_column_interface WHERE Col1 >= $1 AND Col1 < $2", 10, 30)
+	require.NoError(t, err)
+	var (
+		row uint8 = 10
+	)
+	iCount := 0
+	for rows.Next() {
+		var (
+			col1 uint8
+			col2 string
+			col3 time.Time
+			col4 sql.NullString
+			col5 sql.NullTime
+			col6 sql.NullInt64
+		)
+		require.NoError(t, rows.Scan(&col1, &col2, &col3, &col4, &col5, &col6))
+		assert.Equal(t, row, col1)
+		assert.Equal(t, fmt.Sprintf("value_%d", row), col2)
+		assert.Equal(t, currentTime.Unix(), col3.Unix())
+		assert.Equal(t, fmt.Sprintf("value_%d", row), col4.String)
+		assert.Equal(t, currentTime, col5.Time)
+		assert.Equal(t, int64(row), col6.Int64)
+		row++
+		iCount++
+	}
+	rows.Close()
+	require.NoError(t, rows.Err())
+	assert.Equal(t, 20, iCount)
 }
 
 func TestNullableColumnarInterface(t *testing.T) {

--- a/tests/int_test.go
+++ b/tests/int_test.go
@@ -55,7 +55,7 @@ func TestNullableInt(t *testing.T) {
 		})
 	)
 	require.NoError(t, err)
-	if err := checkMinServerVersion(conn, 21, 9, 0); err != nil {
+	if err := CheckMinServerVersion(conn, 21, 9, 0); err != nil {
 		t.Skip(err.Error())
 		return
 	}

--- a/tests/int_test.go
+++ b/tests/int_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"database/sql"
 	"github.com/stretchr/testify/require"
 	"testing"
 
@@ -36,4 +37,56 @@ func TestSimpleInt(t *testing.T) {
 	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_int")
 	require.NoError(t, err)
 	require.Error(t, batch.Append(222))
+}
+
+func TestNullableInt(t *testing.T) {
+	var (
+		ctx       = context.Background()
+		conn, err = clickhouse.Open(&clickhouse.Options{
+			Addr: []string{"127.0.0.1:9000"},
+			Auth: clickhouse.Auth{
+				Database: "default",
+				Username: "default",
+				Password: "",
+			},
+			Compression: &clickhouse.Compression{
+				Method: clickhouse.CompressionLZ4,
+			},
+		})
+	)
+	require.NoError(t, err)
+	if err := checkMinServerVersion(conn, 21, 9, 0); err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	const ddl = "CREATE TABLE test_int (col1 Int64, col2 Nullable(Int64), col3 Int32, col4 Nullable(Int32), col5 Int16, col6 Nullable(Int16)) Engine Memory"
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_int")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_int")
+	require.NoError(t, err)
+	col1Data := sql.NullInt64{Int64: 1, Valid: true}
+	col2Data := sql.NullInt64{Int64: 0, Valid: false}
+	col3Data := sql.NullInt32{Int32: 2, Valid: true}
+	col4Data := sql.NullInt32{Int32: 0, Valid: false}
+	col5Data := sql.NullInt16{Int16: 3, Valid: true}
+	col6Data := sql.NullInt16{Int16: 0, Valid: false}
+	require.NoError(t, batch.Append(col1Data, col2Data, col3Data, col4Data, col5Data, col6Data))
+	require.NoError(t, batch.Send())
+	var (
+		col1 sql.NullInt64
+		col2 sql.NullInt64
+		col3 sql.NullInt32
+		col4 sql.NullInt32
+		col5 sql.NullInt16
+		col6 sql.NullInt16
+	)
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_int").Scan(&col1, &col2, &col3, &col4, &col5, &col6))
+	require.Equal(t, col1Data, col1)
+	require.Equal(t, col2Data, col2)
+	require.Equal(t, col3Data, col3)
+	require.Equal(t, col4Data, col4)
+	require.Equal(t, col5Data, col5)
+	require.Equal(t, col6Data, col6)
 }

--- a/tests/issues/utils.go
+++ b/tests/issues/utils.go
@@ -28,6 +28,7 @@ import (
 func init() {
 	rand.Seed(time.Now().UnixNano())
 }
+
 func checkMinServerVersion(conn driver.Conn, major, minor uint64) error {
 	v, err := conn.ServerVersion()
 	if err != nil {

--- a/tests/std/date32_test.go
+++ b/tests/std/date32_test.go
@@ -20,6 +20,7 @@ package std
 import (
 	"database/sql"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
@@ -31,84 +32,86 @@ func TestStdDate32(t *testing.T) {
 
 	for name, dsn := range dsns {
 		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
-			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
-				if err := checkMinServerVersion(conn, 21, 9, 0); err != nil {
-					t.Skip(err.Error())
-					return
-				}
-				const ddl = `
+			conn, err := sql.Open("clickhouse", dsn)
+			require.NoError(t, err)
+			if err := checkMinServerVersion(conn, 21, 9, 0); err != nil {
+				t.Skip(err.Error())
+				return
+			}
+			const ddl = `
 			CREATE TABLE test_date32 (
 				  ID   UInt8
 				, Col1 Date32
 				, Col2 Nullable(Date32)
 				, Col3 Array(Date32)
 				, Col4 Array(Nullable(Date32))
+				, Col5 Nullable(Date32)
+				, Col6 Date32
 			) Engine Memory
 		`
-				defer func() {
-					conn.Exec("DROP TABLE test_date32")
-				}()
-				type result struct {
-					ColID uint8 `ch:"ID"`
-					Col1  time.Time
-					Col2  *time.Time
-					Col3  []time.Time
-					Col4  []*time.Time
-				}
-				if _, err := conn.Exec(ddl); assert.NoError(t, err) {
-					scope, err := conn.Begin()
-					if !assert.NoError(t, err) {
-						return
-					}
-					if batch, err := scope.Prepare("INSERT INTO test_date32"); assert.NoError(t, err) {
-						var (
-							date1, _ = time.Parse("2006-01-02 15:04:05", "2283-11-11 00:00:00")
-							date2, _ = time.Parse("2006-01-02 15:04:05", "1925-01-01 00:00:00")
-						)
-						if _, err := batch.Exec(uint8(1), date1, &date2, []time.Time{date2}, []*time.Time{&date2, nil, &date1}); !assert.NoError(t, err) {
-							return
-						}
-						if _, err := batch.Exec(uint8(2), date2, nil, []time.Time{date1}, []*time.Time{nil, nil, &date2}); !assert.NoError(t, err) {
-							return
-						}
-						if err := scope.Commit(); assert.NoError(t, err) {
-							var (
-								result1 result
-								result2 result
-							)
-							if err := conn.QueryRow("SELECT * FROM test_date32 WHERE ID = $1", 1).Scan(
-								&result1.ColID,
-								&result1.Col1,
-								&result1.Col2,
-								&result1.Col3,
-								&result1.Col4,
-							); assert.NoError(t, err) {
-								if assert.Equal(t, date1, result1.Col1) {
-									assert.Equal(t, "UTC", result1.Col1.Location().String())
-									assert.Equal(t, date2, *result1.Col2)
-									assert.Equal(t, []time.Time{date2}, result1.Col3)
-									assert.Equal(t, []*time.Time{&date2, nil, &date1}, result1.Col4)
-								}
-							}
-							if err := conn.QueryRow("SELECT * FROM test_date32 WHERE ID = $1", 2).Scan(
-								&result2.ColID,
-								&result2.Col1,
-								&result2.Col2,
-								&result2.Col3,
-								&result2.Col4,
-							); assert.NoError(t, err) {
-								if assert.Equal(t, date2, result2.Col1) {
-									assert.Equal(t, "UTC", result2.Col1.Location().String())
-									if assert.Nil(t, result2.Col2) {
-										assert.Equal(t, []time.Time{date1}, result2.Col3)
-										assert.Equal(t, []*time.Time{nil, nil, &date2}, result2.Col4)
-									}
-								}
-							}
-						}
-					}
-				}
+			defer func() {
+				conn.Exec("DROP TABLE test_date32")
+			}()
+			type result struct {
+				ColID uint8 `ch:"ID"`
+				Col1  time.Time
+				Col2  *time.Time
+				Col3  []time.Time
+				Col4  []*time.Time
+				Col5  sql.NullTime
+				Col6  sql.NullTime
 			}
+			_, err = conn.Exec(ddl)
+			require.NoError(t, err)
+			scope, err := conn.Begin()
+			require.NoError(t, err)
+			batch, err := scope.Prepare("INSERT INTO test_date32")
+			require.NoError(t, err)
+			var (
+				date1, _ = time.Parse("2006-01-02 15:04:05", "2283-11-11 00:00:00")
+				date2, _ = time.Parse("2006-01-02 15:04:05", "1925-01-01 00:00:00")
+			)
+			_, err = batch.Exec(uint8(1), date1, &date2, []time.Time{date2}, []*time.Time{&date2, nil, &date1}, sql.NullTime{Time: time.Time{}, Valid: false}, sql.NullTime{Time: date1, Valid: true})
+			require.NoError(t, err)
+			_, err = batch.Exec(uint8(2), date2, nil, []time.Time{date1}, []*time.Time{nil, nil, &date2}, sql.NullTime{Time: time.Time{}, Valid: false}, sql.NullTime{Time: date2, Valid: true})
+			require.NoError(t, err)
+			require.NoError(t, scope.Commit())
+			var (
+				result1 result
+				result2 result
+			)
+			require.NoError(t, conn.QueryRow("SELECT * FROM test_date32 WHERE ID = $1", 1).Scan(
+				&result1.ColID,
+				&result1.Col1,
+				&result1.Col2,
+				&result1.Col3,
+				&result1.Col4,
+				&result1.Col5,
+				&result1.Col6,
+			))
+			require.Equal(t, date1, result1.Col1)
+			assert.Equal(t, "UTC", result1.Col1.Location().String())
+			assert.Equal(t, date2, *result1.Col2)
+			assert.Equal(t, []time.Time{date2}, result1.Col3)
+			assert.Equal(t, []*time.Time{&date2, nil, &date1}, result1.Col4)
+			assert.Equal(t, sql.NullTime{Time: time.Time{}, Valid: false}, result1.Col5)
+			assert.Equal(t, sql.NullTime{Time: date1, Valid: true}, result1.Col6)
+			require.NoError(t, conn.QueryRow("SELECT * FROM test_date32 WHERE ID = $1", 2).Scan(
+				&result2.ColID,
+				&result2.Col1,
+				&result2.Col2,
+				&result2.Col3,
+				&result2.Col4,
+				&result1.Col5,
+				&result1.Col6,
+			))
+			require.Equal(t, date2, result2.Col1)
+			require.Equal(t, "UTC", result2.Col1.Location().String())
+			require.Nil(t, result2.Col2)
+			assert.Equal(t, []time.Time{date1}, result2.Col3)
+			assert.Equal(t, []*time.Time{nil, nil, &date2}, result2.Col4)
+			assert.Equal(t, sql.NullTime{Time: time.Time{}, Valid: false}, result1.Col5)
+			assert.Equal(t, sql.NullTime{Time: date2, Valid: true}, result1.Col6)
 		})
 	}
 }

--- a/tests/std/datetime64_test.go
+++ b/tests/std/datetime64_test.go
@@ -20,6 +20,7 @@ package std
 import (
 	"database/sql"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
@@ -31,12 +32,13 @@ func TestStdDateTime64(t *testing.T) {
 
 	for name, dsn := range dsns {
 		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
-			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
-				if err := checkMinServerVersion(conn, 20, 3, 0); err != nil {
-					t.Skip(err.Error())
-					return
-				}
-				const ddl = `
+			conn, err := sql.Open("clickhouse", dsn)
+			require.NoError(t, err)
+			if err := checkMinServerVersion(conn, 20, 3, 0); err != nil {
+				t.Skip(err.Error())
+				return
+			}
+			const ddl = `
 			CREATE TABLE test_datetime64 (
 				  Col1 DateTime64(3)
 				, Col2 DateTime64(9, 'Europe/Moscow')
@@ -44,62 +46,63 @@ func TestStdDateTime64(t *testing.T) {
 				, Col4 Nullable(DateTime64(3, 'Europe/Moscow'))
 				, Col5 Array(DateTime64(3, 'Europe/Moscow'))
 				, Col6 Array(Nullable(DateTime64(3, 'Europe/Moscow')))
+				, Col7 DateTime64(0, 'Europe/London')
+				, Col8 Nullable(DateTime64(3, 'Europe/Moscow'))
 			) Engine Memory
 		`
-				defer func() {
-					conn.Exec("DROP TABLE test_datetime64")
-				}()
-				if _, err := conn.Exec(ddl); assert.NoError(t, err) {
-					scope, err := conn.Begin()
-					if !assert.NoError(t, err) {
-						return
-					}
-					if batch, err := scope.Prepare("INSERT INTO test_datetime64"); assert.NoError(t, err) {
-						var (
-							datetime1 = time.Now().Truncate(time.Millisecond)
-							datetime2 = time.Now().Truncate(time.Nanosecond)
-							datetime3 = time.Now().Truncate(time.Second)
-						)
-						if _, err := batch.Exec(
-							datetime1,
-							datetime2,
-							datetime3,
-							&datetime1,
-							[]time.Time{datetime1, datetime1},
-							[]*time.Time{&datetime3, nil, &datetime3},
-						); assert.NoError(t, err) {
-							if err := scope.Commit(); assert.NoError(t, err) {
-								var (
-									col1 time.Time
-									col2 time.Time
-									col3 time.Time
-									col4 *time.Time
-									col5 []time.Time
-									col6 []*time.Time
-								)
-								if err := conn.QueryRow("SELECT * FROM test_datetime64").Scan(&col1, &col2, &col3, &col4, &col5, &col6); assert.NoError(t, err) {
-									assert.Equal(t, datetime1, col1)
-									assert.Equal(t, datetime2.UnixNano(), col2.UnixNano())
-									assert.Equal(t, datetime3.UnixNano(), col3.UnixNano())
-									if assert.Equal(t, "Europe/Moscow", col2.Location().String()) {
-										assert.Equal(t, "Europe/London", col3.Location().String())
-									}
-									assert.Equal(t, datetime1.UnixNano(), col4.UnixNano())
-									if assert.Len(t, col5, 2) {
-										assert.Equal(t, "Europe/Moscow", col5[0].Location().String())
-										assert.Equal(t, "Europe/Moscow", col5[1].Location().String())
-									}
-									if assert.Len(t, col6, 3) {
-										assert.Nil(t, col6[1])
-										assert.NotNil(t, col6[0])
-										assert.NotNil(t, col6[2])
-									}
-								}
-							}
-						}
-					}
-				}
-			}
+			defer func() {
+				conn.Exec("DROP TABLE test_datetime64")
+			}()
+			_, err = conn.Exec(ddl)
+			require.NoError(t, err)
+			scope, err := conn.Begin()
+			require.NoError(t, err)
+			batch, err := scope.Prepare("INSERT INTO test_datetime64")
+			require.NoError(t, err)
+			var (
+				datetime1 = time.Now().Truncate(time.Millisecond)
+				datetime2 = time.Now().Truncate(time.Nanosecond)
+				datetime3 = time.Now().Truncate(time.Second)
+			)
+			_, err = batch.Exec(
+				datetime1,
+				datetime2,
+				datetime3,
+				&datetime1,
+				[]time.Time{datetime1, datetime1},
+				[]*time.Time{&datetime3, nil, &datetime3},
+				sql.NullTime{Time: datetime3, Valid: true},
+				sql.NullTime{Time: time.Time{}, Valid: false},
+			)
+			require.NoError(t, err)
+			require.NoError(t, scope.Commit())
+			var (
+				col1 time.Time
+				col2 time.Time
+				col3 time.Time
+				col4 *time.Time
+				col5 []time.Time
+				col6 []*time.Time
+				col7 sql.NullTime
+				col8 sql.NullTime
+			)
+			require.NoError(t, conn.QueryRow("SELECT * FROM test_datetime64").Scan(&col1, &col2, &col3, &col4, &col5, &col6, &col7, &col8))
+			assert.Equal(t, datetime1, col1)
+			assert.Equal(t, datetime2.UnixNano(), col2.UnixNano())
+			assert.Equal(t, datetime3.UnixNano(), col3.UnixNano())
+			require.Equal(t, "Europe/Moscow", col2.Location().String())
+			assert.Equal(t, "Europe/London", col3.Location().String())
+
+			assert.Equal(t, datetime1.UnixNano(), col4.UnixNano())
+			require.Len(t, col5, 2)
+			assert.Equal(t, "Europe/Moscow", col5[0].Location().String())
+			assert.Equal(t, "Europe/Moscow", col5[1].Location().String())
+			require.Len(t, col6, 3)
+			assert.Nil(t, col6[1])
+			assert.NotNil(t, col6[0])
+			assert.NotNil(t, col6[2])
+			require.Equal(t, sql.NullTime{Time: datetime3.In(col7.Time.Location()), Valid: true}, col7)
+			require.Equal(t, sql.NullTime{Time: time.Time{}, Valid: false}, col8)
 		})
 	}
 }

--- a/tests/string_test.go
+++ b/tests/string_test.go
@@ -102,7 +102,7 @@ func TestString(t *testing.T) {
 	require.NoError(t, conn.Exec(ctx, ddl))
 	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_string")
 	require.NoError(t, err)
-  col6Data := "D"
+	col6Data := "D"
 	require.NoError(t, batch.Append("A", []string{"A", "B", "C"}, nil, sql.NullString{String: "D", Valid: true}, sql.NullString{Valid: false}, []byte(col6Data)))
 	require.NoError(t, batch.Send())
 	var (
@@ -111,7 +111,7 @@ func TestString(t *testing.T) {
 		col3 *string
 		col4 sql.NullString
 		col5 sql.NullString
-    col6 String
+		col6 string
 	)
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_string").Scan(&col1, &col2, &col3, &col4, &col5, &col6))
 	require.Nil(t, col3)
@@ -119,7 +119,7 @@ func TestString(t *testing.T) {
 	assert.Equal(t, []string{"A", "B", "C"}, col2)
 	assert.Equal(t, sql.NullString{String: "D", Valid: true}, col4)
 	assert.Equal(t, sql.NullString{Valid: false}, col5)
-  assert.Equal(t, col6Data, col6)
+	assert.Equal(t, col6Data, col6)
 }
 
 func BenchmarkString(b *testing.B) {


### PR DESCRIPTION
This starts to address https://github.com/ClickHouse/clickhouse-go/issues/682

@ernado need your feedback on this one. To handle `Nullable` fields correctly I check to see if the variable is a `sql.Scanner` at Scan time and `driver.Valuer` at append time - to ensure they are encoded and decoded correctly. If we're good with this approach I can add the remaining sql.Null* types for their respective fields.