### PR TITLE
Closes #848 (quoted column name in INSERT INTO)

### DIFF
--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -45,7 +45,7 @@ func (h *httpConnect) prepareBatch(ctx context.Context, query string, release fu
 		colMatch := strings.TrimSuffix(strings.TrimPrefix(matches[2], "("), ")")
 		rColumns = strings.Split(colMatch, ",")
 		for i := range rColumns {
-			rColumns[i] = strings.TrimSpace(rColumns[i])
+			rColumns[i] = strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(rColumns[i]), "`"), "`")
 		}
 	}
 	query = "INSERT INTO " + tableName + " FORMAT Native"


### PR DESCRIPTION
Closes #848 by unquoting column names similar to how the brackets are currently parsed %)