### PR TITLE
Closes #715 (quoted table name in INSERT INTO)

### DIFF
--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -29,7 +29,7 @@ import (
 	"regexp"
 )
 
-var splitHttpInsertRe = regexp.MustCompile(`(?i)^INSERT INTO\s([\w.]+)`)
+var splitHttpInsertRe = regexp.MustCompile("(?i)^INSERT INTO\\s+`?([\\w.]+)`?")
 
 // release is ignored, because http used by std with empty release function
 func (h *httpConnect) prepareBatch(ctx context.Context, query string, release func(*connect, error)) (driver.Batch, error) {


### PR DESCRIPTION
Closes #715 by extending the regex with optional backticks.