### PR TITLE
Set username/password in Auth if in DSN

### DIFF
--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -209,6 +209,10 @@ func (o *Options) fromDSN(in string) error {
 			case "round_robin":
 				o.ConnOpenStrategy = ConnOpenRoundRobin
 			}
+		case "username":
+			o.Auth.Username = params.Get(v)
+		case "password":
+			o.Auth.Password = params.Get(v)
 
 		default:
 			switch p := strings.ToLower(params.Get(v)); p {

--- a/conn_http.go
+++ b/conn_http.go
@@ -35,7 +35,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
 	"time"
 )
@@ -173,12 +172,9 @@ func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpCon
 	}
 
 	for k, v := range opt.Settings {
-		// skip auth settings if already set - can't be set in both places
-		if (strings.ToLower(k) == "username" || strings.ToLower(k) == "password") && (u.User != nil) {
-			continue
-		}
 		query.Set(k, fmt.Sprint(v))
 	}
+
 	query.Set("default_format", "Native")
 	u.RawQuery = query.Encode()
 

--- a/conn_http.go
+++ b/conn_http.go
@@ -35,6 +35,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 )
@@ -172,6 +173,10 @@ func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpCon
 	}
 
 	for k, v := range opt.Settings {
+		// skip auth settings if already set - can't be set in both places
+		if (strings.ToLower(k) == "username" || strings.ToLower(k) == "password") && (u.User != nil) {
+			continue
+		}
 		query.Set(k, fmt.Sprint(v))
 	}
 	query.Set("default_format", "Native")

--- a/tests/std/conn_test.go
+++ b/tests/std/conn_test.go
@@ -60,6 +60,7 @@ func TestStdConnFailover(t *testing.T) {
 		})
 	}
 }
+
 func TestStdConnFailoverConnOpenRoundRobin(t *testing.T) {
 	dsns := map[string]string{
 		"Native": "clickhouse://127.0.0.1:9001,127.0.0.1:9002,127.0.0.1:9003,127.0.0.1:9004,127.0.0.1:9005,127.0.0.1:9006,127.0.0.1:9000/?connection_open_strategy=round_robin",
@@ -76,6 +77,7 @@ func TestStdConnFailoverConnOpenRoundRobin(t *testing.T) {
 		})
 	}
 }
+
 func TestStdPingDeadline(t *testing.T) {
 	dsns := map[string]string{
 		"Native": "clickhouse://127.0.0.1:9000",
@@ -89,6 +91,24 @@ func TestStdPingDeadline(t *testing.T) {
 				defer cancel()
 				if err := conn.PingContext(ctx); assert.Error(t, err) {
 					assert.Equal(t, err, context.DeadlineExceeded)
+				}
+			}
+		})
+	}
+}
+
+func TestStdConnAuth(t *testing.T) {
+	dsns := map[string]string{"Native": "clickhouse://127.0.0.1:9000?username=default&password=", "Http": "http://127.0.0.1:8123?username=default&password="}
+
+	for name, dsn := range dsns {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
+			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
+				if assert.NoError(t, err) {
+					if err := conn.PingContext(context.Background()); assert.NoError(t, err) {
+						if assert.NoError(t, conn.Close()) {
+							t.Log(conn.Stats())
+						}
+					}
 				}
 			}
 		})


### PR DESCRIPTION
If username/password are passed as parameters these should be set in Auth and not settings.