### PR TITLE
dont panic batch on send after invalid append

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -41,6 +41,7 @@ type (
 )
 
 var (
+	ErrBatchInvalid              = errors.New("clickhouse: batch is invalid. check appended data is correct")
 	ErrBatchAlreadySent          = errors.New("clickhouse: batch has already been sent")
 	ErrAcquireConnTimeout        = errors.New("clickhouse: acquire conn timeout. you can increase the number of max open conn or the dial timeout")
 	ErrUnsupportedServerRevision = errors.New("clickhouse: unsupported server revision")

--- a/conn_batch.go
+++ b/conn_batch.go
@@ -20,6 +20,7 @@ package clickhouse
 import (
 	"context"
 	"fmt"
+	"github.com/pkg/errors"
 	"os"
 	"regexp"
 	"strings"
@@ -105,6 +106,7 @@ func (b *batch) Append(v ...interface{}) error {
 	}
 	//
 	if err := b.block.Append(v...); err != nil {
+		b.err = errors.Wrap(ErrBatchInvalid, err.Error())
 		b.release(err)
 		return err
 	}

--- a/tests/issues/798_test.go
+++ b/tests/issues/798_test.go
@@ -1,0 +1,52 @@
+package issues
+
+import (
+	"context"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test798(t *testing.T) {
+	var (
+		conn, err = clickhouse_tests.GetConnection("issues", clickhouse.Settings{
+			"max_execution_time": 60,
+		}, nil, &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		})
+	)
+	ctx := context.Background()
+	require.NoError(t, err)
+	const ddl = `
+			CREATE TABLE test_issue_798 (
+				  Col1 Bool
+				, Col2 Bool
+				, Col3 Array(Bool)
+			) Engine MergeTree() ORDER BY tuple()
+		`
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE IF EXISTS test_issue_798")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_issue_798")
+	require.NoError(t, err)
+	require.NoError(t, batch.Append(true, false, []bool{true, false, true}))
+	require.NoError(t, batch.Send())
+	// test resend
+	require.ErrorIs(t, batch.Send(), clickhouse.ErrBatchAlreadySent)
+	batch, err = conn.PrepareBatch(ctx, "INSERT INTO test_issue_798")
+	require.NoError(t, err)
+	// test empty batch
+	require.NoError(t, batch.Send())
+	batch, err = conn.PrepareBatch(ctx, "INSERT INTO test_issue_798")
+	// append invalid batch
+	require.Error(t, batch.Append("true", false, []bool{true, false, true}))
+	// send invalid batch
+	require.ErrorIs(t, batch.Send(), clickhouse.ErrBatchInvalid)
+	// test append, send, append
+	batch, err = conn.PrepareBatch(ctx, "INSERT INTO test_issue_798")
+	require.NoError(t, batch.Append(true, false, []bool{true, false, true}))
+	require.NoError(t, batch.Send())
+	require.ErrorIs(t, batch.Append(true, false, []bool{true, false, true}), clickhouse.ErrBatchAlreadySent)
+}

--- a/tests/issues/798_test.go
+++ b/tests/issues/798_test.go
@@ -43,6 +43,7 @@ func Test798(t *testing.T) {
 	// append invalid batch
 	require.Error(t, batch.Append("true", false, []bool{true, false, true}))
 	// send invalid batch
+	require.ErrorIs(t, batch.Flush(), clickhouse.ErrBatchInvalid)
 	require.ErrorIs(t, batch.Send(), clickhouse.ErrBatchInvalid)
 	// test append, send, append
 	batch, err = conn.PrepareBatch(ctx, "INSERT INTO test_issue_798")


### PR DESCRIPTION
Closes [issue_798](https://github.com/ClickHouse/clickhouse-go/issues/798)

Failed `Append` followed by `Send` currently causes panic. 

This fixes so an `Append` of invalid data invalidates the batch and `Send` returns an error. 

Better would be that the `Append` of invalid data fails but the batch is still valid - `Send` will then succeed. This is trickier as columns are added one by one. If the error occurs due to a column other than the first, we have to undo the previous changes. I suspect this isn't trivial as it will mean reversing the changes to the buffer. We could check to see all values are valid beforehand - this will incur an overhead though. Will raise an issue for this as it needs benchmarking.