### PR TITLE
concurrency on batch fix

### DIFF
--- a/conn_batch.go
+++ b/conn_batch.go
@@ -35,6 +35,11 @@ var splitInsertRe = regexp.MustCompile(`(?i)\sVALUES\s*\(`)
 var columnMatch = regexp.MustCompile(`.*\((?P<Columns>.+)\)$`)
 
 func (c *connect) prepareBatch(ctx context.Context, query string, release func(*connect, error)) (driver.Batch, error) {
+	//defer func() {
+	//	if err := recover(); err != nil {
+	//		fmt.Printf("panic occurred on %d:\n", c.num)
+	//	}
+	//}()
 	query = splitInsertRe.Split(query, -1)[0]
 	colMatch := columnMatch.FindStringSubmatch(query)
 	var columns []string
@@ -69,24 +74,31 @@ func (c *connect) prepareBatch(ctx context.Context, query string, release func(*
 		return nil, err
 	}
 	return &batch{
-		ctx:   ctx,
-		conn:  c,
-		block: block,
-		release: func(err error) {
-			release(c, err)
-		},
-		onProcess: onProcess,
+		ctx:         ctx,
+		conn:        c,
+		block:       block,
+		released:    false,
+		connRelease: release,
+		onProcess:   onProcess,
 	}, nil
 }
 
 type batch struct {
-	err       error
-	ctx       context.Context
-	conn      *connect
-	sent      bool
-	block     *proto.Block
-	release   func(error)
-	onProcess *onProcess
+	err         error
+	ctx         context.Context
+	conn        *connect
+	sent        bool
+	released    bool
+	block       *proto.Block
+	connRelease func(*connect, error)
+	onProcess   *onProcess
+}
+
+func (b *batch) release(err error) {
+	if !b.released {
+		b.released = true
+		b.connRelease(b.conn, err)
+	}
 }
 
 func (b *batch) Abort() error {
@@ -104,7 +116,9 @@ func (b *batch) Append(v ...interface{}) error {
 	if b.sent {
 		return ErrBatchAlreadySent
 	}
-	//
+	if b.err != nil {
+		return b.err
+	}
 	if err := b.block.Append(v...); err != nil {
 		b.err = errors.Wrap(ErrBatchInvalid, err.Error())
 		b.release(err)
@@ -114,6 +128,9 @@ func (b *batch) Append(v ...interface{}) error {
 }
 
 func (b *batch) AppendStruct(v interface{}) error {
+	if b.err != nil {
+		return b.err
+	}
 	values, err := b.conn.structMap.Map("AppendStruct", b.block.ColumnsNames(), v, false)
 	if err != nil {
 		return err


### PR DESCRIPTION
Close #798 specifically https://github.com/ClickHouse/clickhouse-go/issues/798#issuecomment-1330584467

The issue was originally detected due to the use of a batch in a go routine and `Abort` being called after the connection was released on the batch. This would invalidate the connection which had been subsequently reassigned.

This issue could occur as soon as the conn is released (this can happen in a number of places e.g. after `Send` or an `Append` error), and it potentially returns to the pool for use in another go routine. Subsequent releases could then occur e.g., the user calls `Abort` mainly but also `Send` would do it. The result is the connection being closed in the `release` function while another batch or query potentially used it.

This adds a guard - it prevents release being called more than once on a batch. It assumes that batches are not thread safe - they aren't (only connections are).