### PR TITLE
consider tz in date

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/ClickHouse/clickhouse-go/v2
 go 1.18
 
 require (
-	github.com/ClickHouse/ch-go v0.47.1
+	github.com/ClickHouse/ch-go v0.47.2
 	github.com/ClickHouse/clickhouse-go v1.5.4
+	github.com/andybalholm/brotli v1.0.4
 	github.com/google/uuid v1.3.0
 	github.com/mkevac/debugcharts v0.0.0-20191222103121-ae1c48aa8615
 	github.com/paulmach/orb v0.7.1
@@ -17,14 +18,13 @@ require (
 require go.opentelemetry.io/otel v1.8.0 // indirect
 
 require (
-	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.6.1 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gorilla/websocket v1.4.1 // indirect
-	github.com/klauspost/compress v1.15.8 // indirect
+	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/ClickHouse/ch-go v0.47.1 h1:4epuZI30bZaozLxEVsb6zpZvVyE1x5Bv3bhQbU6uCKo=
-github.com/ClickHouse/ch-go v0.47.1/go.mod h1:CL1kjJVNy5dMz5lWS52fMvL7nQnLYxjn+qEaOViz/Js=
+github.com/ClickHouse/ch-go v0.47.2 h1:94mxqpQc48PLijPp5McmrJ0MnRUV0/w768Q9JgPVb/k=
+github.com/ClickHouse/ch-go v0.47.2/go.mod h1:z97ZbsIa3G2xtr/mENSumixSf2kRCh+gSH3tvtUSRw8=
 github.com/ClickHouse/clickhouse-go v1.5.4 h1:cKjXeYLNWVJIx2J1K6H2CqyRmfwVJVY1OV1coaaFcI0=
 github.com/ClickHouse/clickhouse-go v1.5.4/go.mod h1:EaI/sW7Azgz9UATzd5ZdZHRUhHgv5+JMS9NSr2smCJI=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
@@ -32,8 +32,8 @@ github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.15.8 h1:JahtItbkWjf2jzm/T+qgMxkP9EMHsqEUA6vCMGmXvhA=
-github.com/klauspost/compress v1.15.8/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/klauspost/compress v1.15.9 h1:wKRjX6JRtDdrE9qwa4b/Cip7ACOshUI4smpCQanqjSY=
+github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/tests/issues/692_test.go
+++ b/tests/issues/692_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestStdMap(t *testing.T) {
+func Test692(t *testing.T) {
 	conn, err := sql.Open("clickhouse", "clickhouse://127.0.0.1:9000")
 	require.NoError(t, err)
 	if err := std.CheckMinServerVersion(conn, 21, 9, 0); err != nil {

--- a/tests/issues/693_test.go
+++ b/tests/issues/693_test.go
@@ -1,0 +1,77 @@
+package issues
+
+import (
+	"database/sql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func Test693(t *testing.T) {
+	conn, err := sql.Open("clickhouse", "clickhouse://127.0.0.1:9000")
+	require.NoError(t, err)
+	const ddl = `
+			CREATE TABLE test_date (
+				  ID   UInt8
+				, Col1 Date
+				, Col2 Nullable(Date)
+				, Col3 Array(Date)
+				, Col4 Array(Nullable(Date))
+			) Engine Memory
+		`
+	type result struct {
+		ColID uint8 `ch:"ID"`
+		Col1  time.Time
+		Col2  *time.Time
+		Col3  []time.Time
+		Col4  []*time.Time
+	}
+	conn.Exec("DROP TABLE test_date")
+	defer func() {
+		conn.Exec("DROP TABLE test_date")
+	}()
+	_, err = conn.Exec(ddl)
+	require.NoError(t, err)
+	scope, err := conn.Begin()
+	require.NoError(t, err)
+	batch, err := scope.Prepare("INSERT INTO test_date")
+	require.NoError(t, err)
+	// date, err := time.Parse("2006-01-02 15:04:05", "2022-01-12 00:00:00")
+	CurrentLoc, _ := time.LoadLocation("Asia/Shanghai")
+	date, err := time.ParseInLocation("2006-01-02 15:04:05", "2022-01-12 00:00:00", CurrentLoc)
+	require.NoError(t, err)
+	_, err = batch.Exec(uint8(1), date, &date, []time.Time{date}, []*time.Time{&date, nil, &date})
+	require.NoError(t, err)
+	_, err = batch.Exec(uint8(2), date, nil, []time.Time{date}, []*time.Time{nil, nil, &date})
+	require.NoError(t, err)
+	require.NoError(t, scope.Commit())
+	var (
+		result1 result
+		result2 result
+	)
+	require.NoError(t, conn.QueryRow("SELECT * FROM test_date WHERE ID = $1", 1).Scan(
+		&result1.ColID,
+		&result1.Col1,
+		&result1.Col2,
+		&result1.Col3,
+		&result1.Col4,
+	))
+	require.Equal(t, date, result1.Col1)
+	assert.Equal(t, "UTC", result1.Col1.Location().String())
+	assert.Equal(t, date, *result1.Col2)
+	assert.Equal(t, []time.Time{date}, result1.Col3)
+	assert.Equal(t, []*time.Time{&date, nil, &date}, result1.Col4)
+	require.NoError(t, conn.QueryRow("SELECT * FROM test_date WHERE ID = $1", 2).Scan(
+		&result2.ColID,
+		&result2.Col1,
+		&result2.Col2,
+		&result2.Col3,
+		&result2.Col4,
+	))
+	require.Equal(t, date, result2.Col1)
+	assert.Equal(t, "UTC", result2.Col1.Location().String())
+	require.Nil(t, result2.Col2)
+	assert.Equal(t, []time.Time{date}, result2.Col3)
+	assert.Equal(t, []*time.Time{nil, nil, &date}, result2.Col4)
+}

--- a/tests/issues/693_test.go
+++ b/tests/issues/693_test.go
@@ -45,6 +45,6 @@ func Test693(t *testing.T) {
 		&result1.ColID,
 		&result1.Col1,
 	))
-	require.Equal(t, date.Format("2006-01-02 15:04:05"), result1.Col1.Format("2006-01-02 15:04:05"))
+	require.Equal(t, date.Format("2006-01-02"), result1.Col1.Format("2006-01-02"))
 	assert.Equal(t, "UTC", result1.Col1.Location().String())
 }

--- a/tests/issues/693_test.go
+++ b/tests/issues/693_test.go
@@ -35,9 +35,9 @@ func Test693(t *testing.T) {
 	CurrentLoc, _ := time.LoadLocation("Asia/Shanghai")
 	date, err := time.ParseInLocation("2006-01-02 15:04:05", "2022-01-12 00:00:00", CurrentLoc)
 	require.NoError(t, err)
-	_, err = batch.Exec(uint8(1), date, &date, []time.Time{date}, []*time.Time{&date, nil, &date})
+	_, err = batch.Exec(uint8(1), date)
 	require.NoError(t, err)
-	_, err = batch.Exec(uint8(2), date, nil, []time.Time{date}, []*time.Time{nil, nil, &date})
+	_, err = batch.Exec(uint8(2), date)
 	require.NoError(t, err)
 	require.NoError(t, scope.Commit())
 	var (

--- a/tests/issues/693_test.go
+++ b/tests/issues/693_test.go
@@ -37,12 +37,9 @@ func Test693(t *testing.T) {
 	require.NoError(t, err)
 	_, err = batch.Exec(uint8(1), date)
 	require.NoError(t, err)
-	_, err = batch.Exec(uint8(2), date)
-	require.NoError(t, err)
 	require.NoError(t, scope.Commit())
 	var (
 		result1 result
-		result2 result
 	)
 	require.NoError(t, conn.QueryRow("SELECT * FROM test_date WHERE ID = $1", 1).Scan(
 		&result1.ColID,
@@ -50,10 +47,4 @@ func Test693(t *testing.T) {
 	))
 	require.Equal(t, date, result1.Col1)
 	assert.Equal(t, "UTC", result1.Col1.Location().String())
-	require.NoError(t, conn.QueryRow("SELECT * FROM test_date WHERE ID = $1", 2).Scan(
-		&result2.ColID,
-		&result2.Col1,
-	))
-	require.Equal(t, date, result2.Col1)
-	assert.Equal(t, "UTC", result2.Col1.Location().String())
 }

--- a/tests/issues/693_test.go
+++ b/tests/issues/693_test.go
@@ -15,17 +15,11 @@ func Test693(t *testing.T) {
 			CREATE TABLE test_date (
 				  ID   UInt8
 				, Col1 Date
-				, Col2 Nullable(Date)
-				, Col3 Array(Date)
-				, Col4 Array(Nullable(Date))
 			) Engine Memory
 		`
 	type result struct {
 		ColID uint8 `ch:"ID"`
 		Col1  time.Time
-		Col2  *time.Time
-		Col3  []time.Time
-		Col4  []*time.Time
 	}
 	conn.Exec("DROP TABLE test_date")
 	defer func() {
@@ -53,25 +47,13 @@ func Test693(t *testing.T) {
 	require.NoError(t, conn.QueryRow("SELECT * FROM test_date WHERE ID = $1", 1).Scan(
 		&result1.ColID,
 		&result1.Col1,
-		&result1.Col2,
-		&result1.Col3,
-		&result1.Col4,
 	))
 	require.Equal(t, date, result1.Col1)
 	assert.Equal(t, "UTC", result1.Col1.Location().String())
-	assert.Equal(t, date, *result1.Col2)
-	assert.Equal(t, []time.Time{date}, result1.Col3)
-	assert.Equal(t, []*time.Time{&date, nil, &date}, result1.Col4)
 	require.NoError(t, conn.QueryRow("SELECT * FROM test_date WHERE ID = $1", 2).Scan(
 		&result2.ColID,
 		&result2.Col1,
-		&result2.Col2,
-		&result2.Col3,
-		&result2.Col4,
 	))
 	require.Equal(t, date, result2.Col1)
 	assert.Equal(t, "UTC", result2.Col1.Location().String())
-	require.Nil(t, result2.Col2)
-	assert.Equal(t, []time.Time{date}, result2.Col3)
-	assert.Equal(t, []*time.Time{nil, nil, &date}, result2.Col4)
 }

--- a/tests/issues/693_test.go
+++ b/tests/issues/693_test.go
@@ -45,6 +45,6 @@ func Test693(t *testing.T) {
 		&result1.ColID,
 		&result1.Col1,
 	))
-	require.Equal(t, date, result1.Col1)
+	require.Equal(t, date.Format("2006-01-02 15:04:05"), result1.Col1.Format("2006-01-02 15:04:05"))
 	assert.Equal(t, "UTC", result1.Col1.Location().String())
 }


### PR DESCRIPTION
This passes based on the patch from 0.47.2.

We should explicitly document though that Date and Date32 are persisted as-is - they are not converted to UTC. This can lead to the retrieved date (which will be in UTC as we have no means of knowing the tz in Date) being different than the inserted - this is the only case in the entire driver we have this behavior @ernado 