### PR TITLE
Allow optional HTTP headers; For HTTPS connections, pass auth as headers

### DIFF
--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -129,7 +129,8 @@ type Options struct {
 	MaxIdleConns     int           // default 5
 	ConnMaxLifetime  time.Duration // default 1 hour
 	ConnOpenStrategy ConnOpenStrategy
-	BlockBufferSize  uint8 // default 2 - can be overwritten on query
+	HttpHeaders      map[string]string // set additional headers on HTTP requests
+	BlockBufferSize  uint8             // default 2 - can be overwritten on query
 
 	scheme      string
 	ReadTimeout time.Duration

--- a/conn_http_query.go
+++ b/conn_http_query.go
@@ -21,10 +21,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	chproto "github.com/ClickHouse/ch-go/proto"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"io"
 	"strings"
+
+	chproto "github.com/ClickHouse/ch-go/proto"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
 // release is ignored, because http used by std with empty release function
@@ -41,6 +42,10 @@ func (h *httpConnect) query(ctx context.Context, release func(*connect, error), 
 	case CompressionGZIP, CompressionDeflate, CompressionBrotli:
 		// request encoding
 		headers["Accept-Encoding"] = h.compression.String()
+	}
+
+	for k, v := range h.additionalHttpHeaders {
+		headers[k] = v
 	}
 
 	res, err := h.sendQuery(ctx, strings.NewReader(query), &options, headers)


### PR DESCRIPTION
Some proxies require additional headers to be passed with HTTP requests in order to work correctly.
Additionally, in HTTPS mode IMO it makes sense to pass username and password as headers by default, since the URLs are not incrypted.