### PR TITLE
Support custom types (eg type customString string)

### DIFF
--- a/examples/clickhouse_api/custom_types.go
+++ b/examples/clickhouse_api/custom_types.go
@@ -51,7 +51,7 @@ func CustomTypes() error {
 	err = conn.Exec(ctx, `
 		CREATE TABLE IF NOT EXISTS example (
 			  Col1 String,
-			  Col2 Enum ('hello'   = 1,  'world' = 2),
+			  Col2 Enum ('hello'   = 1,  'world' = 2)
 		) Engine = Memory
 	`)
 	if err != nil {

--- a/examples/clickhouse_api/custom_types.go
+++ b/examples/clickhouse_api/custom_types.go
@@ -1,0 +1,88 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package clickhouse_api
+
+import (
+	"context"
+	"fmt"
+)
+
+type customStr string
+
+func (s *customStr) Scan(src any) error {
+	if t, ok := src.(string); ok {
+		*s = customStr(t)
+		return nil
+	}
+	return fmt.Errorf("cannot scan %T into customStr", src)
+}
+
+func (s customStr) String() string {
+	return string(s)
+}
+
+func CustomTypes() error {
+	conn, err := GetNativeConnection(nil, nil, nil)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	defer func() {
+		conn.Exec(context.Background(), "DROP TABLE example")
+	}()
+	if err := conn.Exec(ctx, `DROP TABLE IF EXISTS example`); err != nil {
+		return err
+	}
+	err = conn.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS example (
+			  Col1 String,
+			  Col2 Enum ('hello'   = 1,  'world' = 2),
+		) Engine = Memory
+	`)
+	if err != nil {
+		return err
+	}
+
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO example")
+	if err != nil {
+		return err
+	}
+
+	err = batch.Append(
+		customStr("A"), customStr("hello"),
+	)
+	if err != nil {
+		return err
+	}
+
+	err = batch.Send()
+	if err != nil {
+		return err
+	}
+
+	var (
+		col1 customStr
+		col2 customStr
+	)
+
+	if err = conn.QueryRow(ctx, "SELECT * FROM example").Scan(&col1, &col2); err != nil {
+		return err
+	}
+	fmt.Printf("col1=%v (T=%T), col2=%v (T=%T)\n", col1, col1, col2, col2)
+	return nil
+}

--- a/examples/clickhouse_api/main_test.go
+++ b/examples/clickhouse_api/main_test.go
@@ -127,6 +127,10 @@ func TestContext(t *testing.T) {
 	require.NoError(t, UseContext())
 }
 
+func TestCustomTypes(t *testing.T) {
+	require.NoError(t, CustomTypes())
+}
+
 func TestDynamicScan(t *testing.T) {
 	require.NoError(t, DynamicScan())
 }

--- a/lib/column/array.go
+++ b/lib/column/array.go
@@ -240,10 +240,6 @@ func (col *Array) scan(sliceType reflect.Type, row int) (reflect.Value, error) {
 		}
 		return subSlice, nil
 	}
-	return reflect.Value{}, &Error{
-		ColumnType: fmt.Sprint(sliceType.Kind()),
-		Err:        fmt.Errorf("column %s - needs a slice or interface{}", col.Name()),
-	}
 }
 
 func (col *Array) scanSlice(sliceType reflect.Type, row int, level int) (reflect.Value, error) {
@@ -352,7 +348,6 @@ func (col *Array) scanSliceOfObjects(sliceType reflect.Type, row int) (reflect.V
 				Err:        fmt.Errorf("column %s - needs a slice of objects or an interface{}", col.Name()),
 			}
 		}
-		return reflect.Value{}, nil
 	}
 	return reflect.Value{}, &Error{
 		ColumnType: fmt.Sprint(sliceType.Kind()),

--- a/lib/column/bool.go
+++ b/lib/column/bool.go
@@ -65,7 +65,7 @@ func (col *Bool) ScanRow(dest interface{}, row int) error {
 		*d = new(bool)
 		**d = col.row(row)
 	case *sql.NullBool:
-		d.Scan(col.row(row))
+		return d.Scan(col.row(row))
 	default:
 		return &ColumnConverterError{
 			Op:   "ScanRow",

--- a/lib/column/codegen/column.tpl
+++ b/lib/column/codegen/column.tpl
@@ -381,10 +381,14 @@ func (col *{{ .ChType }}) AppendRow(v interface{}) error {
         col.col.Append(val)
 	{{- end }}
 	default:
-		return &ColumnConverterError{
-			Op:   "AppendRow",
-			To:   "{{ .ChType }}",
-			From: fmt.Sprintf("%T", v),
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+			col.col.Append(rv.Convert(col.ScanType()).Interface().({{ .GoType }}))
+		} else {
+			return &ColumnConverterError{
+				Op:   "AppendRow",
+				To:   "{{ .ChType }}",
+				From: fmt.Sprintf("%T", v),
+			}
 		}
 	}
 	return nil

--- a/lib/column/codegen/column.tpl
+++ b/lib/column/codegen/column.tpl
@@ -227,7 +227,7 @@ func (col *{{ .ChType }}) ScanRow(dest interface{}, row int) error {
 	{{- end }}
 	{{- if or (eq .ChType "Int64") (eq .ChType "Int32") (eq .ChType "Int16") (eq .ChType "Float64") }}
 	case *sql.Null{{ .ChType }}:
-		d.Scan(value)
+		return d.Scan(value)
 	{{- end }}
     {{- if eq .ChType "Int8" }}
 	case *bool:
@@ -239,6 +239,9 @@ func (col *{{ .ChType }}) ScanRow(dest interface{}, row int) error {
 		}
     {{- end }}
 	default:
+		if scan, ok := dest.(sql.Scanner); ok {
+			return scan.Scan(value)
+		}
 		return &ColumnConverterError{
 			Op:   "ScanRow",
 			To:   fmt.Sprintf("%T", dest),

--- a/lib/column/column_gen.go
+++ b/lib/column/column_gen.go
@@ -285,6 +285,9 @@ func (col *Float32) ScanRow(dest interface{}, row int) error {
 		*d = new(float32)
 		**d = value
 	default:
+		if scan, ok := dest.(sql.Scanner); ok {
+			return scan.Scan(value)
+		}
 		return &ColumnConverterError{
 			Op:   "ScanRow",
 			To:   fmt.Sprintf("%T", dest),
@@ -391,8 +394,11 @@ func (col *Float64) ScanRow(dest interface{}, row int) error {
 		*d = new(float64)
 		**d = value
 	case *sql.NullFloat64:
-		d.Scan(value)
+		return d.Scan(value)
 	default:
+		if scan, ok := dest.(sql.Scanner); ok {
+			return scan.Scan(value)
+		}
 		return &ColumnConverterError{
 			Op:   "ScanRow",
 			To:   fmt.Sprintf("%T", dest),
@@ -533,6 +539,9 @@ func (col *Int8) ScanRow(dest interface{}, row int) error {
 			*d = true
 		}
 	default:
+		if scan, ok := dest.(sql.Scanner); ok {
+			return scan.Scan(value)
+		}
 		return &ColumnConverterError{
 			Op:   "ScanRow",
 			To:   fmt.Sprintf("%T", dest),
@@ -669,8 +678,11 @@ func (col *Int16) ScanRow(dest interface{}, row int) error {
 		*d = new(int16)
 		**d = value
 	case *sql.NullInt16:
-		d.Scan(value)
+		return d.Scan(value)
 	default:
+		if scan, ok := dest.(sql.Scanner); ok {
+			return scan.Scan(value)
+		}
 		return &ColumnConverterError{
 			Op:   "ScanRow",
 			To:   fmt.Sprintf("%T", dest),
@@ -804,8 +816,11 @@ func (col *Int32) ScanRow(dest interface{}, row int) error {
 		*d = new(int32)
 		**d = value
 	case *sql.NullInt32:
-		d.Scan(value)
+		return d.Scan(value)
 	default:
+		if scan, ok := dest.(sql.Scanner); ok {
+			return scan.Scan(value)
+		}
 		return &ColumnConverterError{
 			Op:   "ScanRow",
 			To:   fmt.Sprintf("%T", dest),
@@ -941,8 +956,11 @@ func (col *Int64) ScanRow(dest interface{}, row int) error {
 	case *time.Duration:
 		*d = time.Duration(value)
 	case *sql.NullInt64:
-		d.Scan(value)
+		return d.Scan(value)
 	default:
+		if scan, ok := dest.(sql.Scanner); ok {
+			return scan.Scan(value)
+		}
 		return &ColumnConverterError{
 			Op:   "ScanRow",
 			To:   fmt.Sprintf("%T", dest),
@@ -1080,6 +1098,9 @@ func (col *UInt8) ScanRow(dest interface{}, row int) error {
 		*d = new(uint8)
 		**d = value
 	default:
+		if scan, ok := dest.(sql.Scanner); ok {
+			return scan.Scan(value)
+		}
 		return &ColumnConverterError{
 			Op:   "ScanRow",
 			To:   fmt.Sprintf("%T", dest),
@@ -1192,6 +1213,9 @@ func (col *UInt16) ScanRow(dest interface{}, row int) error {
 		*d = new(uint16)
 		**d = value
 	default:
+		if scan, ok := dest.(sql.Scanner); ok {
+			return scan.Scan(value)
+		}
 		return &ColumnConverterError{
 			Op:   "ScanRow",
 			To:   fmt.Sprintf("%T", dest),
@@ -1298,6 +1322,9 @@ func (col *UInt32) ScanRow(dest interface{}, row int) error {
 		*d = new(uint32)
 		**d = value
 	default:
+		if scan, ok := dest.(sql.Scanner); ok {
+			return scan.Scan(value)
+		}
 		return &ColumnConverterError{
 			Op:   "ScanRow",
 			To:   fmt.Sprintf("%T", dest),
@@ -1404,6 +1431,9 @@ func (col *UInt64) ScanRow(dest interface{}, row int) error {
 		*d = new(uint64)
 		**d = value
 	default:
+		if scan, ok := dest.(sql.Scanner); ok {
+			return scan.Scan(value)
+		}
 		return &ColumnConverterError{
 			Op:   "ScanRow",
 			To:   fmt.Sprintf("%T", dest),

--- a/lib/column/column_gen.go
+++ b/lib/column/column_gen.go
@@ -348,10 +348,14 @@ func (col *Float32) AppendRow(v interface{}) error {
 	case nil:
 		col.col.Append(0)
 	default:
-		return &ColumnConverterError{
-			Op:   "AppendRow",
-			To:   "Float32",
-			From: fmt.Sprintf("%T", v),
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+			col.col.Append(rv.Convert(col.ScanType()).Interface().(float32))
+		} else {
+			return &ColumnConverterError{
+				Op:   "AppendRow",
+				To:   "Float32",
+				From: fmt.Sprintf("%T", v),
+			}
 		}
 	}
 	return nil
@@ -486,10 +490,14 @@ func (col *Float64) AppendRow(v interface{}) error {
 			col.col.Append(0)
 		}
 	default:
-		return &ColumnConverterError{
-			Op:   "AppendRow",
-			To:   "Float64",
-			From: fmt.Sprintf("%T", v),
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+			col.col.Append(rv.Convert(col.ScanType()).Interface().(float64))
+		} else {
+			return &ColumnConverterError{
+				Op:   "AppendRow",
+				To:   "Float64",
+				From: fmt.Sprintf("%T", v),
+			}
 		}
 	}
 	return nil
@@ -632,10 +640,14 @@ func (col *Int8) AppendRow(v interface{}) error {
 		}
 		col.col.Append(val)
 	default:
-		return &ColumnConverterError{
-			Op:   "AppendRow",
-			To:   "Int8",
-			From: fmt.Sprintf("%T", v),
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+			col.col.Append(rv.Convert(col.ScanType()).Interface().(int8))
+		} else {
+			return &ColumnConverterError{
+				Op:   "AppendRow",
+				To:   "Int8",
+				From: fmt.Sprintf("%T", v),
+			}
 		}
 	}
 	return nil
@@ -770,10 +782,14 @@ func (col *Int16) AppendRow(v interface{}) error {
 			col.col.Append(0)
 		}
 	default:
-		return &ColumnConverterError{
-			Op:   "AppendRow",
-			To:   "Int16",
-			From: fmt.Sprintf("%T", v),
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+			col.col.Append(rv.Convert(col.ScanType()).Interface().(int16))
+		} else {
+			return &ColumnConverterError{
+				Op:   "AppendRow",
+				To:   "Int16",
+				From: fmt.Sprintf("%T", v),
+			}
 		}
 	}
 	return nil
@@ -908,10 +924,14 @@ func (col *Int32) AppendRow(v interface{}) error {
 			col.col.Append(0)
 		}
 	default:
-		return &ColumnConverterError{
-			Op:   "AppendRow",
-			To:   "Int32",
-			From: fmt.Sprintf("%T", v),
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+			col.col.Append(rv.Convert(col.ScanType()).Interface().(int32))
+		} else {
+			return &ColumnConverterError{
+				Op:   "AppendRow",
+				To:   "Int32",
+				From: fmt.Sprintf("%T", v),
+			}
 		}
 	}
 	return nil
@@ -1052,10 +1072,14 @@ func (col *Int64) AppendRow(v interface{}) error {
 	case *time.Duration:
 		col.col.Append(int64(*v))
 	default:
-		return &ColumnConverterError{
-			Op:   "AppendRow",
-			To:   "Int64",
-			From: fmt.Sprintf("%T", v),
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+			col.col.Append(rv.Convert(col.ScanType()).Interface().(int64))
+		} else {
+			return &ColumnConverterError{
+				Op:   "AppendRow",
+				To:   "Int64",
+				From: fmt.Sprintf("%T", v),
+			}
 		}
 	}
 	return nil
@@ -1167,10 +1191,14 @@ func (col *UInt8) AppendRow(v interface{}) error {
 		}
 		col.col.Append(t)
 	default:
-		return &ColumnConverterError{
-			Op:   "AppendRow",
-			To:   "UInt8",
-			From: fmt.Sprintf("%T", v),
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+			col.col.Append(rv.Convert(col.ScanType()).Interface().(uint8))
+		} else {
+			return &ColumnConverterError{
+				Op:   "AppendRow",
+				To:   "UInt8",
+				From: fmt.Sprintf("%T", v),
+			}
 		}
 	}
 	return nil
@@ -1276,10 +1304,14 @@ func (col *UInt16) AppendRow(v interface{}) error {
 	case nil:
 		col.col.Append(0)
 	default:
-		return &ColumnConverterError{
-			Op:   "AppendRow",
-			To:   "UInt16",
-			From: fmt.Sprintf("%T", v),
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+			col.col.Append(rv.Convert(col.ScanType()).Interface().(uint16))
+		} else {
+			return &ColumnConverterError{
+				Op:   "AppendRow",
+				To:   "UInt16",
+				From: fmt.Sprintf("%T", v),
+			}
 		}
 	}
 	return nil
@@ -1385,10 +1417,14 @@ func (col *UInt32) AppendRow(v interface{}) error {
 	case nil:
 		col.col.Append(0)
 	default:
-		return &ColumnConverterError{
-			Op:   "AppendRow",
-			To:   "UInt32",
-			From: fmt.Sprintf("%T", v),
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+			col.col.Append(rv.Convert(col.ScanType()).Interface().(uint32))
+		} else {
+			return &ColumnConverterError{
+				Op:   "AppendRow",
+				To:   "UInt32",
+				From: fmt.Sprintf("%T", v),
+			}
 		}
 	}
 	return nil
@@ -1494,10 +1530,14 @@ func (col *UInt64) AppendRow(v interface{}) error {
 	case nil:
 		col.col.Append(0)
 	default:
-		return &ColumnConverterError{
-			Op:   "AppendRow",
-			To:   "UInt64",
-			From: fmt.Sprintf("%T", v),
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+			col.col.Append(rv.Convert(col.ScanType()).Interface().(uint64))
+		} else {
+			return &ColumnConverterError{
+				Op:   "AppendRow",
+				To:   "UInt64",
+				From: fmt.Sprintf("%T", v),
+			}
 		}
 	}
 	return nil

--- a/lib/column/date.go
+++ b/lib/column/date.go
@@ -76,7 +76,7 @@ func (col *Date) ScanRow(dest interface{}, row int) error {
 		*d = new(time.Time)
 		**d = col.row(row)
 	case *sql.NullTime:
-		d.Scan(col.row(row))
+		return d.Scan(col.row(row))
 	default:
 		if scan, ok := dest.(sql.Scanner); ok {
 			return scan.Scan(col.row(row))

--- a/lib/column/date32.go
+++ b/lib/column/date32.go
@@ -71,7 +71,7 @@ func (col *Date32) ScanRow(dest interface{}, row int) error {
 		*d = new(time.Time)
 		**d = col.row(row)
 	case *sql.NullTime:
-		d.Scan(col.row(row))
+		return d.Scan(col.row(row))
 	default:
 		if scan, ok := dest.(sql.Scanner); ok {
 			return scan.Scan(col.row(row))

--- a/lib/column/datetime.go
+++ b/lib/column/datetime.go
@@ -94,7 +94,7 @@ func (col *DateTime) ScanRow(dest interface{}, row int) error {
 		*d = new(time.Time)
 		**d = col.row(row)
 	case *sql.NullTime:
-		d.Scan(col.row(row))
+		return d.Scan(col.row(row))
 	default:
 		if scan, ok := dest.(sql.Scanner); ok {
 			return scan.Scan(col.row(row))

--- a/lib/column/datetime64.go
+++ b/lib/column/datetime64.go
@@ -114,7 +114,7 @@ func (col *DateTime64) ScanRow(dest interface{}, row int) error {
 		*d = new(time.Time)
 		**d = col.row(row)
 	case *sql.NullTime:
-		d.Scan(col.row(row))
+		return d.Scan(col.row(row))
 	default:
 		if scan, ok := dest.(sql.Scanner); ok {
 			return scan.Scan(col.row(row))

--- a/lib/column/decimal.go
+++ b/lib/column/decimal.go
@@ -18,6 +18,7 @@
 package column
 
 import (
+	"database/sql"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -137,6 +138,9 @@ func (col *Decimal) ScanRow(dest interface{}, row int) error {
 		*d = new(decimal.Decimal)
 		**d = *col.row(row)
 	default:
+		if scan, ok := dest.(sql.Scanner); ok {
+			return scan.Scan(*col.row(row))
+		}
 		return &ColumnConverterError{
 			Op:   "ScanRow",
 			To:   fmt.Sprintf("%T", dest),

--- a/lib/column/enum16.go
+++ b/lib/column/enum16.go
@@ -18,6 +18,7 @@
 package column
 
 import (
+	"database/sql"
 	"fmt"
 	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
@@ -68,6 +69,9 @@ func (col *Enum16) ScanRow(dest interface{}, row int) error {
 		*d = new(string)
 		**d = col.vi[value]
 	default:
+		if scan, ok := dest.(sql.Scanner); ok {
+			return scan.Scan(col.vi[value])
+		}
 		return &ColumnConverterError{
 			Op:   "ScanRow",
 			To:   fmt.Sprintf("%T", dest),
@@ -210,10 +214,14 @@ func (col *Enum16) AppendRow(elem interface{}) error {
 	case nil:
 		col.col.Append(0)
 	default:
-		return &ColumnConverterError{
-			Op:   "AppendRow",
-			To:   "Enum16",
-			From: fmt.Sprintf("%T", elem),
+		if s, ok := elem.(fmt.Stringer); ok {
+			return col.AppendRow(s.String())
+		} else {
+			return &ColumnConverterError{
+				Op:   "AppendRow",
+				To:   "Enum16",
+				From: fmt.Sprintf("%T", elem),
+			}
 		}
 	}
 	return nil

--- a/lib/column/string.go
+++ b/lib/column/string.go
@@ -69,10 +69,13 @@ func (col *String) ScanRow(dest interface{}, row int) error {
 		*d = new(string)
 		**d = val
 	case *sql.NullString:
-		d.Scan(val)
+		return d.Scan(val)
 	case encoding.BinaryUnmarshaler:
 		return d.UnmarshalBinary(binary.Str2Bytes(val))
 	default:
+		if scan, ok := dest.(sql.Scanner); ok {
+			return scan.Scan(val)
+		}
 		return &ColumnConverterError{
 			Op:   "ScanRow",
 			To:   fmt.Sprintf("%T", dest),

--- a/lib/column/tuple.go
+++ b/lib/column/tuple.go
@@ -196,8 +196,10 @@ func setJSONFieldValue(field reflect.Value, value reflect.Value) error {
 
 	// check if our target is a string
 	if field.Kind() == reflect.String {
-		field.Set(reflect.ValueOf(fmt.Sprint(value.Interface())))
-		return nil
+		if v := reflect.ValueOf(fmt.Sprint(value.Interface())); v.Type().AssignableTo(field.Type()) {
+			field.Set(v)
+			return nil
+		}
 	}
 	if value.CanConvert(field.Type()) {
 		field.Set(value.Convert(field.Type()))

--- a/tests/array_test.go
+++ b/tests/array_test.go
@@ -66,6 +66,46 @@ func TestSimpleArray(t *testing.T) {
 	require.NoError(t, rows.Err())
 }
 
+type customArr []customStr
+
+func TestCustomArray(t *testing.T) {
+	conn, err := GetNativeConnection(nil, nil, &clickhouse.Compression{
+		Method: clickhouse.CompressionLZ4,
+	})
+	ctx := context.Background()
+	require.NoError(t, err)
+	const ddl = `
+		CREATE TABLE test_array (
+			  Col1 Array(Enum ('hello'   = 1,  'world' = 2))
+		) Engine MergeTree() ORDER BY tuple()
+		`
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_array")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_array")
+	require.NoError(t, err)
+	var (
+		col1Data = customArr{"hello", "hello", "world"}
+	)
+	for i := 0; i < 10; i++ {
+		require.NoError(t, batch.Append(col1Data))
+		require.NoError(t, batch.Flush())
+	}
+	require.NoError(t, batch.Send())
+	rows, err := conn.Query(ctx, "SELECT * FROM test_array")
+	require.NoError(t, err)
+	for rows.Next() {
+		var (
+			col1 customArr
+		)
+		require.NoError(t, rows.Scan(&col1))
+		assert.Equal(t, col1Data, col1)
+	}
+	require.NoError(t, rows.Close())
+	require.NoError(t, rows.Err())
+}
+
 func TestInterfaceArray(t *testing.T) {
 	conn, err := GetNativeConnection(nil, nil, &clickhouse.Compression{
 		Method: clickhouse.CompressionLZ4,

--- a/tests/array_test.go
+++ b/tests/array_test.go
@@ -76,7 +76,8 @@ func TestCustomArray(t *testing.T) {
 	require.NoError(t, err)
 	const ddl = `
 		CREATE TABLE test_array (
-			  Col1 Array(Enum ('hello'   = 1,  'world' = 2))
+			  Col1 Array(Enum ('hello'   = 1,  'world' = 2)),
+			  Col2 Array(String)
 		) Engine MergeTree() ORDER BY tuple()
 		`
 	defer func() {
@@ -87,9 +88,10 @@ func TestCustomArray(t *testing.T) {
 	require.NoError(t, err)
 	var (
 		col1Data = customArr{"hello", "hello", "world"}
+		col2Data = customArr{"a", "b", "c"}
 	)
 	for i := 0; i < 10; i++ {
-		require.NoError(t, batch.Append(col1Data))
+		require.NoError(t, batch.Append(col1Data, col2Data))
 		require.NoError(t, batch.Flush())
 	}
 	require.NoError(t, batch.Send())
@@ -98,9 +100,11 @@ func TestCustomArray(t *testing.T) {
 	for rows.Next() {
 		var (
 			col1 customArr
+			col2 customArr
 		)
-		require.NoError(t, rows.Scan(&col1))
+		require.NoError(t, rows.Scan(&col1, &col2))
 		assert.Equal(t, col1Data, col1)
+		assert.Equal(t, col2Data, col2)
 	}
 	require.NoError(t, rows.Close())
 	require.NoError(t, rows.Err())


### PR DESCRIPTION
Proposal: In each ScanRow() check if destination type is implementing sql.Scanner
This PR will add support of custom types, eg:
```
type myStr string
type myInt int32
type myFloat float64
```
One requirement: implement sql.Scanner interface. 

Resolves https://github.com/ClickHouse/clickhouse-go/issues/845

---

Also I found unreachable code:
[lib/column/array](https://github.com/ClickHouse/clickhouse-go/blob/main/lib/column/array.go#L243-L246)
Contains unreachable code