### PR TITLE
Support inserting Enums as int8/int16/int values

### DIFF
--- a/lib/column/enum16.go
+++ b/lib/column/enum16.go
@@ -79,6 +79,46 @@ func (col *Enum16) ScanRow(dest interface{}, row int) error {
 
 func (col *Enum16) Append(v interface{}) (nulls []uint8, err error) {
 	switch v := v.(type) {
+	case []int16:
+		nulls = make([]uint8, len(v))
+		for _, elem := range v {
+			if err = col.AppendRow(elem); err != nil {
+				return nil, err
+			}
+		}
+	case []*int16:
+		nulls = make([]uint8, len(v))
+		for i, elem := range v {
+			switch {
+			case elem != nil:
+				if err = col.AppendRow(elem); err != nil {
+					return nil, err
+				}
+			default:
+				col.col.Append(0)
+				nulls[i] = 1
+			}
+		}
+	case []int:
+		nulls = make([]uint8, len(v))
+		for _, elem := range v {
+			if err = col.AppendRow(elem); err != nil {
+				return nil, err
+			}
+		}
+	case []*int:
+		nulls = make([]uint8, len(v))
+		for i, elem := range v {
+			switch {
+			case elem != nil:
+				if err = col.AppendRow(elem); err != nil {
+					return nil, err
+				}
+			default:
+				col.col.Append(0)
+				nulls[i] = 1
+			}
+		}
 	case []string:
 		nulls = make([]uint8, len(v))
 		for _, elem := range v {
@@ -115,6 +155,35 @@ func (col *Enum16) Append(v interface{}) (nulls []uint8, err error) {
 
 func (col *Enum16) AppendRow(elem interface{}) error {
 	switch elem := elem.(type) {
+	case int16:
+		return col.AppendRow(int(elem))
+	case *int16:
+		return col.AppendRow(int(*elem))
+	case int:
+		v := proto.Enum16(elem)
+		_, ok := col.vi[v]
+		if !ok {
+			return &Error{
+				Err:        fmt.Errorf("unknown element %v", elem),
+				ColumnType: string(col.chType),
+			}
+		}
+		col.col.Append(v)
+	case *int:
+		switch {
+		case elem != nil:
+			v := proto.Enum16(*elem)
+			_, ok := col.vi[v]
+			if !ok {
+				return &Error{
+					Err:        fmt.Errorf("unknown element %v", *elem),
+					ColumnType: string(col.chType),
+				}
+			}
+			col.col.Append(v)
+		default:
+			col.col.Append(0)
+		}
 	case string:
 		v, ok := col.iv[elem]
 		if !ok {

--- a/lib/column/enum8.go
+++ b/lib/column/enum8.go
@@ -79,6 +79,46 @@ func (col *Enum8) ScanRow(dest interface{}, row int) error {
 
 func (col *Enum8) Append(v interface{}) (nulls []uint8, err error) {
 	switch v := v.(type) {
+	case []int8:
+		nulls = make([]uint8, len(v))
+		for _, elem := range v {
+			if err = col.AppendRow(elem); err != nil {
+				return nil, err
+			}
+		}
+	case []*int8:
+		nulls = make([]uint8, len(v))
+		for i, elem := range v {
+			switch {
+			case elem != nil:
+				if err = col.AppendRow(elem); err != nil {
+					return nil, err
+				}
+			default:
+				col.col.Append(0)
+				nulls[i] = 1
+			}
+		}
+	case []int:
+		nulls = make([]uint8, len(v))
+		for _, elem := range v {
+			if err = col.AppendRow(elem); err != nil {
+				return nil, err
+			}
+		}
+	case []*int:
+		nulls = make([]uint8, len(v))
+		for i, elem := range v {
+			switch {
+			case elem != nil:
+				if err = col.AppendRow(elem); err != nil {
+					return nil, err
+				}
+			default:
+				col.col.Append(0)
+				nulls[i] = 1
+			}
+		}
 	case []string:
 		nulls = make([]uint8, len(v))
 		for _, elem := range v {
@@ -121,6 +161,35 @@ func (col *Enum8) Append(v interface{}) (nulls []uint8, err error) {
 
 func (col *Enum8) AppendRow(elem interface{}) error {
 	switch elem := elem.(type) {
+	case int8:
+		return col.AppendRow(int(elem))
+	case *int8:
+		return col.AppendRow(int(*elem))
+	case int:
+		v := proto.Enum8(elem)
+		_, ok := col.vi[v]
+		if !ok {
+			return &Error{
+				Err:        fmt.Errorf("unknown element %v", elem),
+				ColumnType: string(col.chType),
+			}
+		}
+		col.col.Append(v)
+	case *int:
+		switch {
+		case elem != nil:
+			v := proto.Enum8(*elem)
+			_, ok := col.vi[v]
+			if !ok {
+				return &Error{
+					Err:        fmt.Errorf("unknown element %v", *elem),
+					ColumnType: string(col.chType),
+				}
+			}
+			col.col.Append(v)
+		default:
+			col.col.Append(0)
+		}
 	case string:
 		v, ok := col.iv[elem]
 		if !ok {

--- a/tests/std/enum_test.go
+++ b/tests/std/enum_test.go
@@ -99,3 +99,103 @@ func TestStdEnum(t *testing.T) {
 		})
 	}
 }
+
+func TestStdEnumInsertAsInt(t *testing.T) {
+	dsns := map[string]clickhouse.Protocol{"Native": clickhouse.Native, "Http": clickhouse.HTTP}
+	useSSL, err := strconv.ParseBool(clickhouse_tests.GetEnv("CLICKHOUSE_USE_SSL", "false"))
+	require.NoError(t, err)
+	for name, protocol := range dsns {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
+			conn, err := GetStdDSNConnection(protocol, useSSL, "false")
+			require.NoError(t, err)
+			const ddl = `
+			CREATE TABLE test_enum_int (
+				  Col1 Enum  ('hello' = 1,  'world' = 2)
+				, Col2 Enum8 ('click' = 5,  'house' = 25)
+				, Col3 Enum16('house' = 10,   'value' = 50)
+				, Col4 Array(Enum8  ('click' = 1, 'house' = 2))
+				, Col5 Array(Enum16 ('click' = 1, 'house' = 2))
+				, Col6 Array(Nullable(Enum8  ('click' = 1, 'house' = 2)))
+				, Col7 Array(Nullable(Enum16 ('click' = 1, 'house' = 2)))
+			) Engine MergeTree() ORDER BY tuple()
+		`
+			defer func() {
+				conn.Exec("DROP TABLE test_enum_int")
+			}()
+			_, err = conn.Exec(ddl)
+			require.NoError(t, err)
+			scope, err := conn.Begin()
+			require.NoError(t, err)
+			batch, err := scope.Prepare("INSERT INTO test_enum_int")
+			require.NoError(t, err)
+			var (
+				col6Int8Val  = int8(2)
+				col7Int16Val = int16(2)
+				col1Data     = 1
+				col2Data     = int8(5)
+				col3Data     = int16(10)
+				col4Data     = []int8{1, 2}
+				col5Data     = []int16{2, 1}
+				col6Data     = []*int8{&col6Int8Val, nil, &col6Int8Val}
+				col7Data     = []*int16{&col7Int16Val, nil, &col7Int16Val}
+			)
+			_, err = batch.Exec(
+				col1Data,
+				col2Data,
+				col3Data,
+				col4Data,
+				col5Data,
+				col6Data,
+				col7Data,
+			)
+			require.NoError(t, err)
+			require.NoError(t, scope.Commit())
+			var (
+				col1 int8
+				col2 int8
+				col3 int16
+				col4 []string
+				col5 []string
+				col6 []*string
+				col7 []*string
+			)
+			require.NoError(t, conn.QueryRow(`SELECT 
+					  CAST(Col1, 'Int8') AS Col1
+					, CAST(Col2, 'Int8') AS Col2
+					, CAST(Col3, 'Int16') AS Col3
+					, Col4
+					, Col5
+					, Col6
+					, Col7
+					FROM test_enum_int`).Scan(
+				&col1, &col2, &col3, &col4,
+				&col5, &col6, &col7,
+			))
+			assert.Equal(t, int8(col1Data), col1) // cast for comparing correctly
+			assert.Equal(t, col2Data, col2)
+			assert.Equal(t, col3Data, col3)
+			assert.Equal(t, []string{"click", "house"}, col4)
+			assert.Equal(t, []string{"house", "click"}, col5)
+			houseVal := "house"
+			assert.Equal(t, []*string{&houseVal, nil, &houseVal}, col6)
+			assert.Equal(t, []*string{&houseVal, nil, &houseVal}, col7)
+
+			// Error should be thrown for invalid Enum value
+			scopeFail, err := conn.Begin()
+			require.NoError(t, err)
+			batchFail, err := scopeFail.Prepare("INSERT INTO test_enum_int")
+			require.NoError(t, err)
+			_, err = batchFail.Exec(
+				col1Data,
+				col2Data,
+				100, // Only 10,50 are known
+				col4Data,
+				col5Data,
+				col6Data,
+				col7Data,
+			)
+			require.Error(t, err)
+			require.Error(t, scope.Rollback()) // Errors because already rolled-back
+		})
+	}
+}


### PR DESCRIPTION
`Enum` values in ClickHouse are always stored as numeric (`Int8` or `Int16`) values. While normally they will be retrieved as `String` values in Golang, in queries its perfectly fine to insert them as the numeric value.

Customers might have their reasons to insert as numeric value instead of the string value. Extend the API so batch inserts support this, as currently you would get the error:
```
        	Error:      	Received unexpected error:
        	            	clickhouse [AppendRow]: auth_type clickhouse [AppendRow]: converting int8 to Enum8 is unsupported
```

