### PR TITLE
run tests in 1.18 and 1.19 as the problem with go compiler is fixed

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,8 @@ jobs:
       fail-fast: true
       matrix:
         go:
-          - 1.18.3 #pin to 1.18.3 for now due to https://github.com/ClickHouse/ch-go/issues/160
+          - 1.18
+          - 1.19
         clickhouse:
           - 21.8
           - 22.3


### PR DESCRIPTION
https://github.com/ClickHouse/ch-go/issues/160 is closed, we can enable testing against a few versions of the golang compiler