### PR TITLE
Fix copylock when use sync.Pool in clickhouse.Pool

### DIFF
--- a/conn_http.go
+++ b/conn_http.go
@@ -25,11 +25,6 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/compress"
-	chproto "github.com/ClickHouse/ch-go/proto"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
-	"github.com/andybalholm/brotli"
-	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"net"
@@ -37,6 +32,12 @@ import (
 	"net/url"
 	"sync"
 	"time"
+
+	"github.com/ClickHouse/ch-go/compress"
+	chproto "github.com/ClickHouse/ch-go/proto"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/andybalholm/brotli"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -45,12 +46,12 @@ const (
 )
 
 type Pool[T any] struct {
-	pool sync.Pool
+	pool *sync.Pool
 }
 
 func NewPool[T any](fn func() T) Pool[T] {
 	return Pool[T]{
-		pool: sync.Pool{New: func() interface{} { return fn() }},
+		pool: &sync.Pool{New: func() interface{} { return fn() }},
 	}
 }
 


### PR DESCRIPTION
In the `conn_http.go`, [line 48](https://github.com/ClickHouse/clickhouse-go/blob/65abd39572ada7026adb1e4c6ea8093ae1c39e3b/conn_http.go#L48), the `clickhouse.Pool` contains a `sync.Pool`, but according to `sync.Pool` doc:

> A Pool must not be copied after first use

That is because `sync.Pool` contains `noCopy`. So to **avoid** _copied after use_, we should wrap a `*sync.Pool` in `clickhouse.Pool`:
```go
type Pool[T any] struct {
    pool *sync.Pool
}
```