### PR TITLE
Respect ReadTimeout in native

### DIFF
--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -264,7 +264,7 @@ func (o Options) setDefaults() *Options {
 		o.DialTimeout = time.Second
 	}
 	if o.ReadTimeout == 0 {
-		o.ReadTimeout = time.Minute * time.Duration(5)
+		o.ReadTimeout = time.Second * time.Duration(300)
 	}
 	if o.MaxIdleConns <= 0 {
 		o.MaxIdleConns = 5

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -195,7 +195,7 @@ func (o *Options) fromDSN(in string) error {
 		case "read_timeout":
 			duration, err := time.ParseDuration(params.Get(v))
 			if err != nil {
-				return fmt.Errorf("clickhouse [dsn parse]: http timeout: %s", err)
+				return fmt.Errorf("clickhouse [dsn parse]:read timeout: %s", err)
 			}
 			o.ReadTimeout = duration
 		case "secure":
@@ -262,6 +262,9 @@ func (o Options) setDefaults() *Options {
 	}
 	if o.DialTimeout == 0 {
 		o.DialTimeout = time.Second
+	}
+	if o.ReadTimeout == 0 {
+		o.ReadTimeout = time.Minute * time.Duration(5)
 	}
 	if o.MaxIdleConns <= 0 {
 		o.MaxIdleConns = 5

--- a/conn.go
+++ b/conn.go
@@ -80,6 +80,7 @@ func dial(ctx context.Context, addr string, num int, opt *Options) (*connect, er
 			compression: compression,
 			connectedAt: time.Now(),
 			compressor:  compress.NewWriter(),
+			readTimeout: opt.ReadTimeout,
 		}
 	)
 	if err := connect.handshake(opt.Auth.Database, opt.Auth.Username, opt.Auth.Password); err != nil {
@@ -101,9 +102,9 @@ type connect struct {
 	revision    uint64
 	structMap   *structMap
 	compression CompressionMethod
-	// lastUsedIn  time.Time
 	connectedAt time.Time
 	compressor  *compress.Writer
+	readTimeout time.Duration
 }
 
 func (c *connect) settings(querySettings Settings) []proto.Setting {

--- a/conn_exec.go
+++ b/conn_exec.go
@@ -30,6 +30,10 @@ func (c *connect) exec(ctx context.Context, query string, args ...interface{}) e
 	if err != nil {
 		return err
 	}
+	// set a read deadline - alternative to context.Read operation will fail if no data is received after deadline.
+	c.conn.SetReadDeadline(time.Now().Add(c.readTimeout))
+	defer c.conn.SetReadDeadline(time.Time{})
+	// context level deadlines override any read deadline
 	if deadline, ok := ctx.Deadline(); ok {
 		c.conn.SetDeadline(deadline)
 		defer c.conn.SetDeadline(time.Time{})

--- a/conn_handshake.go
+++ b/conn_handshake.go
@@ -27,6 +27,10 @@ import (
 func (c *connect) handshake(database, username, password string) error {
 	defer c.buffer.Reset()
 	c.debugf("[handshake] -> %s", proto.ClientHandshake{})
+	// set a read deadline - alternative to context.Read operation will fail if no data is received after deadline.
+	c.conn.SetReadDeadline(time.Now().Add(c.readTimeout))
+	defer c.conn.SetReadDeadline(time.Time{})
+	// context level deadlines override any read deadline
 	c.conn.SetDeadline(time.Now().Add(c.opt.DialTimeout))
 	defer c.conn.SetDeadline(time.Time{})
 	{

--- a/conn_ping.go
+++ b/conn_ping.go
@@ -28,6 +28,10 @@ import (
 // Connection::ping
 // https://github.com/ClickHouse/ClickHouse/blob/master/src/Client/Connection.cpp
 func (c *connect) ping(ctx context.Context) (err error) {
+	// set a read deadline - alternative to context.Read operation will fail if no data is received after deadline.
+	c.conn.SetReadDeadline(time.Now().Add(c.readTimeout))
+	defer c.conn.SetReadDeadline(time.Time{})
+	// context level deadlines override any read deadline
 	if deadline, ok := ctx.Deadline(); ok {
 		c.conn.SetDeadline(deadline)
 		defer c.conn.SetDeadline(time.Time{})

--- a/conn_query.go
+++ b/conn_query.go
@@ -36,6 +36,10 @@ func (c *connect) query(ctx context.Context, release func(*connect, error), quer
 		return nil, err
 	}
 
+	// set a read deadline - alternative to context.Read operation will fail if no data is received after deadline.
+	c.conn.SetReadDeadline(time.Now().Add(c.readTimeout))
+	defer c.conn.SetReadDeadline(time.Time{})
+	// context level deadlines override any read deadline
 	if deadline, ok := ctx.Deadline(); ok {
 		c.conn.SetDeadline(deadline)
 		defer c.conn.SetDeadline(time.Time{})

--- a/tests/conn_test.go
+++ b/tests/conn_test.go
@@ -150,6 +150,10 @@ func TestReadDeadline(t *testing.T) {
 	err = conn.Ping(context.Background())
 	require.Error(t, err)
 	assert.ErrorIs(t, err, os.ErrDeadlineExceeded)
+	// check we can override with context
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*time.Duration(10)))
+	defer cancel()
+	require.NoError(t, conn.Ping(ctx))
 }
 
 func TestQueryDeadline(t *testing.T) {

--- a/tests/conn_test.go
+++ b/tests/conn_test.go
@@ -19,6 +19,8 @@ package tests
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
+	"os"
 	"testing"
 	"time"
 
@@ -37,17 +39,13 @@ func TestConn(t *testing.T) {
 		Compression: &clickhouse.Compression{
 			Method: clickhouse.CompressionLZ4,
 		},
-		//Debug: true,
 	})
-	if assert.NoError(t, err) {
-		if err := conn.Ping(context.Background()); assert.NoError(t, err) {
-			if assert.NoError(t, conn.Close()) {
-				t.Log(conn.Stats())
-				t.Log(conn.ServerVersion())
-				t.Log(conn.Ping(context.Background()))
-			}
-		}
-	}
+	require.NoError(t, err)
+	require.NoError(t, conn.Ping(context.Background()))
+	require.NoError(t, conn.Close())
+	t.Log(conn.Stats())
+	t.Log(conn.ServerVersion())
+	t.Log(conn.Ping(context.Background()))
 }
 
 func TestBadConn(t *testing.T) {
@@ -59,16 +57,15 @@ func TestBadConn(t *testing.T) {
 			Password: "",
 		},
 		MaxOpenConns: 2,
-		//Debug: true,
 	})
-	if assert.NoError(t, err) {
-		for i := 0; i < 20; i++ {
-			if err := conn.Ping(context.Background()); assert.Error(t, err) {
-				assert.Contains(t, err.Error(), "connect: connection refused")
-			}
+	require.NoError(t, err)
+	for i := 0; i < 20; i++ {
+		if err := conn.Ping(context.Background()); assert.Error(t, err) {
+			assert.Contains(t, err.Error(), "connect: connection refused")
 		}
 	}
 }
+
 func TestConnFailover(t *testing.T) {
 	conn, err := clickhouse.Open(&clickhouse.Options{
 		Addr: []string{
@@ -86,13 +83,12 @@ func TestConnFailover(t *testing.T) {
 		},
 		//	Debug: true,
 	})
-	if assert.NoError(t, err) {
-		if err := conn.Ping(context.Background()); assert.NoError(t, err) {
-			t.Log(conn.ServerVersion())
-			t.Log(conn.Ping(context.Background()))
-		}
-	}
+	require.NoError(t, err)
+	require.NoError(t, conn.Ping(context.Background()))
+	t.Log(conn.ServerVersion())
+	t.Log(conn.Ping(context.Background()))
 }
+
 func TestConnFailoverConnOpenRoundRobin(t *testing.T) {
 	conn, err := clickhouse.Open(&clickhouse.Options{
 		Addr: []string{
@@ -111,13 +107,12 @@ func TestConnFailoverConnOpenRoundRobin(t *testing.T) {
 		ConnOpenStrategy: clickhouse.ConnOpenRoundRobin,
 		//	Debug: true,
 	})
-	if assert.NoError(t, err) {
-		if err := conn.Ping(context.Background()); assert.NoError(t, err) {
-			t.Log(conn.ServerVersion())
-			t.Log(conn.Ping(context.Background()))
-		}
-	}
+	require.NoError(t, err)
+	require.NoError(t, conn.Ping(context.Background()))
+	t.Log(conn.ServerVersion())
+	t.Log(conn.Ping(context.Background()))
 }
+
 func TestPingDeadline(t *testing.T) {
 	conn, err := clickhouse.Open(&clickhouse.Options{
 		Addr: []string{"127.0.0.1:9000"},
@@ -129,13 +124,50 @@ func TestPingDeadline(t *testing.T) {
 		Compression: &clickhouse.Compression{
 			Method: clickhouse.CompressionLZ4,
 		},
-		//Debug: true,
 	})
-	if assert.NoError(t, err) {
-		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
-		defer cancel()
-		if err := conn.Ping(ctx); assert.Error(t, err) {
-			assert.Equal(t, err, context.DeadlineExceeded)
-		}
-	}
+	require.NoError(t, err)
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	err = conn.Ping(ctx)
+	require.Error(t, err)
+	assert.Equal(t, context.DeadlineExceeded, err)
+}
+
+func TestReadDeadline(t *testing.T) {
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Addr: []string{"127.0.0.1:9000"},
+		Auth: clickhouse.Auth{
+			Database: "default",
+			Username: "default",
+			Password: "",
+		},
+		Compression: &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		},
+		ReadTimeout: time.Duration(-1) * time.Second,
+	})
+	require.NoError(t, err)
+	err = conn.Ping(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, os.ErrDeadlineExceeded)
+}
+
+func TestQueryDeadline(t *testing.T) {
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Addr: []string{"127.0.0.1:9000"},
+		Auth: clickhouse.Auth{
+			Database: "default",
+			Username: "default",
+			Password: "",
+		},
+		Compression: &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		},
+		ReadTimeout: time.Duration(-1) * time.Second,
+	})
+	require.NoError(t, err)
+	var count uint64
+	err = conn.QueryRow(context.Background(), "SELECT count() FROM numbers(10000000)").Scan(&count)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, os.ErrDeadlineExceeded)
 }


### PR DESCRIPTION
We now respect `ReadTimeout` in native.

Closes https://github.com/ClickHouse/clickhouse-go/issues/676

Note we align the ReadTimeout with the[ ClickHouse default of 300s](https://clickhouse.com/docs/en/operations/settings/settings/#connect-timeout-receive-timeout-send-timeout).

We should increase dial timeout to 10s as well.

This could be considered a breaking change - since current behaviour is no timeout. I think this is risky however - and could be considered poor implementation.