### PR TITLE
fix timeZone() not working on versions below 21.4

### DIFF
--- a/conn_http.go
+++ b/conn_http.go
@@ -239,7 +239,7 @@ func (h *httpConnect) isBad() bool {
 }
 
 func (h *httpConnect) readTimeZone(ctx context.Context) (*time.Location, error) {
-	rows, err := h.query(ctx, func(*connect, error) {}, "SELECT timeZone()")
+	rows, err := h.query(ctx, func(*connect, error) {}, "SELECT timezone()")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
CH Server below 21.4 does not understand the timeZone() function.
timezone() works fine through all versions therefore it should be used instead.

Fixes #780