### PR TITLE
handle empty http response

### DIFF
--- a/tests/compression_test.go
+++ b/tests/compression_test.go
@@ -9,6 +9,18 @@ import (
 )
 
 func TestZSTDCompression(t *testing.T) {
+	CompressionTest(t, clickhouse.CompressionZSTD)
+}
+
+func TestLZ4Compression(t *testing.T) {
+	CompressionTest(t, clickhouse.CompressionLZ4)
+}
+
+func TestNoCompression(t *testing.T) {
+	CompressionTest(t, clickhouse.CompressionNone)
+}
+
+func CompressionTest(t *testing.T, method clickhouse.CompressionMethod) {
 	var (
 		ctx       = context.Background()
 		conn, err = clickhouse.Open(&clickhouse.Options{
@@ -19,7 +31,7 @@ func TestZSTDCompression(t *testing.T) {
 				Password: "",
 			},
 			Compression: &clickhouse.Compression{
-				Method: clickhouse.CompressionZSTD,
+				Method: method,
 			},
 			MaxOpenConns: 1,
 		})

--- a/tests/flush_test.go
+++ b/tests/flush_test.go
@@ -81,9 +81,9 @@ func TestFlush(t *testing.T) {
 }
 
 func insertWithFlush(t *testing.T, conn driver.Conn, flush bool) {
-	//defer func() {
-	//	conn.Exec(ctx, "DROP TABLE flush_example")
-	//}()
+	defer func() {
+		conn.Exec(context.Background(), "DROP TABLE flush_example")
+	}()
 	conn.Exec(context.Background(), "DROP TABLE IF EXISTS flush_example")
 	ctx := context.Background()
 	err := conn.Exec(ctx, `


### PR DESCRIPTION
Queries with no response have an empty body. HTTP didn't allow for this.