### PR TITLE
Avoid panic when decoding an array of tuple with nullable properties …

### DIFF
--- a/lib/column/tuple.go
+++ b/lib/column/tuple.go
@@ -289,8 +289,8 @@ func (col *Tuple) scanMap(targetMap reflect.Value, row int) error {
 		default:
 			val := c.Row(row, false)
 			if val != nil {
-				field := reflect.New(reflect.TypeOf(c.Row(0, false))).Elem()
-				value := reflect.ValueOf(c.Row(row, false))
+				field := reflect.New(reflect.TypeOf(val)).Elem()
+				value := reflect.ValueOf(val)
 				if err := setJSONFieldValue(field, value); err != nil {
 					return err
 				}

--- a/lib/column/tuple.go
+++ b/lib/column/tuple.go
@@ -295,7 +295,7 @@ func (col *Tuple) scanMap(targetMap reflect.Value, row int) error {
 					return err
 				}
 				targetMap.SetMapIndex(reflect.ValueOf(colName), field)
-			} else {
+			} else if _, isNullable := c.(*Nullable); !isNullable {
 				targetMap.SetMapIndex(reflect.ValueOf(colName), reflect.Zero(c.ScanType().Elem()))
 			}
 


### PR DESCRIPTION
Following a debugging session of issue #816 

It seems that the proposed change do fix the issue