### PR TITLE
Flush support

### DIFF
--- a/conn_batch.go
+++ b/conn_batch.go
@@ -70,7 +70,6 @@ type batch struct {
 	ctx       context.Context
 	conn      *connect
 	sent      bool
-	flushed   bool
 	block     *proto.Block
 	release   func(error)
 	onProcess *onProcess
@@ -156,9 +155,6 @@ func (b *batch) Send() (err error) {
 }
 
 func (b *batch) Flush() error {
-	defer func() {
-		b.flushed = true
-	}()
 	if b.sent {
 		return ErrBatchAlreadySent
 	}

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -195,4 +195,8 @@ func (b *httpBatch) Send() (err error) {
 	return err
 }
 
+func (b *httpBatch) Flush() error {
+	return nil
+}
+
 var _ driver.Batch = (*httpBatch)(nil)

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -87,7 +87,7 @@ type httpBatch struct {
 	block     *proto.Block
 }
 
-// Flush TODO: noop on http currently - requires streaming
+// Flush TODO: noop on http currently - requires streaming to be implemented
 func (b *httpBatch) Flush() error {
 	return nil
 }

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -87,6 +87,11 @@ type httpBatch struct {
 	block     *proto.Block
 }
 
+// Flush TODO: noop on http currently - requires streaming
+func (b *httpBatch) Flush() error {
+	return nil
+}
+
 func (b *httpBatch) Abort() error {
 	defer func() {
 		b.sent = true
@@ -193,10 +198,6 @@ func (b *httpBatch) Send() (err error) {
 	}
 
 	return err
-}
-
-func (b *httpBatch) Flush() error {
-	return nil
 }
 
 var _ driver.Batch = (*httpBatch)(nil)

--- a/lib/column/array.go
+++ b/lib/column/array.go
@@ -38,6 +38,13 @@ type Array struct {
 	name     string
 }
 
+func (col *Array) Reset() {
+	col.values.Reset()
+	for i := range col.offsets {
+		col.offsets[i].values.Reset()
+	}
+}
+
 func (col *Array) Name() string {
 	return col.name
 }

--- a/lib/column/bigint.go
+++ b/lib/column/bigint.go
@@ -33,6 +33,10 @@ type BigInt struct {
 	col    proto.Column
 }
 
+func (col *BigInt) Reset() {
+	col.col.Reset()
+}
+
 func (col *BigInt) Name() string {
 	return col.name
 }

--- a/lib/column/bool.go
+++ b/lib/column/bool.go
@@ -29,6 +29,10 @@ type Bool struct {
 	name string
 }
 
+func (col *Bool) Reset() {
+	col.col.Reset()
+}
+
 func (col *Bool) Name() string {
 	return col.name
 }

--- a/lib/column/codegen/column.tpl
+++ b/lib/column/codegen/column.tpl
@@ -229,6 +229,15 @@ func (col *{{ .ChType }}) ScanRow(dest interface{}, row int) error {
 	case *sql.Null{{ .ChType }}:
 		d.Scan(value)
 	{{- end }}
+    {{- if eq .ChType "Int8" }}
+	case *bool:
+		switch value {
+		case 0:
+			*d = false
+		default:
+			*d = true
+		}
+    {{- end }}
 	default:
 		return &ColumnConverterError{
 			Op:   "ScanRow",
@@ -280,6 +289,26 @@ func (col *{{ .ChType }}) Append(v interface{}) (nulls []uint8,err error) {
             }
             col.AppendRow(v[i])
         }
+	{{- end }}
+	{{- if eq .ChType "Int8" }}
+	case []bool:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			val := int8(0)
+			if v[i] {
+				val = 1
+			}
+			col.col.Append(val)
+		}
+	case []*bool:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			val := int8(0)
+			if *v[i] {
+				val = 1
+			}
+			col.col.Append(val)
+		}
 	{{- end }}
 	default:
 		return nil, &ColumnConverterError{
@@ -333,6 +362,20 @@ func (col *{{ .ChType }}) AppendRow(v interface{}) error {
         col.col.Append(int64(v))
     case *time.Duration:
         col.col.Append(int64(*v))
+	{{- end }}
+	{{- if eq .ChType "Int8" }}
+    case bool:
+        val := int8(0)
+        if v {
+            val = 1
+        }
+        col.col.Append(val)
+    case *bool:
+        val := int8(0)
+        if *v {
+            val = 1
+        }
+        col.col.Append(val)
 	{{- end }}
 	default:
 		return &ColumnConverterError{

--- a/lib/column/codegen/column.tpl
+++ b/lib/column/codegen/column.tpl
@@ -209,6 +209,10 @@ func (col *{{ .ChType }}) Rows() int {
 	return col.col.Rows()
 }
 
+func (col *{{ .ChType }}) Reset() {
+    col.col.Reset()
+}
+
 func (col *{{ .ChType }}) ScanRow(dest interface{}, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {

--- a/lib/column/column.go
+++ b/lib/column/column.go
@@ -85,6 +85,7 @@ type Interface interface {
 	Decode(reader *proto.Reader, rows int) error
 	Encode(buffer *proto.Buffer)
 	ScanType() reflect.Type
+	Reset()
 }
 
 type CustomSerialization interface {

--- a/lib/column/column_gen.go
+++ b/lib/column/column_gen.go
@@ -525,6 +525,13 @@ func (col *Int8) ScanRow(dest interface{}, row int) error {
 	case **int8:
 		*d = new(int8)
 		**d = value
+	case *bool:
+		switch value {
+		case 0:
+			*d = false
+		default:
+			*d = true
+		}
 	default:
 		return &ColumnConverterError{
 			Op:   "ScanRow",
@@ -562,6 +569,24 @@ func (col *Int8) Append(v interface{}) (nulls []uint8, err error) {
 				nulls[i] = 1
 			}
 		}
+	case []bool:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			val := int8(0)
+			if v[i] {
+				val = 1
+			}
+			col.col.Append(val)
+		}
+	case []*bool:
+		nulls = make([]uint8, len(v))
+		for i := range v {
+			val := int8(0)
+			if *v[i] {
+				val = 1
+			}
+			col.col.Append(val)
+		}
 	default:
 		return nil, &ColumnConverterError{
 			Op:   "Append",
@@ -585,6 +610,18 @@ func (col *Int8) AppendRow(v interface{}) error {
 		}
 	case nil:
 		col.col.Append(0)
+	case bool:
+		val := int8(0)
+		if v {
+			val = 1
+		}
+		col.col.Append(val)
+	case *bool:
+		val := int8(0)
+		if *v {
+			val = 1
+		}
+		col.col.Append(val)
 	default:
 		return &ColumnConverterError{
 			Op:   "AppendRow",

--- a/lib/column/column_gen.go
+++ b/lib/column/column_gen.go
@@ -272,6 +272,10 @@ func (col *Float32) Rows() int {
 	return col.col.Rows()
 }
 
+func (col *Float32) Reset() {
+	col.col.Reset()
+}
+
 func (col *Float32) ScanRow(dest interface{}, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
@@ -372,6 +376,10 @@ func (col *Float64) ScanType() reflect.Type {
 
 func (col *Float64) Rows() int {
 	return col.col.Rows()
+}
+
+func (col *Float64) Reset() {
+	col.col.Reset()
 }
 
 func (col *Float64) ScanRow(dest interface{}, row int) error {
@@ -505,6 +513,10 @@ func (col *Int8) Rows() int {
 	return col.col.Rows()
 }
 
+func (col *Int8) Reset() {
+	col.col.Reset()
+}
+
 func (col *Int8) ScanRow(dest interface{}, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
@@ -605,6 +617,10 @@ func (col *Int16) ScanType() reflect.Type {
 
 func (col *Int16) Rows() int {
 	return col.col.Rows()
+}
+
+func (col *Int16) Reset() {
+	col.col.Reset()
 }
 
 func (col *Int16) ScanRow(dest interface{}, row int) error {
@@ -738,6 +754,10 @@ func (col *Int32) Rows() int {
 	return col.col.Rows()
 }
 
+func (col *Int32) Reset() {
+	col.col.Reset()
+}
+
 func (col *Int32) ScanRow(dest interface{}, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
@@ -867,6 +887,10 @@ func (col *Int64) ScanType() reflect.Type {
 
 func (col *Int64) Rows() int {
 	return col.col.Rows()
+}
+
+func (col *Int64) Reset() {
+	col.col.Reset()
 }
 
 func (col *Int64) ScanRow(dest interface{}, row int) error {
@@ -1006,6 +1030,10 @@ func (col *UInt8) Rows() int {
 	return col.col.Rows()
 }
 
+func (col *UInt8) Reset() {
+	col.col.Reset()
+}
+
 func (col *UInt8) ScanRow(dest interface{}, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
@@ -1114,6 +1142,10 @@ func (col *UInt16) Rows() int {
 	return col.col.Rows()
 }
 
+func (col *UInt16) Reset() {
+	col.col.Reset()
+}
+
 func (col *UInt16) ScanRow(dest interface{}, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
@@ -1216,6 +1248,10 @@ func (col *UInt32) Rows() int {
 	return col.col.Rows()
 }
 
+func (col *UInt32) Reset() {
+	col.col.Reset()
+}
+
 func (col *UInt32) ScanRow(dest interface{}, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
@@ -1316,6 +1352,10 @@ func (col *UInt64) ScanType() reflect.Type {
 
 func (col *UInt64) Rows() int {
 	return col.col.Rows()
+}
+
+func (col *UInt64) Reset() {
+	col.col.Reset()
 }
 
 func (col *UInt64) ScanRow(dest interface{}, row int) error {

--- a/lib/column/date.go
+++ b/lib/column/date.go
@@ -35,6 +35,10 @@ type Date struct {
 	name string
 }
 
+func (col *Date) Reset() {
+	col.col.Reset()
+}
+
 func (col *Date) Name() string {
 	return col.name
 }

--- a/lib/column/date32.go
+++ b/lib/column/date32.go
@@ -35,6 +35,10 @@ type Date32 struct {
 	name string
 }
 
+func (col *Date32) Reset() {
+	col.col.Reset()
+}
+
 func (col *Date32) Name() string {
 	return col.name
 }

--- a/lib/column/datetime.go
+++ b/lib/column/datetime.go
@@ -39,6 +39,10 @@ type DateTime struct {
 	col    proto.ColDateTime
 }
 
+func (col *DateTime) Reset() {
+	col.col.Reset()
+}
+
 func (col *DateTime) Name() string {
 	return col.name
 }

--- a/lib/column/datetime64.go
+++ b/lib/column/datetime64.go
@@ -42,6 +42,10 @@ type DateTime64 struct {
 	col      proto.ColDateTime64
 }
 
+func (col *DateTime64) Reset() {
+	col.col.Reset()
+}
+
 func (col *DateTime64) Name() string {
 	return col.name
 }

--- a/lib/column/decimal.go
+++ b/lib/column/decimal.go
@@ -42,6 +42,10 @@ func (col *Decimal) Name() string {
 	return col.name
 }
 
+func (col *Decimal) Reset() {
+	col.col.Reset()
+}
+
 func (col *Decimal) parse(t Type) (_ *Decimal, err error) {
 	col.chType = t
 	params := strings.Split(t.params(), ",")

--- a/lib/column/enum16.go
+++ b/lib/column/enum16.go
@@ -31,6 +31,10 @@ type Enum16 struct {
 	name   string
 }
 
+func (col *Enum16) Reset() {
+	col.col.Reset()
+}
+
 func (col *Enum16) Name() string {
 	return col.name
 }

--- a/lib/column/enum8.go
+++ b/lib/column/enum8.go
@@ -31,6 +31,10 @@ type Enum8 struct {
 	col    proto.ColEnum8
 }
 
+func (col *Enum8) Reset() {
+	col.col.Reset()
+}
+
 func (col *Enum8) Name() string {
 	return col.name
 }

--- a/lib/column/fixed_string.go
+++ b/lib/column/fixed_string.go
@@ -31,6 +31,10 @@ type FixedString struct {
 	col  proto.ColFixedStr
 }
 
+func (col *FixedString) Reset() {
+	col.col.Reset()
+}
+
 func (col *FixedString) Name() string {
 	return col.name
 }

--- a/lib/column/geo_multi_polygon.go
+++ b/lib/column/geo_multi_polygon.go
@@ -30,6 +30,10 @@ type MultiPolygon struct {
 	name string
 }
 
+func (col *MultiPolygon) Reset() {
+	col.set.Reset()
+}
+
 func (col *MultiPolygon) Name() string {
 	return col.name
 }

--- a/lib/column/geo_point.go
+++ b/lib/column/geo_point.go
@@ -30,6 +30,10 @@ type Point struct {
 	col  proto.ColPoint
 }
 
+func (col *Point) Reset() {
+	col.col.Reset()
+}
+
 func (col *Point) Name() string {
 	return col.name
 }

--- a/lib/column/geo_polygon.go
+++ b/lib/column/geo_polygon.go
@@ -30,6 +30,10 @@ type Polygon struct {
 	name string
 }
 
+func (col *Polygon) Reset() {
+	col.set.Reset()
+}
+
 func (col *Polygon) Name() string {
 	return col.name
 }

--- a/lib/column/geo_ring.go
+++ b/lib/column/geo_ring.go
@@ -30,6 +30,10 @@ type Ring struct {
 	name string
 }
 
+func (col *Ring) Reset() {
+	col.set.Reset()
+}
+
 func (col *Ring) Name() string {
 	return col.name
 }

--- a/lib/column/interval.go
+++ b/lib/column/interval.go
@@ -31,6 +31,10 @@ type Interval struct {
 	col    proto.ColInt64
 }
 
+func (col *Interval) Reset() {
+	col.col.Reset()
+}
+
 func (col *Interval) Name() string {
 	return col.name
 }

--- a/lib/column/ipv4.go
+++ b/lib/column/ipv4.go
@@ -30,6 +30,10 @@ type IPv4 struct {
 	col  proto.ColIPv4
 }
 
+func (col *IPv4) Reset() {
+	col.col.Reset()
+}
+
 func (col *IPv4) Name() string {
 	return col.name
 }

--- a/lib/column/ipv6.go
+++ b/lib/column/ipv6.go
@@ -30,6 +30,10 @@ type IPv6 struct {
 	name string
 }
 
+func (col *IPv6) Reset() {
+	col.col.Reset()
+}
+
 func (col *IPv6) Name() string {
 	return col.name
 }

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -512,6 +512,10 @@ type JSONValue struct {
 	origType reflect.Type
 }
 
+func (jCol *JSONValue) Reset() {
+	jCol.Interface.Reset()
+}
+
 func (jCol *JSONValue) appendEmptyValue() error {
 	switch jCol.Interface.(type) {
 	case *Array:
@@ -681,6 +685,12 @@ type JSONObject struct {
 	name     string
 	root     bool
 	encoding uint8
+}
+
+func (jCol *JSONObject) Reset() {
+	for i := range jCol.columns {
+		jCol.columns[i].Reset()
+	}
 }
 
 func (jCol *JSONObject) Name() string {

--- a/lib/column/lowcardinality.go
+++ b/lib/column/lowcardinality.go
@@ -69,6 +69,17 @@ type LowCardinality struct {
 	name string
 }
 
+func (col *LowCardinality) Reset() {
+	col.rows = 0
+	col.index.Reset()
+	col.keys8.Reset()
+	col.keys16.Reset()
+	col.keys32.Reset()
+	col.keys64.Reset()
+	col.append.index = make(map[interface{}]int)
+	col.append.keys = col.append.keys[:0]
+}
+
 func (col *LowCardinality) Name() string {
 	return col.name
 }

--- a/lib/column/map.go
+++ b/lib/column/map.go
@@ -34,6 +34,12 @@ type Map struct {
 	name     string
 }
 
+func (col *Map) Reset() {
+	col.keys.Reset()
+	col.values.Reset()
+	col.offsets.Reset()
+}
+
 func (col *Map) Name() string {
 	return col.name
 }

--- a/lib/column/nested.go
+++ b/lib/column/nested.go
@@ -27,6 +27,10 @@ type Nested struct {
 	name string
 }
 
+func (col *Nested) Reset() {
+	col.Interface.Reset()
+}
+
 func asDDL(cols []namedCol) string {
 	sCols := make([]string, len(cols), len(cols))
 	for i := range cols {

--- a/lib/column/nothing.go
+++ b/lib/column/nothing.go
@@ -28,6 +28,10 @@ type Nothing struct {
 	col  proto.ColNothing
 }
 
+func (col *Nothing) Reset() {
+	col.col.Reset()
+}
+
 func (col Nothing) Name() string {
 	return col.name
 }

--- a/lib/column/nullable.go
+++ b/lib/column/nullable.go
@@ -32,6 +32,11 @@ type Nullable struct {
 	name     string
 }
 
+func (col *Nullable) Reset() {
+	col.base.Reset()
+	col.nulls.Reset()
+}
+
 func (col *Nullable) Name() string {
 	return col.name
 }

--- a/lib/column/simple_aggregate_function.go
+++ b/lib/column/simple_aggregate_function.go
@@ -29,6 +29,10 @@ type SimpleAggregateFunction struct {
 	name   string
 }
 
+func (col *SimpleAggregateFunction) Reset() {
+	col.base.Reset()
+}
+
 func (col *SimpleAggregateFunction) Name() string {
 	return col.name
 }

--- a/lib/column/string.go
+++ b/lib/column/string.go
@@ -31,6 +31,10 @@ type String struct {
 	col  proto.ColStr
 }
 
+func (col *String) Reset() {
+	col.col.Reset()
+}
+
 func (col String) Name() string {
 	return col.name
 }

--- a/lib/column/tuple.go
+++ b/lib/column/tuple.go
@@ -33,7 +33,13 @@ type Tuple struct {
 	columns []Interface
 	name    string
 	isNamed bool           // true if all columns are named
-	index   map[string]int // map from col name to off set in columns
+	index   map[string]int // map from col name to offset in columns
+}
+
+func (col *Tuple) Reset() {
+	for i := range col.columns {
+		col.columns[i].Reset()
+	}
 }
 
 func (col *Tuple) Name() string {

--- a/lib/column/uuid.go
+++ b/lib/column/uuid.go
@@ -30,6 +30,10 @@ type UUID struct {
 	name string
 }
 
+func (col *UUID) Reset() {
+	col.col.Reset()
+}
+
 func (col *UUID) Name() string {
 	return col.name
 }

--- a/lib/driver/driver.go
+++ b/lib/driver/driver.go
@@ -81,6 +81,7 @@ type (
 		Append(v ...interface{}) error
 		AppendStruct(v interface{}) error
 		Column(int) BatchColumn
+		Flush() error
 		Send() error
 		IsSent() bool
 	}

--- a/lib/proto/block.go
+++ b/lib/proto/block.go
@@ -79,10 +79,11 @@ func (b *Block) Encode(buffer *proto.Buffer, revision uint64) error {
 	if len(b.Columns) != 0 {
 		rows = b.Columns[0].Rows()
 		for _, c := range b.Columns[1:] {
-			if rows != c.Rows() {
+			cRows := c.Rows()
+			if rows != cRows {
 				return &BlockError{
 					Op:  "Encode",
-					Err: errors.New("mismatched len of columns"),
+					Err: fmt.Errorf("mismatched len of columns - expected %d, recieved %d for col %s", rows, cRows, c.Name()),
 				}
 			}
 		}
@@ -165,6 +166,12 @@ func (b *Block) Decode(reader *proto.Reader, revision uint64) (err error) {
 		b.names, b.Columns = append(b.names, columnName), append(b.Columns, c)
 	}
 	return nil
+}
+
+func (b *Block) Reset() {
+	for i := range b.Columns {
+		b.Columns[i].Reset()
+	}
 }
 
 func encodeBlockInfo(buffer *proto.Buffer) {

--- a/tests/array_test.go
+++ b/tests/array_test.go
@@ -43,43 +43,38 @@ func TestSimpleArray(t *testing.T) {
 			MaxOpenConns: 1,
 		})
 	)
-	if assert.NoError(t, err) {
-		const ddl = `
+	require.NoError(t, err)
+	const ddl = `
 		CREATE TABLE test_array (
 			  Col1 Array(String)
 		) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_array")
-		}()
-		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
-			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_array"); assert.NoError(t, err) {
-				var (
-					col1Data = []string{"A", "b", "c"}
-				)
-				for i := 0; i < 10; i++ {
-					if err := batch.Append(col1Data); !assert.NoError(t, err) {
-						return
-					}
-				}
-				if assert.NoError(t, batch.Send()) {
-					if rows, err := conn.Query(ctx, "SELECT * FROM test_array"); assert.NoError(t, err) {
-						for rows.Next() {
-							var (
-								col1 []string
-							)
-							if err := rows.Scan(&col1); assert.NoError(t, err) {
-								assert.Equal(t, col1Data, col1)
-							}
-						}
-						if assert.NoError(t, rows.Close()) {
-							assert.NoError(t, rows.Err())
-						}
-					}
-				}
-			}
-		}
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_array")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_array")
+	require.NoError(t, err)
+	var (
+		col1Data = []string{"A", "b", "c"}
+	)
+	for i := 0; i < 10; i++ {
+		require.NoError(t, batch.Append(col1Data))
+		batch.Flush()
 	}
+	require.NoError(t, batch.Send())
+	rows, err := conn.Query(ctx, "SELECT * FROM test_array")
+	require.NoError(t, err)
+	for rows.Next() {
+		var (
+			col1 []string
+		)
+		require.NoError(t, rows.Scan(&col1))
+		assert.Equal(t, col1Data, col1)
+
+	}
+	require.NoError(t, rows.Close())
+	require.NoError(t, rows.Err())
 }
 
 func TestInterfaceArray(t *testing.T) {
@@ -193,31 +188,28 @@ func TestArray(t *testing.T) {
 					col4Data = &[]string{"M", "D"}
 				)
 				for i := 0; i < 10; i++ {
-					if err := batch.Append(col1Data, col2Data, col3Data, col4Data); !assert.NoError(t, err) {
-						return
-					}
+					require.NoError(t, batch.Append(col1Data, col2Data, col3Data, col4Data))
+					batch.Flush()
 				}
-				if assert.NoError(t, batch.Send()) {
-					if rows, err := conn.Query(ctx, "SELECT * FROM test_array"); assert.NoError(t, err) {
-						for rows.Next() {
-							var (
-								col1 []string
-								col2 [][]uint32
-								col3 [][][]time.Time
-								col4 []string
-							)
-							if err := rows.Scan(&col1, &col2, &col3, &col4); assert.NoError(t, err) {
-								assert.Equal(t, col1Data, col1)
-								assert.Equal(t, col2Data, col2)
-								assert.Equal(t, col3Data, col3)
-								assert.Equal(t, col4Data, &col4)
-							}
-						}
-						if assert.NoError(t, rows.Close()) {
-							assert.NoError(t, rows.Err())
-						}
-					}
+				require.NoError(t, batch.Send())
+				rows, err := conn.Query(ctx, "SELECT * FROM test_array")
+				require.NoError(t, err)
+				for rows.Next() {
+					var (
+						col1 []string
+						col2 [][]uint32
+						col3 [][][]time.Time
+						col4 []string
+					)
+					require.NoError(t, rows.Scan(&col1, &col2, &col3, &col4))
+					assert.Equal(t, col1Data, col1)
+					assert.Equal(t, col2Data, col2)
+					assert.Equal(t, col3Data, col3)
+					assert.Equal(t, col4Data, &col4)
+
 				}
+				require.NoError(t, rows.Close())
+				require.NoError(t, rows.Err())
 			}
 		}
 	}

--- a/tests/bigint_test.go
+++ b/tests/bigint_test.go
@@ -43,32 +43,32 @@ func TestSimpleBigInt(t *testing.T) {
 			MaxOpenConns: 1,
 		})
 	)
-	if assert.NoError(t, err) {
-		if err := CheckMinServerVersion(conn, 21, 12, 0); err != nil {
-			t.Skip(err.Error())
-			return
-		}
-		const ddl = `
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 21, 12, 0); err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	const ddl = `
 		CREATE TABLE test_bigint (
 			  Col1 Int128
 		) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_bigint")
-		}()
-		require.NoError(t, conn.Exec(ctx, ddl))
-		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_bigint")
-		require.NoError(t, err)
-		col1Data, ok := new(big.Int).SetString("170141183460469231731687303715884105727", 10)
-		require.True(t, ok)
-		require.NoError(t, batch.Append(col1Data))
-		require.NoError(t, batch.Send())
-		var (
-			col1 big.Int
-		)
-		require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_bigint").Scan(&col1))
-		assert.Equal(t, *col1Data, col1)
-	}
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_bigint")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_bigint")
+	require.NoError(t, err)
+	col1Data, ok := new(big.Int).SetString("170141183460469231731687303715884105727", 10)
+	require.True(t, ok)
+	require.NoError(t, batch.Append(col1Data))
+	require.NoError(t, batch.Send())
+	var (
+		col1 big.Int
+	)
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_bigint").Scan(&col1))
+	assert.Equal(t, *col1Data, col1)
+
 }
 
 func TestBigInt(t *testing.T) {
@@ -87,12 +87,12 @@ func TestBigInt(t *testing.T) {
 			MaxOpenConns: 1,
 		})
 	)
-	if assert.NoError(t, err) {
-		if err := CheckMinServerVersion(conn, 21, 12, 0); err != nil {
-			t.Skip(err.Error())
-			return
-		}
-		const ddl = `
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 21, 12, 0); err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	const ddl = `
 		CREATE TABLE test_bigint (
 			  Col1 Int128
 			, Col2 UInt128
@@ -103,59 +103,53 @@ func TestBigInt(t *testing.T) {
 			, Col7 Array(UInt256)
 		) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_bigint")
-		}()
-
-		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
-			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_bigint"); assert.NoError(t, err) {
-				col1Data, ok := new(big.Int).SetString("170141183460469231731687303715884105727", 10)
-				require.True(t, ok)
-				var (
-					col2Data = big.NewInt(128)
-					col3Data = []*big.Int{
-						big.NewInt(-128),
-						big.NewInt(128128),
-						big.NewInt(128128128),
-					}
-					col4Data = big.NewInt(256)
-					col5Data = []*big.Int{
-						big.NewInt(256),
-						big.NewInt(256256),
-						big.NewInt(256256256256),
-					}
-					col6Data = big.NewInt(256)
-					col7Data = []*big.Int{
-						big.NewInt(256),
-						big.NewInt(256256),
-						big.NewInt(256256256256),
-					}
-				)
-				if err := batch.Append(col1Data, col2Data, col3Data, col4Data, col5Data, col6Data, col7Data); assert.NoError(t, err) {
-					if err := batch.Send(); assert.NoError(t, err) {
-						var (
-							col1 big.Int
-							col2 big.Int
-							col3 []*big.Int
-							col4 big.Int
-							col5 []*big.Int
-							col6 big.Int
-							col7 []*big.Int
-						)
-						if err := conn.QueryRow(ctx, "SELECT * FROM test_bigint").Scan(&col1, &col2, &col3, &col4, &col5, &col6, &col7); assert.NoError(t, err) {
-							assert.Equal(t, *col1Data, col1)
-							assert.Equal(t, *col2Data, col2)
-							assert.Equal(t, col3Data, col3)
-							assert.Equal(t, *col4Data, col4)
-							assert.Equal(t, col5Data, col5)
-							assert.Equal(t, *col6Data, col6)
-							assert.Equal(t, col7Data, col7)
-						}
-					}
-				}
-			}
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_bigint")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_bigint")
+	require.NoError(t, err)
+	col1Data, ok := new(big.Int).SetString("170141183460469231731687303715884105727", 10)
+	require.True(t, ok)
+	var (
+		col2Data = big.NewInt(128)
+		col3Data = []*big.Int{
+			big.NewInt(-128),
+			big.NewInt(128128),
+			big.NewInt(128128128),
 		}
-	}
+		col4Data = big.NewInt(256)
+		col5Data = []*big.Int{
+			big.NewInt(256),
+			big.NewInt(256256),
+			big.NewInt(256256256256),
+		}
+		col6Data = big.NewInt(256)
+		col7Data = []*big.Int{
+			big.NewInt(256),
+			big.NewInt(256256),
+			big.NewInt(256256256256),
+		}
+	)
+	require.NoError(t, batch.Append(col1Data, col2Data, col3Data, col4Data, col5Data, col6Data, col7Data))
+	require.NoError(t, batch.Send())
+	var (
+		col1 big.Int
+		col2 big.Int
+		col3 []*big.Int
+		col4 big.Int
+		col5 []*big.Int
+		col6 big.Int
+		col7 []*big.Int
+	)
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_bigint").Scan(&col1, &col2, &col3, &col4, &col5, &col6, &col7))
+	assert.Equal(t, *col1Data, col1)
+	assert.Equal(t, *col2Data, col2)
+	assert.Equal(t, col3Data, col3)
+	assert.Equal(t, *col4Data, col4)
+	assert.Equal(t, col5Data, col5)
+	assert.Equal(t, *col6Data, col6)
+	assert.Equal(t, col7Data, col7)
 }
 
 func TestNullableBigInt(t *testing.T) {
@@ -174,12 +168,12 @@ func TestNullableBigInt(t *testing.T) {
 			MaxOpenConns: 1,
 		})
 	)
-	if assert.NoError(t, err) {
-		if err := CheckMinServerVersion(conn, 21, 12, 0); err != nil {
-			t.Skip(err.Error())
-			return
-		}
-		const ddl = `
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 21, 12, 0); err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	const ddl = `
 		CREATE TABLE test_nullable_bigint (
 			  Col1 Nullable(Int128)
 			, Col2 Array(Nullable(Int128))
@@ -189,54 +183,49 @@ func TestNullableBigInt(t *testing.T) {
 			, Col6 Array(Nullable(UInt256))
 		) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_nullable_bigint")
-		}()
-		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
-			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_nullable_bigint"); assert.NoError(t, err) {
-				var (
-					col1Data = big.NewInt(128)
-					col2Data = []*big.Int{
-						big.NewInt(-128),
-						big.NewInt(128128),
-						big.NewInt(128128128),
-					}
-					col3Data = big.NewInt(256)
-					col4Data = []*big.Int{
-						big.NewInt(256),
-						nil,
-						big.NewInt(256256256256),
-					}
-					col5Data = big.NewInt(256)
-					col6Data = []*big.Int{
-						big.NewInt(256),
-						big.NewInt(256256),
-						big.NewInt(256256256256),
-					}
-				)
-				if err := batch.Append(col1Data, col2Data, col3Data, col4Data, col5Data, col6Data); assert.NoError(t, err) {
-					if err := batch.Send(); assert.NoError(t, err) {
-						var (
-							col1 *big.Int
-							col2 []*big.Int
-							col3 *big.Int
-							col4 []*big.Int
-							col5 *big.Int
-							col6 []*big.Int
-						)
-						if err := conn.QueryRow(ctx, "SELECT * FROM test_nullable_bigint").Scan(&col1, &col2, &col3, &col4, &col5, &col6); assert.NoError(t, err) {
-							assert.Equal(t, *col1Data, *col1)
-							assert.Equal(t, col2Data, col2)
-							assert.Equal(t, *col3Data, *col3)
-							assert.Equal(t, col4Data, col4)
-							assert.Equal(t, *col5Data, *col5)
-							assert.Equal(t, col6Data, col6)
-						}
-					}
-				}
-			}
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_nullable_bigint")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_nullable_bigint")
+	require.NoError(t, err)
+	var (
+		col1Data = big.NewInt(128)
+		col2Data = []*big.Int{
+			big.NewInt(-128),
+			big.NewInt(128128),
+			big.NewInt(128128128),
 		}
-	}
+		col3Data = big.NewInt(256)
+		col4Data = []*big.Int{
+			big.NewInt(256),
+			nil,
+			big.NewInt(256256256256),
+		}
+		col5Data = big.NewInt(256)
+		col6Data = []*big.Int{
+			big.NewInt(256),
+			big.NewInt(256256),
+			big.NewInt(256256256256),
+		}
+	)
+	require.NoError(t, batch.Append(col1Data, col2Data, col3Data, col4Data, col5Data, col6Data))
+	require.NoError(t, batch.Send())
+	var (
+		col1 *big.Int
+		col2 []*big.Int
+		col3 *big.Int
+		col4 []*big.Int
+		col5 *big.Int
+		col6 []*big.Int
+	)
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_nullable_bigint").Scan(&col1, &col2, &col3, &col4, &col5, &col6))
+	assert.Equal(t, *col1Data, *col1)
+	assert.Equal(t, col2Data, col2)
+	assert.Equal(t, *col3Data, *col3)
+	assert.Equal(t, col4Data, col4)
+	assert.Equal(t, *col5Data, *col5)
+	assert.Equal(t, col6Data, col6)
 }
 
 func TestBigIntUIntOverflow(t *testing.T) {
@@ -255,8 +244,8 @@ func TestBigIntUIntOverflow(t *testing.T) {
 			MaxOpenConns: 1,
 		})
 	)
-	if assert.NoError(t, err) {
-		const ddl = `
+	require.NoError(t, err)
+	const ddl = `
 		CREATE TABLE test_bigint_uint_overflow (
 			  Col1 UInt128,
 			  Col2 UInt128,
@@ -266,60 +255,102 @@ func TestBigIntUIntOverflow(t *testing.T) {
 			  Col6 Array(UInt256)
 		) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_bigint_uint_overflow")
-		}()
-		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
-			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_bigint_uint_overflow"); assert.NoError(t, err) {
-				bigUint128Val := big.NewInt(0)
-				bigUint128Val.SetString("170141183460469231731687303715884105729", 10)
-				maxUint128Val := big.NewInt(0)
-				maxUint128Val.SetString("340282366920938463463374607431768211455", 10)
-				bigUint256Val := big.NewInt(0)
-				bigUint256Val.SetString("57896044618658097711785492504343953926634992332820282019728792003956564819969", 10)
-				maxUint256Val := big.NewInt(0)
-				maxUint256Val.SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10)
-				var (
-					col1Data = bigUint128Val
-					col2Data = maxUint128Val
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_bigint_uint_overflow")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_bigint_uint_overflow")
+	require.NoError(t, err)
+	bigUint128Val := big.NewInt(0)
+	bigUint128Val.SetString("170141183460469231731687303715884105729", 10)
+	maxUint128Val := big.NewInt(0)
+	maxUint128Val.SetString("340282366920938463463374607431768211455", 10)
+	bigUint256Val := big.NewInt(0)
+	bigUint256Val.SetString("57896044618658097711785492504343953926634992332820282019728792003956564819969", 10)
+	maxUint256Val := big.NewInt(0)
+	maxUint256Val.SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10)
+	var (
+		col1Data = bigUint128Val
+		col2Data = maxUint128Val
 
-					col3Data = []*big.Int{
-						big.NewInt(256),
-						bigUint128Val,
-						maxUint128Val,
-					}
-
-					col4Data = bigUint256Val
-					col5Data = maxUint256Val
-
-					col6Data = []*big.Int{
-						big.NewInt(256),
-						bigUint256Val,
-						maxUint256Val,
-					}
-				)
-
-				if err := batch.Append(col1Data, col2Data, col3Data, col4Data, col5Data, col6Data); assert.NoError(t, err) {
-					if err := batch.Send(); assert.NoError(t, err) {
-						var (
-							col1 big.Int
-							col2 big.Int
-							col3 []*big.Int
-							col4 big.Int
-							col5 big.Int
-							col6 []*big.Int
-						)
-						if err := conn.QueryRow(ctx, "SELECT * FROM test_bigint_uint_overflow").Scan(&col1, &col2, &col3, &col4, &col5, &col6); assert.NoError(t, err) {
-							assert.Equal(t, *col1Data, col1)
-							assert.Equal(t, *col2Data, col2)
-							assert.Equal(t, col3Data, col3)
-							assert.Equal(t, *col4Data, col4)
-							assert.Equal(t, *col5Data, col5)
-							assert.Equal(t, col6Data, col6)
-						}
-					}
-				}
-			}
+		col3Data = []*big.Int{
+			big.NewInt(256),
+			bigUint128Val,
+			maxUint128Val,
 		}
+
+		col4Data = bigUint256Val
+		col5Data = maxUint256Val
+
+		col6Data = []*big.Int{
+			big.NewInt(256),
+			bigUint256Val,
+			maxUint256Val,
+		}
+	)
+	require.NoError(t, batch.Append(col1Data, col2Data, col3Data, col4Data, col5Data, col6Data))
+	require.NoError(t, batch.Send())
+	var (
+		col1 big.Int
+		col2 big.Int
+		col3 []*big.Int
+		col4 big.Int
+		col5 big.Int
+		col6 []*big.Int
+	)
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_bigint_uint_overflow").Scan(&col1, &col2, &col3, &col4, &col5, &col6))
+	assert.Equal(t, *col1Data, col1)
+	assert.Equal(t, *col2Data, col2)
+	assert.Equal(t, col3Data, col3)
+	assert.Equal(t, *col4Data, col4)
+	assert.Equal(t, *col5Data, col5)
+	assert.Equal(t, col6Data, col6)
+}
+
+func TestBigIntFlush(t *testing.T) {
+	var (
+		ctx       = context.Background()
+		conn, err = clickhouse.Open(&clickhouse.Options{
+			Addr: []string{"127.0.0.1:9000"},
+			Auth: clickhouse.Auth{
+				Database: "default",
+				Username: "default",
+				Password: "",
+			},
+			Compression: &clickhouse.Compression{
+				Method: clickhouse.CompressionLZ4,
+			},
+			MaxOpenConns: 1,
+		})
+	)
+	require.NoError(t, err)
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE big_int_flush")
+	}()
+	const ddl = `
+		CREATE TABLE big_int_flush (
+			  Col1 UInt128
+		) Engine Memory
+		`
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO big_int_flush")
+	require.NoError(t, err)
+	vals := [1000]*big.Int{}
+	for i := 0; i < 1000; i++ {
+		bigUint128Val := big.NewInt(0)
+		bigUint128Val.SetString(RandIntString(20), 10)
+		vals[i] = bigUint128Val
+		batch.Append(vals[i])
+		batch.Flush()
+	}
+	batch.Send()
+	rows, err := conn.Query(ctx, "SELECT * FROM big_int_flush")
+	require.NoError(t, err)
+	i := 0
+	for rows.Next() {
+		var col1 big.Int
+		require.NoError(t, rows.Scan(&col1))
+		assert.Equal(t, *vals[i], col1)
+		i += 1
 	}
 }

--- a/tests/bool_test.go
+++ b/tests/bool_test.go
@@ -230,8 +230,8 @@ func TestBoolFlush(t *testing.T) {
 
 	for i := 0; i < 1000; i++ {
 		vals[i] = r.Intn(2) != 0
-		batch.Append(vals[i])
-		batch.Flush()
+		require.NoError(t, batch.Append(vals[i]))
+		require.NoError(t, batch.Flush())
 	}
 	batch.Send()
 	rows, err := conn.Query(ctx, "SELECT * FROM bool_flush")

--- a/tests/bool_test.go
+++ b/tests/bool_test.go
@@ -20,11 +20,12 @@ package tests
 import (
 	"context"
 	"database/sql"
-	"github.com/stretchr/testify/require"
-	"testing"
-
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"testing"
+	"time"
 )
 
 func TestBool(t *testing.T) {
@@ -192,5 +193,54 @@ func TestColumnarBool(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func TestBoolFlush(t *testing.T) {
+	var (
+		ctx       = context.Background()
+		conn, err = clickhouse.Open(&clickhouse.Options{
+			Addr: []string{"127.0.0.1:9000"},
+			Auth: clickhouse.Auth{
+				Database: "default",
+				Username: "default",
+				Password: "",
+			},
+			Compression: &clickhouse.Compression{
+				Method: clickhouse.CompressionLZ4,
+			},
+			MaxOpenConns: 1,
+		})
+	)
+	require.NoError(t, err)
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE bool_flush")
+	}()
+	const ddl = `
+		CREATE TABLE bool_flush (
+			  Col1 Bool
+		) Engine Memory
+		`
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO bool_flush")
+	require.NoError(t, err)
+	vals := [1000]bool{}
+	var src = rand.NewSource(time.Now().UnixNano())
+	var r = rand.New(src)
+
+	for i := 0; i < 1000; i++ {
+		vals[i] = r.Intn(2) != 0
+		batch.Append(vals[i])
+		batch.Flush()
+	}
+	batch.Send()
+	rows, err := conn.Query(ctx, "SELECT * FROM bool_flush")
+	require.NoError(t, err)
+	i := 0
+	for rows.Next() {
+		var col1 bool
+		require.NoError(t, rows.Scan(&col1))
+		assert.Equal(t, vals[i], col1)
+		i += 1
 	}
 }

--- a/tests/column_types_test.go
+++ b/tests/column_types_test.go
@@ -19,6 +19,7 @@ package tests
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
 	"reflect"
 	"testing"
 
@@ -39,7 +40,6 @@ func TestColumnTypes(t *testing.T) {
 			Compression: &clickhouse.Compression{
 				Method: clickhouse.CompressionLZ4,
 			},
-			//Debug: true,
 		})
 	)
 	const query = `
@@ -47,27 +47,28 @@ func TestColumnTypes(t *testing.T) {
 			  CAST(1   AS UInt8)  AS Col1
 			, CAST('X' AS String) AS Col2
 	`
-	if assert.NoError(t, err) {
-		if rows, err := conn.Query(ctx, query); assert.NoError(t, err) {
-			if types := rows.ColumnTypes(); assert.Len(t, types, 2) {
-				for i, v := range types {
-					switch i {
-					case 0:
-						if assert.False(t, v.Nullable()) {
-							assert.Equal(t, "Col1", v.Name())
-							assert.Equal(t, reflect.TypeOf(uint8(0)), v.ScanType())
-							assert.Equal(t, "UInt8", v.DatabaseTypeName())
-						}
-					case 1:
-						if assert.False(t, v.Nullable()) {
-							assert.Equal(t, "Col2", v.Name())
-							assert.Equal(t, reflect.TypeOf(""), v.ScanType())
-							assert.Equal(t, "String", v.DatabaseTypeName())
-						}
 
-					}
+	require.NoError(t, err)
+	rows, err := conn.Query(ctx, query)
+	require.NoError(t, err)
+	if types := rows.ColumnTypes(); assert.Len(t, types, 2) {
+		for i, v := range types {
+			switch i {
+			case 0:
+				if assert.False(t, v.Nullable()) {
+					assert.Equal(t, "Col1", v.Name())
+					assert.Equal(t, reflect.TypeOf(uint8(0)), v.ScanType())
+					assert.Equal(t, "UInt8", v.DatabaseTypeName())
 				}
+			case 1:
+				if assert.False(t, v.Nullable()) {
+					assert.Equal(t, "Col2", v.Name())
+					assert.Equal(t, reflect.TypeOf(""), v.ScanType())
+					assert.Equal(t, "String", v.DatabaseTypeName())
+				}
+
 			}
 		}
 	}
+
 }

--- a/tests/date32_test.go
+++ b/tests/date32_test.go
@@ -282,6 +282,10 @@ func TestDate32Flush(t *testing.T) {
 			MaxOpenConns: 1,
 		})
 	)
+	if err := CheckMinServerVersion(conn, 21, 9, 0); err != nil {
+		t.Skip(err.Error())
+		return
+	}
 	require.NoError(t, err)
 	defer func() {
 		conn.Exec(ctx, "DROP TABLE date_32_flush")

--- a/tests/date32_test.go
+++ b/tests/date32_test.go
@@ -19,6 +19,7 @@ package tests
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
@@ -42,12 +43,12 @@ func TestDate32(t *testing.T) {
 			//Debug: true,
 		})
 	)
-	if assert.NoError(t, err) {
-		if err := CheckMinServerVersion(conn, 21, 9, 0); err != nil {
-			t.Skip(err.Error())
-			return
-		}
-		const ddl = `
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 21, 9, 0); err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	const ddl = `
 			CREATE TABLE test_date32 (
 				  ID   UInt8
 				, Col1 Date32
@@ -56,77 +57,63 @@ func TestDate32(t *testing.T) {
 				, Col4 Array(Nullable(Date32))
 			) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_date32")
-		}()
-		type result struct {
-			ColID uint8 `ch:"ID"`
-			Col1  time.Time
-			Col2  *time.Time
-			Col3  []time.Time
-			Col4  []*time.Time
-		}
-		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
-			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_date32"); assert.NoError(t, err) {
-				var (
-					date1, _ = time.Parse("2006-01-02 15:04:05", "2100-01-01 00:00:00")
-					date2, _ = time.Parse("2006-01-02 15:04:05", "1925-01-01 00:00:00")
-					date3, _ = time.Parse("2006-01-02 15:04:05", "2283-11-11 00:00:00")
-				)
-				if err := batch.Append(uint8(1), date1, &date2, []time.Time{date2}, []*time.Time{&date2, nil, &date1}); !assert.NoError(t, err) {
-					return
-				}
-				if err := batch.Append(uint8(2), date2, nil, []time.Time{date1}, []*time.Time{nil, nil, &date2}); !assert.NoError(t, err) {
-					return
-				}
-				if err := batch.Append(uint8(3), date3, nil, []time.Time{date3}, []*time.Time{nil, nil, &date3}); !assert.NoError(t, err) {
-					return
-				}
-				if err := batch.Send(); assert.NoError(t, err) {
-					var (
-						result1 result
-						result2 result
-						result3 result
-					)
-					if err := conn.QueryRow(ctx, "SELECT * FROM test_date32 WHERE ID = $1", 1).ScanStruct(&result1); assert.NoError(t, err) {
-						if assert.Equal(t, date1, result1.Col1) {
-							assert.Equal(t, 2100, date1.Year())
-							assert.Equal(t, 1, int(date1.Month()))
-							assert.Equal(t, 1, date1.Day())
-							assert.Equal(t, "UTC", result1.Col1.Location().String())
-							assert.Equal(t, date2, *result1.Col2)
-							assert.Equal(t, []time.Time{date2}, result1.Col3)
-							assert.Equal(t, []*time.Time{&date2, nil, &date1}, result1.Col4)
-						}
-					}
-					if err := conn.QueryRow(ctx, "SELECT * FROM test_date32 WHERE ID = $1", 2).ScanStruct(&result2); assert.NoError(t, err) {
-						if assert.Equal(t, date2, result2.Col1) {
-							assert.Equal(t, "UTC", result2.Col1.Location().String())
-							if assert.Nil(t, result2.Col2) {
-								assert.Equal(t, 1925, date2.Year())
-								assert.Equal(t, 1, int(date2.Month()))
-								assert.Equal(t, 1, date2.Day())
-								assert.Equal(t, []time.Time{date1}, result2.Col3)
-								assert.Equal(t, []*time.Time{nil, nil, &date2}, result2.Col4)
-							}
-						}
-					}
-					if err := conn.QueryRow(ctx, "SELECT * FROM test_date32 WHERE ID = $1", 3).ScanStruct(&result3); assert.NoError(t, err) {
-						if assert.Equal(t, date3, result3.Col1) {
-							assert.Equal(t, "UTC", result3.Col1.Location().String())
-							if assert.Nil(t, result3.Col2) {
-								assert.Equal(t, 2283, date3.Year())
-								assert.Equal(t, 11, int(date3.Month()))
-								assert.Equal(t, 11, date3.Day())
-								assert.Equal(t, []time.Time{date3}, result3.Col3)
-								assert.Equal(t, []*time.Time{nil, nil, &date3}, result3.Col4)
-							}
-						}
-					}
-				}
-			}
-		}
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_date32")
+	}()
+	type result struct {
+		ColID uint8 `ch:"ID"`
+		Col1  time.Time
+		Col2  *time.Time
+		Col3  []time.Time
+		Col4  []*time.Time
 	}
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_date32")
+	require.NoError(t, err)
+	var (
+		date1, _ = time.Parse("2006-01-02 15:04:05", "2100-01-01 00:00:00")
+		date2, _ = time.Parse("2006-01-02 15:04:05", "1925-01-01 00:00:00")
+		date3, _ = time.Parse("2006-01-02 15:04:05", "2283-11-11 00:00:00")
+	)
+	require.NoError(t, batch.Append(uint8(1), date1, &date2, []time.Time{date2}, []*time.Time{&date2, nil, &date1}))
+	require.NoError(t, batch.Append(uint8(2), date2, nil, []time.Time{date1}, []*time.Time{nil, nil, &date2}))
+	require.NoError(t, batch.Append(uint8(3), date3, nil, []time.Time{date3}, []*time.Time{nil, nil, &date3}))
+	require.NoError(t, batch.Send())
+	var (
+		result1 result
+		result2 result
+		result3 result
+	)
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_date32 WHERE ID = $1", 1).ScanStruct(&result1))
+	require.Equal(t, date1, result1.Col1)
+	assert.Equal(t, 2100, date1.Year())
+	assert.Equal(t, 1, int(date1.Month()))
+	assert.Equal(t, 1, date1.Day())
+	assert.Equal(t, "UTC", result1.Col1.Location().String())
+	assert.Equal(t, date2, *result1.Col2)
+	assert.Equal(t, []time.Time{date2}, result1.Col3)
+	assert.Equal(t, []*time.Time{&date2, nil, &date1}, result1.Col4)
+
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_date32 WHERE ID = $1", 2).ScanStruct(&result2))
+	require.Equal(t, date2, result2.Col1)
+	assert.Equal(t, "UTC", result2.Col1.Location().String())
+	require.Nil(t, result2.Col2)
+	assert.Equal(t, 1925, date2.Year())
+	assert.Equal(t, 1, int(date2.Month()))
+	assert.Equal(t, 1, date2.Day())
+	assert.Equal(t, []time.Time{date1}, result2.Col3)
+	assert.Equal(t, []*time.Time{nil, nil, &date2}, result2.Col4)
+
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_date32 WHERE ID = $1", 3).ScanStruct(&result3))
+	require.Equal(t, date3, result3.Col1)
+	assert.Equal(t, "UTC", result3.Col1.Location().String())
+	require.Nil(t, result3.Col2)
+	assert.Equal(t, 2283, date3.Year())
+	assert.Equal(t, 11, int(date3.Month()))
+	assert.Equal(t, 11, date3.Day())
+	assert.Equal(t, []time.Time{date3}, result3.Col3)
+	assert.Equal(t, []*time.Time{nil, nil, &date3}, result3.Col4)
+
 }
 
 func TestNullableDate32(t *testing.T) {
@@ -145,64 +132,46 @@ func TestNullableDate32(t *testing.T) {
 			//Debug: true,
 		})
 	)
-	if assert.NoError(t, err) {
-		if err := CheckMinServerVersion(conn, 21, 9, 0); err != nil {
-			t.Skip(err.Error())
-			return
-		}
-		const ddl = `
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 21, 9, 0); err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	const ddl = `
 			CREATE TABLE test_date32 (
 				  Col1 Date32
 				, Col2 Nullable(Date32)
 			) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_date32")
-		}()
-		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
-			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_date32"); assert.NoError(t, err) {
-				date, err := time.Parse("2006-01-02 15:04:05", "2283-11-11 00:00:00")
-				if !assert.NoError(t, err) {
-					return
-				}
-				if err := batch.Append(date, date); assert.NoError(t, err) {
-					if err := batch.Send(); assert.NoError(t, err) {
-						var (
-							col1 *time.Time
-							col2 *time.Time
-						)
-						if err := conn.QueryRow(ctx, "SELECT * FROM test_date32").Scan(&col1, &col2); assert.NoError(t, err) {
-							assert.Equal(t, date, *col1)
-							assert.Equal(t, date, *col2)
-						}
-					}
-				}
-			}
-			if err := conn.Exec(ctx, "TRUNCATE TABLE test_date32"); !assert.NoError(t, err) {
-				return
-			}
-			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_date32"); assert.NoError(t, err) {
-				date, err := time.Parse("2006-01-02 15:04:05", "1925-01-01 00:00:00")
-				if !assert.NoError(t, err) {
-					return
-				}
-				if err := batch.Append(date, nil); assert.NoError(t, err) {
-					if err := batch.Send(); assert.NoError(t, err) {
-						var (
-							col1 *time.Time
-							col2 *time.Time
-						)
-						if err := conn.QueryRow(ctx, "SELECT * FROM test_date32").Scan(&col1, &col2); assert.NoError(t, err) {
-							if assert.Nil(t, col2) {
-								assert.Equal(t, date, *col1)
-								assert.Equal(t, date.Unix(), col1.Unix())
-							}
-						}
-					}
-				}
-			}
-		}
-	}
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_date32")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_date32")
+	require.NoError(t, err)
+	date, err := time.Parse("2006-01-02 15:04:05", "2283-11-11 00:00:00")
+	require.NoError(t, err)
+	require.NoError(t, batch.Append(date, date))
+	require.NoError(t, batch.Send())
+	var (
+		col1 *time.Time
+		col2 *time.Time
+	)
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_date32").Scan(&col1, &col2))
+	assert.Equal(t, date, *col1)
+	assert.Equal(t, date, *col2)
+	require.NoError(t, conn.Exec(ctx, "TRUNCATE TABLE test_date32"))
+	batch, err = conn.PrepareBatch(ctx, "INSERT INTO test_date32")
+	require.NoError(t, err)
+	date, err = time.Parse("2006-01-02 15:04:05", "1925-01-01 00:00:00")
+	require.NoError(t, err)
+	require.NoError(t, batch.Append(date, nil))
+	require.NoError(t, batch.Send())
+	col2 = nil
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_date32").Scan(&col1, &col2))
+	require.Nil(t, col2)
+	assert.Equal(t, date, *col1)
+	assert.Equal(t, date.Unix(), col1.Unix())
 }
 
 func TestColumnarDate32(t *testing.T) {
@@ -218,15 +187,14 @@ func TestColumnarDate32(t *testing.T) {
 			Compression: &clickhouse.Compression{
 				Method: clickhouse.CompressionLZ4,
 			},
-			//Debug: true,
 		})
 	)
-	if assert.NoError(t, err) {
-		if err := CheckMinServerVersion(conn, 21, 9, 0); err != nil {
-			t.Skip(err.Error())
-			return
-		}
-		const ddl = `
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 21, 9, 0); err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	const ddl = `
 		CREATE TABLE test_date32 (
 			  ID   UInt64
 			, Col1 Date32
@@ -235,70 +203,113 @@ func TestColumnarDate32(t *testing.T) {
 			, Col4 Array(Nullable(Date32))
 		) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_date32")
-		}()
-		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
-			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_date32"); assert.NoError(t, err) {
-				var (
-					id       []uint64
-					col1Data []time.Time
-					col2Data []*time.Time
-					col3Data [][]time.Time
-					col4Data [][]*time.Time
-				)
-				var (
-					date1, _ = time.Parse("2006-01-02 15:04:05", "2283-11-11 00:00:00")
-					date2, _ = time.Parse("2006-01-02 15:04:05", "1925-01-01 00:00:00")
-				)
-				for i := 0; i < 1000; i++ {
-					id = append(id, uint64(i))
-					col1Data = append(col1Data, date1)
-					if i%2 == 0 {
-						col2Data = append(col2Data, &date2)
-					} else {
-						col2Data = append(col2Data, nil)
-					}
-					col3Data = append(col3Data, []time.Time{
-						date1, date2, date1,
-					})
-					col4Data = append(col4Data, []*time.Time{
-						&date2, nil, &date1,
-					})
-				}
-				{
-					if err := batch.Column(0).Append(id); !assert.NoError(t, err) {
-						return
-					}
-					if err := batch.Column(1).Append(col1Data); !assert.NoError(t, err) {
-						return
-					}
-					if err := batch.Column(2).Append(col2Data); !assert.NoError(t, err) {
-						return
-					}
-					if err := batch.Column(3).Append(col3Data); !assert.NoError(t, err) {
-						return
-					}
-					if err := batch.Column(4).Append(col4Data); !assert.NoError(t, err) {
-						return
-					}
-				}
-				if assert.NoError(t, batch.Send()) {
-					var result struct {
-						Col1 time.Time
-						Col2 *time.Time
-						Col3 []time.Time
-						Col4 []*time.Time
-					}
-					if err := conn.QueryRow(ctx, "SELECT Col1, Col2, Col3, Col4 FROM test_date32 WHERE ID = $1", 11).ScanStruct(&result); assert.NoError(t, err) {
-						if assert.Nil(t, result.Col2) {
-							assert.Equal(t, date1, result.Col1)
-							assert.Equal(t, []time.Time{date1, date2, date1}, result.Col3)
-							assert.Equal(t, []*time.Time{&date2, nil, &date1}, result.Col4)
-						}
-					}
-				}
-			}
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_date32")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_date32")
+	require.NoError(t, err)
+	var (
+		id       []uint64
+		col1Data []time.Time
+		col2Data []*time.Time
+		col3Data [][]time.Time
+		col4Data [][]*time.Time
+	)
+	var (
+		date1, _ = time.Parse("2006-01-02 15:04:05", "2283-11-11 00:00:00")
+		date2, _ = time.Parse("2006-01-02 15:04:05", "1925-01-01 00:00:00")
+	)
+	for i := 0; i < 1000; i++ {
+		id = append(id, uint64(i))
+		col1Data = append(col1Data, date1)
+		if i%2 == 0 {
+			col2Data = append(col2Data, &date2)
+		} else {
+			col2Data = append(col2Data, nil)
 		}
+		col3Data = append(col3Data, []time.Time{
+			date1, date2, date1,
+		})
+		col4Data = append(col4Data, []*time.Time{
+			&date2, nil, &date1,
+		})
+	}
+	{
+		if err := batch.Column(0).Append(id); !assert.NoError(t, err) {
+			return
+		}
+		if err := batch.Column(1).Append(col1Data); !assert.NoError(t, err) {
+			return
+		}
+		if err := batch.Column(2).Append(col2Data); !assert.NoError(t, err) {
+			return
+		}
+		if err := batch.Column(3).Append(col3Data); !assert.NoError(t, err) {
+			return
+		}
+		if err := batch.Column(4).Append(col4Data); !assert.NoError(t, err) {
+			return
+		}
+	}
+	require.NoError(t, batch.Send())
+	var result struct {
+		Col1 time.Time
+		Col2 *time.Time
+		Col3 []time.Time
+		Col4 []*time.Time
+	}
+	require.NoError(t, conn.QueryRow(ctx, "SELECT Col1, Col2, Col3, Col4 FROM test_date32 WHERE ID = $1", 11).ScanStruct(&result))
+	require.Nil(t, result.Col2)
+	assert.Equal(t, date1, result.Col1)
+	assert.Equal(t, []time.Time{date1, date2, date1}, result.Col3)
+	assert.Equal(t, []*time.Time{&date2, nil, &date1}, result.Col4)
+}
+
+func TestDate32Flush(t *testing.T) {
+	var (
+		ctx       = context.Background()
+		conn, err = clickhouse.Open(&clickhouse.Options{
+			Addr: []string{"127.0.0.1:9000"},
+			Auth: clickhouse.Auth{
+				Database: "default",
+				Username: "default",
+				Password: "",
+			},
+			Compression: &clickhouse.Compression{
+				Method: clickhouse.CompressionLZ4,
+			},
+			MaxOpenConns: 1,
+		})
+	)
+	require.NoError(t, err)
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE date_32_flush")
+	}()
+	const ddl = `
+		CREATE TABLE date_32_flush (
+			  Col1 Date32
+		) Engine Memory
+		`
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO date_32_flush")
+	require.NoError(t, err)
+	vals := [1000]time.Time{}
+	var now = time.Now()
+
+	for i := 0; i < 1000; i++ {
+		vals[i] = now.Add(time.Duration(i) * time.Hour)
+		batch.Append(vals[i])
+		batch.Flush()
+	}
+	batch.Send()
+	rows, err := conn.Query(ctx, "SELECT * FROM date_32_flush")
+	require.NoError(t, err)
+	i := 0
+	for rows.Next() {
+		var col1 time.Time
+		require.NoError(t, rows.Scan(&col1))
+		assert.Equal(t, vals[i].Format("2016-02-01"), col1.Format("2016-02-01"))
+		i += 1
 	}
 }

--- a/tests/datetime64_test.go
+++ b/tests/datetime64_test.go
@@ -429,7 +429,7 @@ func TestDateTime64Flush(t *testing.T) {
 	)
 	require.NoError(t, err)
 	defer func() {
-		conn.Exec(ctx, "DROP TABLE date_64_flush")
+		conn.Exec(ctx, "DROP TABLE datetime_64_flush")
 	}()
 	const ddl = `
 		CREATE TABLE datetime_64_flush (

--- a/tests/fixed_string_test.go
+++ b/tests/fixed_string_test.go
@@ -20,6 +20,7 @@ package tests
 import (
 	"context"
 	"crypto/rand"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -412,4 +413,51 @@ func BenchmarkColumnarFixedString(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func TestFixedStringFlush(t *testing.T) {
+	var (
+		ctx       = context.Background()
+		conn, err = clickhouse.Open(&clickhouse.Options{
+			Addr: []string{"127.0.0.1:9000"},
+			Auth: clickhouse.Auth{
+				Database: "default",
+				Username: "default",
+				Password: "",
+			},
+			Compression: &clickhouse.Compression{
+				Method: clickhouse.CompressionLZ4,
+			},
+			MaxOpenConns: 1,
+		})
+	)
+	require.NoError(t, err)
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE fixed_string_flush")
+	}()
+	const ddl = `
+		CREATE TABLE fixed_string_flush (
+			  Col1 FixedString(10)
+		) Engine Memory
+		`
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO fixed_string_flush")
+	require.NoError(t, err)
+	vals := [1000]string{}
+	for i := 0; i < 1000; i++ {
+		vals[i] = RandIntString(10)
+		batch.Append(vals[i])
+		batch.Flush()
+	}
+	batch.Send()
+	rows, err := conn.Query(ctx, "SELECT * FROM fixed_string_flush")
+	require.NoError(t, err)
+	i := 0
+	for rows.Next() {
+		var col1 string
+		require.NoError(t, rows.Scan(&col1))
+		require.Equal(t, vals[i], col1)
+		i += 1
+	}
+	require.Equal(t, 1000, i)
 }

--- a/tests/float_test.go
+++ b/tests/float_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"github.com/stretchr/testify/require"
+	"math/rand"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -107,4 +108,56 @@ func BenchmarkFloat(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func TestFixedFloatFlush(t *testing.T) {
+	var (
+		ctx       = context.Background()
+		conn, err = clickhouse.Open(&clickhouse.Options{
+			Addr: []string{"127.0.0.1:9000"},
+			Auth: clickhouse.Auth{
+				Database: "default",
+				Username: "default",
+				Password: "",
+			},
+			Compression: &clickhouse.Compression{
+				Method: clickhouse.CompressionLZ4,
+			},
+			MaxOpenConns: 1,
+		})
+	)
+	require.NoError(t, err)
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE fixed_string_flush")
+	}()
+	const ddl = `
+		CREATE TABLE float_flush (
+			  Col1 Float32,
+			  Col2 Float64	
+		) Engine Memory
+		`
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO float_flush")
+	require.NoError(t, err)
+	val32s := [1000]float32{}
+	val64s := [1000]float64{}
+	for i := 0; i < 1000; i++ {
+		val32s[i] = rand.Float32()
+		val64s[i] = rand.Float64()
+		batch.Append(val32s[i], val64s[i])
+		batch.Flush()
+	}
+	batch.Send()
+	rows, err := conn.Query(ctx, "SELECT * FROM float_flush")
+	require.NoError(t, err)
+	i := 0
+	for rows.Next() {
+		var col1 float32
+		var col2 float64
+		require.NoError(t, rows.Scan(&col1, &col2))
+		require.Equal(t, val32s[i], col1)
+		require.Equal(t, val64s[i], col2)
+		i += 1
+	}
+	require.Equal(t, 1000, i)
 }

--- a/tests/flush_test.go
+++ b/tests/flush_test.go
@@ -1,0 +1,135 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tests
+
+import (
+	"context"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestNoFlushWithCompression(t *testing.T) {
+	var (
+		conn, err = clickhouse.Open(&clickhouse.Options{
+			Addr: []string{"127.0.0.1:9000"},
+			Auth: clickhouse.Auth{
+				Database: "default",
+				Username: "default",
+				Password: "",
+			},
+			Compression: &clickhouse.Compression{
+				Method: clickhouse.CompressionLZ4,
+			},
+		})
+	)
+	require.NoError(t, err)
+	require.NoError(t, err)
+	insertWithFlush(t, conn, false)
+}
+
+func TestFlushWithCompression(t *testing.T) {
+	var (
+		conn, err = clickhouse.Open(&clickhouse.Options{
+			Addr: []string{"127.0.0.1:9000"},
+			Auth: clickhouse.Auth{
+				Database: "default",
+				Username: "default",
+				Password: "",
+			},
+			Compression: &clickhouse.Compression{
+				Method: clickhouse.CompressionLZ4,
+			},
+		})
+	)
+	require.NoError(t, err)
+	require.NoError(t, err)
+	insertWithFlush(t, conn, true)
+}
+
+func TestFlush(t *testing.T) {
+	var (
+		conn, err = clickhouse.Open(&clickhouse.Options{
+			Addr: []string{"127.0.0.1:9000"},
+			Auth: clickhouse.Auth{
+				Database: "default",
+				Username: "default",
+				Password: "",
+			},
+		})
+	)
+	require.NoError(t, err)
+	insertWithFlush(t, conn, true)
+}
+
+func insertWithFlush(t *testing.T, conn driver.Conn, flush bool) {
+	//defer func() {
+	//	conn.Exec(ctx, "DROP TABLE flush_example")
+	//}()
+	conn.Exec(context.Background(), "DROP TABLE IF EXISTS flush_example")
+	ctx := context.Background()
+	err := conn.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS flush_example (
+			  Col1 UInt64
+			, Col2 String
+			, Col3 FixedString(3)
+			, Col4 UUID
+			, Col5 Map(String, UInt64)
+			, Col6 Array(String)
+			, Col7 Tuple(String, UInt64, Array(Map(String, UInt64)))
+			, Col8 DateTime
+		) Engine = Memory
+	`)
+	require.NoError(t, err)
+
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO flush_example")
+	require.NoError(t, err)
+	// 1 million rows should only take < 1s on most desktops
+	for i := 0; i < 100_000; i++ {
+		require.NoError(t, batch.Append(
+			uint64(i),
+			RandString(5),
+			RandString(3),
+			uuid.New(),
+			map[string]uint64{"key": uint64(i)}, // Map(String, UInt64)
+			[]string{RandString(1), RandString(1), RandString(1), RandString(1), RandString(1), RandString(1)}, // Array(String)
+			[]interface{}{ // Tuple(String, UInt64, Array(Map(String, UInt64)))
+				RandString(10), uint64(i), []map[string]uint64{
+					{"key": uint64(i)},
+					{"key": uint64(i + 1)},
+					{"key": uint64(i) + 2},
+				},
+			},
+			time.Now().Add(time.Duration(i)*time.Second),
+		))
+		if i > 0 && i%10000 == 0 {
+			if flush {
+				require.NoError(t, batch.Flush())
+			}
+			PrintMemUsage()
+		}
+	}
+	require.NoError(t, batch.Send())
+	// confirm we have the right count
+	var col1 uint64
+	require.NoError(t, conn.QueryRow(ctx, "SELECT count() FROM flush_example").Scan(&col1))
+	require.Equal(t, uint64(100_000), col1)
+}

--- a/tests/flush_test.go
+++ b/tests/flush_test.go
@@ -106,13 +106,13 @@ func insertWithFlush(t *testing.T, conn driver.Conn, flush bool) {
 	for i := 0; i < 100_000; i++ {
 		require.NoError(t, batch.Append(
 			uint64(i),
-			RandString(5),
-			RandString(3),
+			RandAsciiString(5),
+			RandAsciiString(3),
 			uuid.New(),
 			map[string]uint64{"key": uint64(i)}, // Map(String, UInt64)
-			[]string{RandString(1), RandString(1), RandString(1), RandString(1), RandString(1), RandString(1)}, // Array(String)
+			[]string{RandAsciiString(1), RandAsciiString(1), RandAsciiString(1), RandAsciiString(1), RandAsciiString(1), RandAsciiString(1)}, // Array(String)
 			[]interface{}{ // Tuple(String, UInt64, Array(Map(String, UInt64)))
-				RandString(10), uint64(i), []map[string]uint64{
+				RandAsciiString(10), uint64(i), []map[string]uint64{
 					{"key": uint64(i)},
 					{"key": uint64(i + 1)},
 					{"key": uint64(i) + 2},

--- a/tests/geo_multipolygon_test.go
+++ b/tests/geo_multipolygon_test.go
@@ -19,6 +19,8 @@ package tests
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
+	"math/rand"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -44,105 +46,174 @@ func TestGeoMultiPolygon(t *testing.T) {
 			},
 		})
 	)
-	if assert.NoError(t, err) {
-		if err := CheckMinServerVersion(conn, 21, 12, 0); err != nil {
-			t.Skip(err.Error())
-			return
-		}
-		const ddl = `
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 21, 12, 0); err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	const ddl = `
 		CREATE TABLE test_geo_multipolygon (
 			  Col1 MultiPolygon
 			, Col2 Array(MultiPolygon)
 		) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_geo_multipolygon")
-		}()
-		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
-			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_geo_multipolygon"); assert.NoError(t, err) {
-				var (
-					col1Data = orb.MultiPolygon{
-						orb.Polygon{
-							orb.Ring{
-								orb.Point{1, 2},
-								orb.Point{12, 2},
-							},
-							orb.Ring{
-								orb.Point{11, 2},
-								orb.Point{1, 12},
-							},
-						},
-						orb.Polygon{
-							orb.Ring{
-								orb.Point{1, 2},
-								orb.Point{12, 2},
-							},
-							orb.Ring{
-								orb.Point{11, 2},
-								orb.Point{1, 12},
-							},
-						},
-					}
-					col2Data = []orb.MultiPolygon{
-						[]orb.Polygon{
-							[]orb.Ring{
-								orb.Ring{
-									orb.Point{1, 2},
-									orb.Point{1, 22},
-								},
-								orb.Ring{
-									orb.Point{1, 23},
-									orb.Point{12, 2},
-								},
-							},
-							[]orb.Ring{
-								orb.Ring{
-									orb.Point{21, 2},
-									orb.Point{1, 222},
-								},
-								orb.Ring{
-									orb.Point{21, 23},
-									orb.Point{12, 22},
-								},
-							},
-						},
-						[]orb.Polygon{
-							[]orb.Ring{
-								orb.Ring{
-									orb.Point{11, 2},
-									orb.Point{1, 22},
-								},
-								orb.Ring{
-									orb.Point{1, 23},
-									orb.Point{12, 22},
-								},
-							},
-							[]orb.Ring{
-								orb.Ring{
-									orb.Point{21, 2},
-									orb.Point{1, 222},
-								},
-								orb.Ring{
-									orb.Point{21, 23},
-									orb.Point{12, 22},
-								},
-							},
-						},
-					}
-				)
-				if err := batch.Append(col1Data, col2Data); assert.NoError(t, err) {
-					if assert.NoError(t, batch.Send()) {
-						var (
-							col1 orb.MultiPolygon
-							col2 []orb.MultiPolygon
-						)
-						if err := conn.QueryRow(ctx, "SELECT * FROM test_geo_multipolygon").Scan(&col1, &col2); assert.NoError(t, err) {
-							assert.Equal(t, col1Data, col1)
-							assert.Equal(t, col2Data, col2)
-						}
-					}
-				}
-			}
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_geo_multipolygon")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_geo_multipolygon")
+	require.NoError(t, err)
+	var (
+		col1Data = orb.MultiPolygon{
+			orb.Polygon{
+				orb.Ring{
+					orb.Point{1, 2},
+					orb.Point{12, 2},
+				},
+				orb.Ring{
+					orb.Point{11, 2},
+					orb.Point{1, 12},
+				},
+			},
+			orb.Polygon{
+				orb.Ring{
+					orb.Point{1, 2},
+					orb.Point{12, 2},
+				},
+				orb.Ring{
+					orb.Point{11, 2},
+					orb.Point{1, 12},
+				},
+			},
 		}
+		col2Data = []orb.MultiPolygon{
+			[]orb.Polygon{
+				[]orb.Ring{
+					orb.Ring{
+						orb.Point{1, 2},
+						orb.Point{1, 22},
+					},
+					orb.Ring{
+						orb.Point{1, 23},
+						orb.Point{12, 2},
+					},
+				},
+				[]orb.Ring{
+					orb.Ring{
+						orb.Point{21, 2},
+						orb.Point{1, 222},
+					},
+					orb.Ring{
+						orb.Point{21, 23},
+						orb.Point{12, 22},
+					},
+				},
+			},
+			[]orb.Polygon{
+				[]orb.Ring{
+					orb.Ring{
+						orb.Point{11, 2},
+						orb.Point{1, 22},
+					},
+					orb.Ring{
+						orb.Point{1, 23},
+						orb.Point{12, 22},
+					},
+				},
+				[]orb.Ring{
+					orb.Ring{
+						orb.Point{21, 2},
+						orb.Point{1, 222},
+					},
+					orb.Ring{
+						orb.Point{21, 23},
+						orb.Point{12, 22},
+					},
+				},
+			},
+		}
+	)
+	require.NoError(t, batch.Append(col1Data, col2Data))
+	require.NoError(t, batch.Send())
+	var (
+		col1 orb.MultiPolygon
+		col2 []orb.MultiPolygon
+	)
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_geo_multipolygon").Scan(&col1, &col2))
+	assert.Equal(t, col1Data, col1)
+	assert.Equal(t, col2Data, col2)
+}
+
+func TestGeoMultiPolygonFlush(t *testing.T) {
+	var (
+		ctx       = context.Background()
+		conn, err = clickhouse.Open(&clickhouse.Options{
+			Addr: []string{"127.0.0.1:9000"},
+			Auth: clickhouse.Auth{
+				Database: "default",
+				Username: "default",
+				Password: "",
+			},
+			Compression: &clickhouse.Compression{
+				Method: clickhouse.CompressionLZ4,
+			},
+			Settings: clickhouse.Settings{
+				"allow_experimental_geo_types": 1,
+			},
+		})
+	)
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 21, 12, 0); err != nil {
+		t.Skip(err.Error())
+		return
 	}
+	const ddl = `
+		CREATE TABLE test_geo_multipolygon_flush (
+			  Col1 MultiPolygon
+		) Engine Memory
+		`
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_geo_multipolygon_flush")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_geo_multipolygon_flush")
+	require.NoError(t, err)
+	vals := [1000]orb.MultiPolygon{}
+	for i := 0; i < 1000; i++ {
+		vals[i] = orb.MultiPolygon{
+			orb.Polygon{
+				orb.Ring{
+					orb.Point{rand.Float64(), rand.Float64()},
+					orb.Point{rand.Float64(), rand.Float64()},
+				},
+				orb.Ring{
+					orb.Point{rand.Float64(), rand.Float64()},
+					orb.Point{rand.Float64(), rand.Float64()},
+				},
+			},
+			orb.Polygon{
+				orb.Ring{
+					orb.Point{rand.Float64(), rand.Float64()},
+					orb.Point{rand.Float64(), rand.Float64()},
+				},
+				orb.Ring{
+					orb.Point{rand.Float64(), rand.Float64()},
+					orb.Point{rand.Float64(), rand.Float64()},
+				},
+			},
+		}
+		require.NoError(t, batch.Append(vals[i]))
+		require.NoError(t, batch.Flush())
+	}
+	require.NoError(t, batch.Send())
+	rows, err := conn.Query(ctx, "SELECT * FROM test_geo_multipolygon_flush")
+	require.NoError(t, err)
+	i := 0
+	for rows.Next() {
+		var col1 orb.MultiPolygon
+		require.NoError(t, rows.Scan(&col1))
+		require.Equal(t, vals[i], col1)
+		i += 1
+	}
+	require.Equal(t, 1000, i)
 }

--- a/tests/geo_polygon_test.go
+++ b/tests/geo_polygon_test.go
@@ -19,6 +19,8 @@ package tests
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
+	"math/rand"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -44,69 +46,126 @@ func TestGeoPolygon(t *testing.T) {
 			},
 		})
 	)
-	if assert.NoError(t, err) {
-		if err := CheckMinServerVersion(conn, 21, 12, 0); err != nil {
-			t.Skip(err.Error())
-			return
-		}
-		const ddl = `
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 21, 12, 0); err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	const ddl = `
 		CREATE TABLE test_geo_polygon (
 			  Col1 Polygon
 			, Col2 Array(Polygon)
 		) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_geo_polygon")
-		}()
-		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
-			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_geo_polygon"); assert.NoError(t, err) {
-				var (
-					col1Data = orb.Polygon{
-						orb.Ring{
-							orb.Point{1, 2},
-							orb.Point{12, 2},
-						},
-						orb.Ring{
-							orb.Point{11, 2},
-							orb.Point{1, 12},
-						},
-					}
-					col2Data = []orb.Polygon{
-						[]orb.Ring{
-							orb.Ring{
-								orb.Point{1, 2},
-								orb.Point{1, 22},
-							},
-							orb.Ring{
-								orb.Point{1, 23},
-								orb.Point{12, 2},
-							},
-						},
-						[]orb.Ring{
-							orb.Ring{
-								orb.Point{21, 2},
-								orb.Point{1, 222},
-							},
-							orb.Ring{
-								orb.Point{21, 23},
-								orb.Point{12, 22},
-							},
-						},
-					}
-				)
-				if err := batch.Append(col1Data, col2Data); assert.NoError(t, err) {
-					if assert.NoError(t, batch.Send()) {
-						var (
-							col1 orb.Polygon
-							col2 []orb.Polygon
-						)
-						if err := conn.QueryRow(ctx, "SELECT * FROM test_geo_polygon").Scan(&col1, &col2); assert.NoError(t, err) {
-							assert.Equal(t, col1Data, col1)
-							assert.Equal(t, col2Data, col2)
-						}
-					}
-				}
-			}
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_geo_polygon")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_geo_polygon")
+	require.NoError(t, err)
+	var (
+		col1Data = orb.Polygon{
+			orb.Ring{
+				orb.Point{1, 2},
+				orb.Point{12, 2},
+			},
+			orb.Ring{
+				orb.Point{11, 2},
+				orb.Point{1, 12},
+			},
 		}
+		col2Data = []orb.Polygon{
+			[]orb.Ring{
+				orb.Ring{
+					orb.Point{1, 2},
+					orb.Point{1, 22},
+				},
+				orb.Ring{
+					orb.Point{1, 23},
+					orb.Point{12, 2},
+				},
+			},
+			[]orb.Ring{
+				orb.Ring{
+					orb.Point{21, 2},
+					orb.Point{1, 222},
+				},
+				orb.Ring{
+					orb.Point{21, 23},
+					orb.Point{12, 22},
+				},
+			},
+		}
+	)
+	require.NoError(t, batch.Append(col1Data, col2Data))
+	require.NoError(t, batch.Send())
+	var (
+		col1 orb.Polygon
+		col2 []orb.Polygon
+	)
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_geo_polygon").Scan(&col1, &col2))
+	assert.Equal(t, col1Data, col1)
+	assert.Equal(t, col2Data, col2)
+}
+
+func TestGeoPolygonFlush(t *testing.T) {
+	var (
+		ctx       = context.Background()
+		conn, err = clickhouse.Open(&clickhouse.Options{
+			Addr: []string{"127.0.0.1:9000"},
+			Auth: clickhouse.Auth{
+				Database: "default",
+				Username: "default",
+				Password: "",
+			},
+			Compression: &clickhouse.Compression{
+				Method: clickhouse.CompressionLZ4,
+			},
+			Settings: clickhouse.Settings{
+				"allow_experimental_geo_types": 1,
+			},
+		})
+	)
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 21, 12, 0); err != nil {
+		t.Skip(err.Error())
+		return
 	}
+	const ddl = `
+		CREATE TABLE test_geo_polygon_flush (
+			  Col1 Polygon
+		) Engine Memory
+		`
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_geo_polygon_flush")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_geo_polygon_flush")
+	require.NoError(t, err)
+	vals := [1000]orb.Polygon{}
+	for i := 0; i < 1000; i++ {
+		vals[i] = orb.Polygon{
+			orb.Ring{
+				orb.Point{rand.Float64(), rand.Float64()},
+				orb.Point{rand.Float64(), rand.Float64()},
+			},
+			orb.Ring{
+				orb.Point{rand.Float64(), rand.Float64()},
+				orb.Point{rand.Float64(), rand.Float64()},
+			},
+		}
+		require.NoError(t, batch.Append(vals[i]))
+		require.NoError(t, batch.Flush())
+	}
+	require.NoError(t, batch.Send())
+	rows, err := conn.Query(ctx, "SELECT * FROM test_geo_polygon_flush")
+	require.NoError(t, err)
+	i := 0
+	for rows.Next() {
+		var col1 orb.Polygon
+		require.NoError(t, rows.Scan(&col1))
+		require.Equal(t, vals[i], col1)
+		i += 1
+	}
+	require.Equal(t, 1000, i)
 }

--- a/tests/geo_ring_test.go
+++ b/tests/geo_ring_test.go
@@ -19,6 +19,7 @@ package tests
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -44,51 +45,102 @@ func TestGeoRing(t *testing.T) {
 			},
 		})
 	)
-	if assert.NoError(t, err) {
-		if err := CheckMinServerVersion(conn, 21, 12, 0); err != nil {
-			t.Skip(err.Error())
-			return
-		}
-		const ddl = `
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 21, 12, 0); err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	const ddl = `
 		CREATE TABLE test_geo_ring (
 			Col1 Ring
 			, Col2 Array(Ring)
 		) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_geo_ring")
-		}()
-		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
-			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_geo_ring"); assert.NoError(t, err) {
-				var (
-					col1Data = orb.Ring{
-						orb.Point{1, 2},
-						orb.Point{1, 2},
-					}
-					col2Data = []orb.Ring{
-						orb.Ring{
-							orb.Point{1, 2},
-							orb.Point{1, 2},
-						},
-						orb.Ring{
-							orb.Point{1, 2},
-							orb.Point{1, 2},
-						},
-					}
-				)
-				if err := batch.Append(col1Data, col2Data); assert.NoError(t, err) {
-					if assert.NoError(t, batch.Send()) {
-						var (
-							col1 orb.Ring
-							col2 []orb.Ring
-						)
-						if err := conn.QueryRow(ctx, "SELECT * FROM test_geo_ring").Scan(&col1, &col2); assert.NoError(t, err) {
-							assert.Equal(t, col1Data, col1)
-							assert.Equal(t, col2Data, col2)
-						}
-					}
-				}
-			}
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_geo_ring")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_geo_ring")
+	require.NoError(t, err)
+	var (
+		col1Data = orb.Ring{
+			orb.Point{1, 2},
+			orb.Point{1, 2},
 		}
+		col2Data = []orb.Ring{
+			orb.Ring{
+				orb.Point{1, 2},
+				orb.Point{1, 2},
+			},
+			orb.Ring{
+				orb.Point{1, 2},
+				orb.Point{1, 2},
+			},
+		}
+	)
+	require.NoError(t, batch.Append(col1Data, col2Data))
+	require.NoError(t, batch.Send())
+	var (
+		col1 orb.Ring
+		col2 []orb.Ring
+	)
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_geo_ring").Scan(&col1, &col2))
+	assert.Equal(t, col1Data, col1)
+	assert.Equal(t, col2Data, col2)
+}
+
+func TestGeoRingFlush(t *testing.T) {
+	var (
+		ctx       = context.Background()
+		conn, err = clickhouse.Open(&clickhouse.Options{
+			Addr: []string{"127.0.0.1:9000"},
+			Auth: clickhouse.Auth{
+				Database: "default",
+				Username: "default",
+				Password: "",
+			},
+			Compression: &clickhouse.Compression{
+				Method: clickhouse.CompressionLZ4,
+			},
+			Settings: clickhouse.Settings{
+				"allow_experimental_geo_types": 1,
+			},
+		})
+	)
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 21, 12, 0); err != nil {
+		t.Skip(err.Error())
+		return
 	}
+	const ddl = `
+		CREATE TABLE test_geo_ring_flush (
+			  Col1 Ring
+		) Engine Memory
+		`
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_geo_ring_flush")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_geo_ring_flush")
+	require.NoError(t, err)
+	vals := [1000]orb.Ring{}
+	for i := 0; i < 1000; i++ {
+		vals[i] = orb.Ring{
+			orb.Point{1, 2},
+			orb.Point{1, 2},
+		}
+		require.NoError(t, batch.Append(vals[i]))
+		require.NoError(t, batch.Flush())
+	}
+	require.NoError(t, batch.Send())
+	rows, err := conn.Query(ctx, "SELECT * FROM test_geo_ring_flush")
+	require.NoError(t, err)
+	i := 0
+	for rows.Next() {
+		var col1 orb.Ring
+		require.NoError(t, rows.Scan(&col1))
+		require.Equal(t, vals[i], col1)
+		i += 1
+	}
+	require.Equal(t, 1000, i)
 }

--- a/tests/issues/utils.go
+++ b/tests/issues/utils.go
@@ -26,7 +26,9 @@ import (
 )
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	seed := time.Now().UnixNano()
+	fmt.Printf("using random seed %d for issues\n", seed)
+	rand.Seed(seed)
 }
 
 func checkMinServerVersion(conn driver.Conn, major, minor uint64) error {

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -2441,7 +2441,7 @@ func TestJSONFlush(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		vals[i] = map[string]interface{}{
 			"i": uint64(i),
-			"s": RandIntString(10),
+			"s": RandAsciiString(10),
 		}
 		require.NoError(t, batch.Append(vals[i]))
 		require.NoError(t, batch.Flush())

--- a/tests/lowcardinality_test.go
+++ b/tests/lowcardinality_test.go
@@ -19,6 +19,7 @@ package tests
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
 	"math/rand"
 	"testing"
 	"time"
@@ -144,7 +145,7 @@ func TestLowCardinality(t *testing.T) {
 	}
 }
 
-func TestColmnarLowCardinality(t *testing.T) {
+func TestColmunarLowCardinality(t *testing.T) {
 	var (
 		ctx       = context.Background()
 		conn, err = clickhouse.Open(&clickhouse.Options{
@@ -160,15 +161,14 @@ func TestColmnarLowCardinality(t *testing.T) {
 			Settings: clickhouse.Settings{
 				"allow_suspicious_low_cardinality_types": 1,
 			},
-			//	Debug: true,
 		})
 	)
-	if assert.NoError(t, err) {
-		if err := CheckMinServerVersion(conn, 20, 1, 0); err != nil {
-			t.Skip(err.Error())
-			return
-		}
-		const ddl = `
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 20, 1, 0); err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	const ddl = `
 		CREATE TABLE test_lowcardinality (
 			  Col1 LowCardinality(String)
 			, Col2 LowCardinality(FixedString(2))
@@ -176,56 +176,97 @@ func TestColmnarLowCardinality(t *testing.T) {
 			, Col4 LowCardinality(Int32)
 		) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_lowcardinality")
-		}()
-		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
-			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_lowcardinality"); assert.NoError(t, err) {
-				var (
-					rnd       = rand.Int31()
-					timestamp = time.Now()
-					col1Data  []string
-					col2Data  []string
-					col3Data  []time.Time
-					col4Data  []int32
-				)
-				for i := 0; i < 10; i++ {
-					col1Data = append(col1Data, timestamp.String())
-					col2Data = append(col2Data, "RU")
-					col3Data = append(col3Data, timestamp.Add(time.Duration(i)*time.Minute))
-					col4Data = append(col4Data, rnd+int32(i))
-				}
-				if err := batch.Column(0).Append(col1Data); !assert.NoError(t, err) {
-					return
-				}
-				if err := batch.Column(1).Append(col2Data); !assert.NoError(t, err) {
-					return
-				}
-				if err := batch.Column(2).Append(col3Data); !assert.NoError(t, err) {
-					return
-				}
-				if err := batch.Column(3).Append(col4Data); !assert.NoError(t, err) {
-					return
-				}
-				if assert.NoError(t, batch.Send()) {
-					var count uint64
-					if err := conn.QueryRow(ctx, "SELECT COUNT() FROM test_lowcardinality").Scan(&count); assert.NoError(t, err) {
-						assert.Equal(t, uint64(10), count)
-					}
-					var (
-						col1 string
-						col2 string
-						col3 time.Time
-						col4 int32
-					)
-					if err := conn.QueryRow(ctx, "SELECT * FROM test_lowcardinality WHERE Col4 = $1", rnd+6).Scan(&col1, &col2, &col3, &col4); assert.NoError(t, err) {
-						assert.Equal(t, timestamp.String(), col1)
-						assert.Equal(t, "RU", col2)
-						assert.Equal(t, timestamp.Add(time.Duration(6)*time.Minute).Truncate(time.Second), col3)
-						assert.Equal(t, int32(rnd+6), col4)
-					}
-				}
-			}
-		}
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_lowcardinality")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_lowcardinality")
+	require.NoError(t, err)
+	var (
+		rnd       = rand.Int31()
+		timestamp = time.Now()
+		col1Data  []string
+		col2Data  []string
+		col3Data  []time.Time
+		col4Data  []int32
+	)
+	for i := 0; i < 10; i++ {
+		col1Data = append(col1Data, timestamp.String())
+		col2Data = append(col2Data, "RU")
+		col3Data = append(col3Data, timestamp.Add(time.Duration(i)*time.Minute))
+		col4Data = append(col4Data, rnd+int32(i))
 	}
+	require.NoError(t, batch.Column(0).Append(col1Data))
+	require.NoError(t, batch.Column(1).Append(col2Data))
+	require.NoError(t, batch.Column(2).Append(col3Data))
+	require.NoError(t, batch.Column(3).Append(col4Data))
+	require.NoError(t, batch.Send())
+	var count uint64
+	if err := conn.QueryRow(ctx, "SELECT COUNT() FROM test_lowcardinality").Scan(&count); assert.NoError(t, err) {
+		assert.Equal(t, uint64(10), count)
+	}
+	var (
+		col1 string
+		col2 string
+		col3 time.Time
+		col4 int32
+	)
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_lowcardinality WHERE Col4 = $1", rnd+6).Scan(&col1, &col2, &col3, &col4))
+	assert.Equal(t, timestamp.String(), col1)
+	assert.Equal(t, "RU", col2)
+	assert.Equal(t, timestamp.Add(time.Duration(6)*time.Minute).Truncate(time.Second), col3)
+	assert.Equal(t, int32(rnd+6), col4)
+}
+
+func TestLowCardinalityFlush(t *testing.T) {
+	var (
+		ctx       = context.Background()
+		conn, err = clickhouse.Open(&clickhouse.Options{
+			Addr: []string{"127.0.0.1:9000"},
+			Auth: clickhouse.Auth{
+				Database: "default",
+				Username: "default",
+				Password: "",
+			},
+			Compression: &clickhouse.Compression{
+				Method: clickhouse.CompressionLZ4,
+			},
+			Settings: clickhouse.Settings{
+				"allow_suspicious_low_cardinality_types": 1,
+			},
+		})
+	)
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 20, 1, 0); err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	const ddl = `
+		CREATE TABLE test_lowcardinality_flush (
+			  Col1 LowCardinality(String)
+		) Engine Memory
+		`
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_lowcardinality_flush")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_lowcardinality_flush")
+	require.NoError(t, err)
+	vals := [1000]string{}
+	for i := 0; i < 1000; i++ {
+		vals[i] = RandAsciiString(10)
+		require.NoError(t, batch.Append(vals[i]))
+		require.NoError(t, batch.Flush())
+	}
+	require.NoError(t, batch.Send())
+	rows, err := conn.Query(ctx, "SELECT * FROM test_lowcardinality_flush")
+	require.NoError(t, err)
+	i := 0
+	for rows.Next() {
+		var col1 string
+		require.NoError(t, rows.Scan(&col1))
+		require.Equal(t, vals[i], col1)
+		i += 1
+	}
+	require.Equal(t, 1000, i)
 }

--- a/tests/map_test.go
+++ b/tests/map_test.go
@@ -20,6 +20,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -42,12 +43,12 @@ func TestMap(t *testing.T) {
 			//Debug: true,
 		})
 	)
-	if assert.NoError(t, err) {
-		if err := CheckMinServerVersion(conn, 21, 9, 0); err != nil {
-			t.Skip(err.Error())
-			return
-		}
-		const ddl = `
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 21, 9, 0); err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	const ddl = `
 		CREATE TABLE test_map (
 			  Col1 Map(String, UInt64)
 			, Col2 Map(String, UInt64)
@@ -57,63 +58,58 @@ func TestMap(t *testing.T) {
 			, Col6 Map(String, Map(String,UInt64))
 		) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_map")
-		}()
-		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
-			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_map"); assert.NoError(t, err) {
-				var (
-					col1Data = map[string]uint64{
-						"key_col_1_1": 1,
-						"key_col_1_2": 2,
-					}
-					col2Data = map[string]uint64{
-						"key_col_2_1": 10,
-						"key_col_2_2": 20,
-					}
-					col3Data = map[string]uint64{}
-					col4Data = []map[string]string{
-						map[string]string{"A": "B"},
-						map[string]string{"C": "D"},
-					}
-					col5Data = map[string]uint64{
-						"key_col_5_1": 100,
-						"key_col_5_2": 200,
-					}
-					col6Data = map[string]map[string]uint64{
-						"key_col_6_1": {
-							"key_col_6_1_1": 100,
-							"key_col_6_1_2": 200,
-						},
-						"key_col_6_2": {
-							"key_col_6_2_1": 100,
-							"key_col_6_2_2": 200,
-						},
-					}
-				)
-				if err := batch.Append(col1Data, col2Data, col3Data, col4Data, col5Data, col6Data); assert.NoError(t, err) {
-					if assert.NoError(t, batch.Send()) {
-						var (
-							col1 map[string]uint64
-							col2 map[string]uint64
-							col3 map[string]uint64
-							col4 []map[string]string
-							col5 map[string]uint64
-							col6 map[string]map[string]uint64
-						)
-						if err := conn.QueryRow(ctx, "SELECT * FROM test_map").Scan(&col1, &col2, &col3, &col4, &col5, &col6); assert.NoError(t, err) {
-							assert.Equal(t, col1Data, col1)
-							assert.Equal(t, col2Data, col2)
-							assert.Equal(t, col3Data, col3)
-							assert.Equal(t, col4Data, col4)
-							assert.Equal(t, col5Data, col5)
-							assert.Equal(t, col6Data, col6)
-						}
-					}
-				}
-			}
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_map")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_map")
+	require.NoError(t, err)
+	var (
+		col1Data = map[string]uint64{
+			"key_col_1_1": 1,
+			"key_col_1_2": 2,
 		}
-	}
+		col2Data = map[string]uint64{
+			"key_col_2_1": 10,
+			"key_col_2_2": 20,
+		}
+		col3Data = map[string]uint64{}
+		col4Data = []map[string]string{
+			map[string]string{"A": "B"},
+			map[string]string{"C": "D"},
+		}
+		col5Data = map[string]uint64{
+			"key_col_5_1": 100,
+			"key_col_5_2": 200,
+		}
+		col6Data = map[string]map[string]uint64{
+			"key_col_6_1": {
+				"key_col_6_1_1": 100,
+				"key_col_6_1_2": 200,
+			},
+			"key_col_6_2": {
+				"key_col_6_2_1": 100,
+				"key_col_6_2_2": 200,
+			},
+		}
+	)
+	require.NoError(t, batch.Append(col1Data, col2Data, col3Data, col4Data, col5Data, col6Data))
+	require.NoError(t, batch.Send())
+	var (
+		col1 map[string]uint64
+		col2 map[string]uint64
+		col3 map[string]uint64
+		col4 []map[string]string
+		col5 map[string]uint64
+		col6 map[string]map[string]uint64
+	)
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_map").Scan(&col1, &col2, &col3, &col4, &col5, &col6))
+	assert.Equal(t, col1Data, col1)
+	assert.Equal(t, col2Data, col2)
+	assert.Equal(t, col3Data, col3)
+	assert.Equal(t, col4Data, col4)
+	assert.Equal(t, col5Data, col5)
+	assert.Equal(t, col6Data, col6)
 }
 
 func TestColmnarMap(t *testing.T) {
@@ -132,71 +128,68 @@ func TestColmnarMap(t *testing.T) {
 			//Debug: true,
 		})
 	)
-	if assert.NoError(t, err) {
-		if err := CheckMinServerVersion(conn, 21, 9, 0); err != nil {
-			t.Skip(err.Error())
-			return
-		}
-		const ddl = `
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 21, 9, 0); err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	const ddl = `
 		CREATE TABLE test_map (
 			  Col1 Map(String, UInt64)
 			, Col2 Map(String, UInt64)
 			, Col3 Map(String, UInt64)
 		) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_map")
-		}()
-		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
-			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_map"); assert.NoError(t, err) {
-				var (
-					col1Data = []map[string]uint64{}
-					col2Data = []map[string]uint64{}
-					col3Data = []map[string]uint64{}
-				)
-				for i := 0; i < 100; i++ {
-					col1Data = append(col1Data, map[string]uint64{
-						fmt.Sprintf("key_col_1_%d_1", i): uint64(i),
-						fmt.Sprintf("key_col_1_%d_2", i): uint64(i),
-					})
-					col2Data = append(col2Data, map[string]uint64{
-						fmt.Sprintf("key_col_2_%d_1", i): uint64(i),
-						fmt.Sprintf("key_col_2_%d_2", i): uint64(i),
-					})
-					col3Data = append(col3Data, map[string]uint64{})
-				}
-				if err := batch.Column(0).Append(col1Data); !assert.NoError(t, err) {
-					return
-				}
-				if err := batch.Column(1).Append(col2Data); !assert.NoError(t, err) {
-					return
-				}
-				if err := batch.Column(2).Append(col3Data); !assert.NoError(t, err) {
-					return
-				}
-
-				if assert.NoError(t, batch.Send()) {
-					var (
-						col1     map[string]uint64
-						col2     map[string]uint64
-						col3     map[string]uint64
-						col1Data = map[string]uint64{
-							"key_col_1_10_1": 10,
-							"key_col_1_10_2": 10,
-						}
-						col2Data = map[string]uint64{
-							"key_col_2_10_1": 10,
-							"key_col_2_10_2": 10,
-						}
-						col3Data = map[string]uint64{}
-					)
-					if err := conn.QueryRow(ctx, "SELECT * FROM test_map WHERE Col1['key_col_1_10_1'] = $1", 10).Scan(&col1, &col2, &col3); assert.NoError(t, err) {
-						assert.Equal(t, col1Data, col1)
-						assert.Equal(t, col2Data, col2)
-						assert.Equal(t, col3Data, col3)
-					}
-				}
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_map")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_map")
+	require.NoError(t, err)
+	var (
+		col1Data = []map[string]uint64{}
+		col2Data = []map[string]uint64{}
+		col3Data = []map[string]uint64{}
+	)
+	for i := 0; i < 100; i++ {
+		col1Data = append(col1Data, map[string]uint64{
+			fmt.Sprintf("key_col_1_%d_1", i): uint64(i),
+			fmt.Sprintf("key_col_1_%d_2", i): uint64(i),
+		})
+		col2Data = append(col2Data, map[string]uint64{
+			fmt.Sprintf("key_col_2_%d_1", i): uint64(i),
+			fmt.Sprintf("key_col_2_%d_2", i): uint64(i),
+		})
+		col3Data = append(col3Data, map[string]uint64{})
+	}
+	if err := batch.Column(0).Append(col1Data); !assert.NoError(t, err) {
+		return
+	}
+	if err := batch.Column(1).Append(col2Data); !assert.NoError(t, err) {
+		return
+	}
+	if err := batch.Column(2).Append(col3Data); !assert.NoError(t, err) {
+		return
+	}
+	require.NoError(t, batch.Send())
+	{
+		var (
+			col1     map[string]uint64
+			col2     map[string]uint64
+			col3     map[string]uint64
+			col1Data = map[string]uint64{
+				"key_col_1_10_1": 10,
+				"key_col_1_10_2": 10,
 			}
-		}
+			col2Data = map[string]uint64{
+				"key_col_2_10_1": 10,
+				"key_col_2_10_2": 10,
+			}
+			col3Data = map[string]uint64{}
+		)
+		require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_map WHERE Col1['key_col_1_10_1'] = $1", 10).Scan(&col1, &col2, &col3))
+		assert.Equal(t, col1Data, col1)
+		assert.Equal(t, col2Data, col2)
+		assert.Equal(t, col3Data, col3)
 	}
 }

--- a/tests/nested_test.go
+++ b/tests/nested_test.go
@@ -233,12 +233,12 @@ func TestNestedUnFlattened(t *testing.T) {
 			},
 		})
 	)
-	if assert.NoError(t, err) {
-		if err := CheckMinServerVersion(conn, 22, 1, 0); err != nil {
-			t.Skip(err.Error())
-			return
-		}
-		const ddl = `
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 22, 1, 0); err != nil {
+		t.Skip(err.Error())
+		return
+	}
+	const ddl = `
 			CREATE TABLE test_nested (
 				Col1 Nested(
 					  Col1_N1 UInt8
@@ -253,59 +253,130 @@ func TestNestedUnFlattened(t *testing.T) {
 				)
 			) Engine Memory
 		`
-		defer func() {
-			conn.Exec(ctx, "DROP TABLE test_nested")
-		}()
-		if err := conn.Exec(ctx, ddl); assert.NoError(t, err) {
-			if batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_nested"); assert.NoError(t, err) {
-				fmt.Println(batch)
-				var (
-					col1Data = []map[string]interface{}{
-						{
-							"Col1_N1": uint8(1),
-							"Col2_N1": uint8(20),
-						},
-						{
-							"Col1_N1": uint8(2),
-							"Col2_N1": uint8(20),
-						},
-						{
-							"Col1_N1": uint8(3),
-							"Col2_N1": uint8(20),
-						},
-					}
-					col2Data = []map[string]interface{}{
-						{
-							"Col1_N2": uint8(101),
-							"Col2_N2": []map[string]interface{}{
-								{
-									"Col1_N2_N1": uint8(1),
-									"Col2_N2_N1": uint8(2),
-								},
-							},
-						},
-						{
-							"Col1_N2": uint8(201),
-							"Col2_N2": []map[string]interface{}{
-								{
-									"Col1_N2_N1": uint8(3),
-									"Col2_N2_N1": uint8(4),
-								},
-							},
-						},
-					}
-				)
-				require.NoError(t, batch.Append(col1Data, col2Data))
-				require.NoError(t, batch.Send())
-				var (
-					col1 []map[string]interface{}
-					col2 []map[string]interface{}
-				)
-				rows := conn.QueryRow(ctx, "SELECT * FROM test_nested")
-				require.NoError(t, rows.Scan(&col1, &col2))
-				assert.Equal(t, col1Data, col1)
-				assert.Equal(t, col2Data, col2)
-			}
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_nested")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_nested")
+	require.NoError(t, err)
+	var (
+		col1Data = []map[string]interface{}{
+			{
+				"Col1_N1": uint8(1),
+				"Col2_N1": uint8(20),
+			},
+			{
+				"Col1_N1": uint8(2),
+				"Col2_N1": uint8(20),
+			},
+			{
+				"Col1_N1": uint8(3),
+				"Col2_N1": uint8(20),
+			},
 		}
+		col2Data = []map[string]interface{}{
+			{
+				"Col1_N2": uint8(101),
+				"Col2_N2": []map[string]interface{}{
+					{
+						"Col1_N2_N1": uint8(1),
+						"Col2_N2_N1": uint8(2),
+					},
+				},
+			},
+			{
+				"Col1_N2": uint8(201),
+				"Col2_N2": []map[string]interface{}{
+					{
+						"Col1_N2_N1": uint8(3),
+						"Col2_N2_N1": uint8(4),
+					},
+				},
+			},
+		}
+	)
+	require.NoError(t, batch.Append(col1Data, col2Data))
+	require.NoError(t, batch.Send())
+	var (
+		col1 []map[string]interface{}
+		col2 []map[string]interface{}
+	)
+	rows := conn.QueryRow(ctx, "SELECT * FROM test_nested")
+	require.NoError(t, rows.Scan(&col1, &col2))
+	assert.Equal(t, col1Data, col1)
+	assert.Equal(t, col2Data, col2)
+}
+
+func TestNestedFlush(t *testing.T) {
+	var (
+		ctx       = context.Background()
+		conn, err = clickhouse.Open(&clickhouse.Options{
+			Addr: []string{"127.0.0.1:9000"},
+			Auth: clickhouse.Auth{
+				Database: "default",
+				Username: "default",
+				Password: "",
+			},
+			Compression: &clickhouse.Compression{
+				Method: clickhouse.CompressionLZ4,
+			},
+			Settings: clickhouse.Settings{
+				"flatten_nested": 0,
+			},
+		})
+	)
+	require.NoError(t, err)
+	if err := CheckMinServerVersion(conn, 22, 1, 0); err != nil {
+		t.Skip(err.Error())
+		return
 	}
+	const ddl = `
+			CREATE TABLE test_nested_flush (
+				Col1 Nested(
+					  Col1_N1 UInt8
+					, Col2_N1 UInt8
+				)
+			) Engine Memory
+		`
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_nested_flush")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_nested_flush")
+	require.NoError(t, err)
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_nested_flush")
+	}()
+	batch, err = conn.PrepareBatch(ctx, "INSERT INTO test_nested_flush")
+	require.NoError(t, err)
+	vals := [1000][]map[string]interface{}{}
+	for i := 0; i < 1000; i++ {
+		vals[i] = []map[string]interface{}{
+			{
+				"Col1_N1": uint8(i),
+				"Col2_N1": uint8(i) + 1,
+			},
+			{
+				"Col1_N1": uint8(i) + 2,
+				"Col2_N1": uint8(i) + 3,
+			},
+			{
+				"Col1_N1": uint8(i) + 4,
+				"Col2_N1": uint8(i) + 5,
+			},
+		}
+		require.NoError(t, batch.Append(vals[i]))
+		require.NoError(t, batch.Flush())
+	}
+	require.NoError(t, batch.Send())
+	rows, err := conn.Query(ctx, "SELECT * FROM test_nested_flush")
+	require.NoError(t, err)
+	i := 0
+	for rows.Next() {
+		var col1 []map[string]interface{}
+		require.NoError(t, rows.Scan(&col1))
+		require.Equal(t, vals[i], col1)
+		i += 1
+	}
+	require.Equal(t, 1000, i)
 }

--- a/tests/std/utils.go
+++ b/tests/std/utils.go
@@ -27,7 +27,9 @@ import (
 )
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	seed := time.Now().UnixNano()
+	fmt.Printf("using random seed %d for std tests\n", seed)
+	rand.Seed(seed)
 }
 func CheckMinServerVersion(conn *sql.DB, major, minor, patch uint64) error {
 	var version struct {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -20,6 +20,7 @@ package tests
 import (
 	"fmt"
 	"math/rand"
+	"net"
 	"runtime"
 	"strings"
 	"time"
@@ -28,7 +29,9 @@ import (
 )
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	seed := time.Now().UnixNano()
+	fmt.Printf("using random seed %d for native tests\n", seed)
+	rand.Seed(seed)
 }
 func CheckMinServerVersion(conn driver.Conn, major, minor, patch uint64) error {
 	v, err := conn.ServerVersion()
@@ -57,6 +60,19 @@ func RandAsciiString(n int) string {
 
 func RandIntString(n int) string {
 	return randString(n, numberBytes)
+}
+
+func RandIPv4() net.IP {
+	return net.IPv4(uint8(rand.Int()), uint8(rand.Int()), uint8(rand.Int()), uint8(rand.Int())).To4()
+}
+
+func RandIPv6() net.IP {
+	size := 16
+	ip := make([]byte, size)
+	for i := 0; i < size; i++ {
+		ip[i] = byte(rand.Intn(256))
+	}
+	return net.IP(ip).To16()
 }
 
 func randString(n int, bytes string) string {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -44,13 +44,22 @@ func CheckMinServerVersion(conn driver.Conn, major, minor, patch uint64) error {
 var src = rand.NewSource(time.Now().UnixNano())
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const numberBytes = "123456789"
 const (
 	letterIdxBits = 6                    // 6 bits to represent a letter index
 	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
 	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
 )
 
-func RandString(n int) string {
+func RandAsciiString(n int) string {
+	return randString(n, letterBytes)
+}
+
+func RandIntString(n int) string {
+	return randString(n, numberBytes)
+}
+
+func randString(n int, bytes string) string {
 	sb := strings.Builder{}
 	sb.Grow(n)
 	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
@@ -58,8 +67,8 @@ func RandString(n int) string {
 		if remain == 0 {
 			cache, remain = src.Int63(), letterIdxMax
 		}
-		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
-			sb.WriteByte(letterBytes[idx])
+		if idx := int(cache & letterIdxMask); idx < len(bytes) {
+			sb.WriteByte(bytes[idx])
 			i--
 		}
 		cache >>= letterIdxBits


### PR DESCRIPTION
Closes https://github.com/ClickHouse/clickhouse-go/issues/684

We add a `Flush()` method to a batch to avoid the need for users to accumulate an entire batch in memory. Flushing effectively writes a block - so we move away from a 1:1 mapping of a block per batch. As well as reducing memory usage this has some performance benefits and ensures users don't need to create a new batch every time.

```
=== RUN   TestNoFlushWithCompression
Alloc = 5 MiB	TotalAlloc = 39 MiB	Sys = 24 MiB	NumGC = 13
Alloc = 10 MiB	TotalAlloc = 78 MiB	Sys = 32 MiB	NumGC = 19
Alloc = 20 MiB	TotalAlloc = 116 MiB	Sys = 36 MiB	NumGC = 22
Alloc = 24 MiB	TotalAlloc = 158 MiB	Sys = 48 MiB	NumGC = 25
Alloc = 34 MiB	TotalAlloc = 199 MiB	Sys = 56 MiB	NumGC = 27
Alloc = 34 MiB	TotalAlloc = 234 MiB	Sys = 56 MiB	NumGC = 29
Alloc = 28 MiB	TotalAlloc = 271 MiB	Sys = 72 MiB	NumGC = 31
Alloc = 51 MiB	TotalAlloc = 318 MiB	Sys = 86 MiB	NumGC = 32
Alloc = 46 MiB	TotalAlloc = 347 MiB	Sys = 86 MiB	NumGC = 33
--- PASS: TestNoFlushWithCompression (0.69s)
=== RUN   TestFlushWithCompression
Alloc = 10 MiB	TotalAlloc = 48 MiB	Sys = 28 MiB	NumGC = 14
Alloc = 10 MiB	TotalAlloc = 70 MiB	Sys = 28 MiB	NumGC = 17
Alloc = 15 MiB	TotalAlloc = 91 MiB	Sys = 28 MiB	NumGC = 19
Alloc = 12 MiB	TotalAlloc = 113 MiB	Sys = 28 MiB	NumGC = 22
Alloc = 10 MiB	TotalAlloc = 134 MiB	Sys = 28 MiB	NumGC = 25
Alloc = 15 MiB	TotalAlloc = 155 MiB	Sys = 28 MiB	NumGC = 27
Alloc = 12 MiB	TotalAlloc = 177 MiB	Sys = 28 MiB	NumGC = 30
Alloc = 9 MiB	TotalAlloc = 198 MiB	Sys = 28 MiB	NumGC = 33
Alloc = 14 MiB	TotalAlloc = 220 MiB	Sys = 28 MiB	NumGC = 35
--- PASS: TestFlushWithCompression (0.38s)
```