### PR TITLE
Fix error in nil check for *Decimal column Append

### DIFF
--- a/lib/column/decimal.go
+++ b/lib/column/decimal.go
@@ -21,11 +21,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"math/big"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/ClickHouse/ch-go/proto"
 
 	"github.com/shopspring/decimal"
 )
@@ -156,7 +157,7 @@ func (col *Decimal) Append(v interface{}) (nulls []uint8, err error) {
 		nulls = make([]uint8, len(v))
 		for i := range v {
 			switch {
-			case v != nil:
+			case v[i] != nil:
 				col.append(v[i])
 			default:
 				nulls[i] = 1


### PR DESCRIPTION
Previously this line was checking that the decimal slice is not nil to determine whether to append the element which will always be true, even if the element being appended is nil. If the element is nil the code will panic. This changes it to check if the element in the slice is not nil before appending the element.