### PR TITLE
Introduce CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+## 2.4.2, 2022-11-24
+### Bug Fixes
+- Don't panic on `Send()` on batch after invalid `Append`. [#830](https://github.com/ClickHouse/clickhouse-go/pull/830)
+- Fix JSON issue with `nil` if column order is inconsisent. [#824](https://github.com/ClickHouse/clickhouse-go/pull/824)
+
+## 2.4.1, 2022-11-23
+### Bug Fixes
+- Patch release to fix "Regression - escape character was not considered when comparing column names". [#828](https://github.com/ClickHouse/clickhouse-go/issues/828)
+
+## 2.4.0, 2022-11-22
+### New Features
+- Support for Nullables in Tuples. [#821](https://github.com/ClickHouse/clickhouse-go/pull/821) [#817](https://github.com/ClickHouse/clickhouse-go/pull/817)
+- Use headers for auth and not url if SSL. [#811](https://github.com/ClickHouse/clickhouse-go/pull/811)
+- Support additional headers. [#811](https://github.com/ClickHouse/clickhouse-go/pull/811)
+- Support int64 for DateTime. [#807](https://github.com/ClickHouse/clickhouse-go/pull/807)
+- Support inserting Enums as int8/int16/int. [#802](https://github.com/ClickHouse/clickhouse-go/pull/802)
+- Print error if unsupported server. [#792](https://github.com/ClickHouse/clickhouse-go/pull/792)
+- Allow block buffer size to tuned for performance - see `BlockBufferSize`. [#776](https://github.com/ClickHouse/clickhouse-go/pull/776)
+- Support custom datetime in Scan. [#767](https://github.com/ClickHouse/clickhouse-go/pull/767)
+- Support insertion of an orderedmap. [#763](https://github.com/ClickHouse/clickhouse-go/pull/763)
+
+### Bug Fixes
+- Decompress errors over HTTP. [#792](https://github.com/ClickHouse/clickhouse-go/pull/792)
+- Use `timezone` vs `timeZone` so we work on older versions. [#781](https://github.com/ClickHouse/clickhouse-go/pull/781)
+- Ensure only columns specified in INSERT are required in batch. [#790](https://github.com/ClickHouse/clickhouse-go/pull/790)
+- Respect order of columns in insert for batch. [#790](https://github.com/ClickHouse/clickhouse-go/pull/790)
+- Handle double pointers for Nullable columns when batch inserting. [#774](https://github.com/ClickHouse/clickhouse-go/pull/774)
+- Use nil for `LowCardinality(Nullable(X))`. [#768](https://github.com/ClickHouse/clickhouse-go/pull/768)
+
+### Breaking Changes
+- Align timezone handling with spec. [#776](https://github.com/ClickHouse/clickhouse-go/pull/766), specifically:
+    - If parsing strings for datetime, datetime64 or dates we assume the locale is Local (i.e. the client) if not specified in the string.
+    - The server (or column tz) is used for datetime and datetime64 rendering. For date/date32, these have no tz info in the server. For now, they will be rendered as UTC - consistent with the clickhouse-client
+    - Addresses bind when no location is set


### PR DESCRIPTION
Adds standard CHANGELOG.md to report notable changes between versions. A separate file is easy to port for the different representations (on the website, application UI, etc.).
Starting from the next release, we can reference CHANGELOG.md from `Release notes` to have a single source of truth. 