### PR TITLE
Append query options to context instead of overwriting.

### DIFF
--- a/context.go
+++ b/context.go
@@ -132,9 +132,7 @@ func WithStdAsync(wait bool) QueryOption {
 }
 
 func Context(parent context.Context, options ...QueryOption) context.Context {
-	opt := QueryOptions{
-		settings: make(Settings),
-	}
+	opt := queryOptions(parent)
 	for _, f := range options {
 		f(&opt)
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,28 @@
+package clickhouse
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestContext(t *testing.T) {
+	// Call context multiple times making sure query options are persisted across calls.
+	ctx := Context(context.Background(), WithQueryID("a"))
+	ctx = Context(ctx, WithQuotaKey("b"))
+	ctx = Context(ctx, WithSettings(Settings{
+		"c": "d",
+	}))
+
+	opts := queryOptions(ctx)
+	require.Equal(t, "a", opts.queryID)
+	require.Equal(t, "b", opts.quotaKey)
+	require.Equal(t, "d", opts.settings["c"])
+
+	// Call context multiple times with the same query options, making sure the latest is persisted.
+	ctx = Context(context.Background(), WithQueryID("a"))
+	ctx = Context(ctx, WithQueryID("b"))
+
+	opts = queryOptions(ctx)
+	require.Equal(t, "b", opts.queryID)
+}

--- a/context_test.go
+++ b/context_test.go
@@ -2,8 +2,9 @@ package clickhouse
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestContext(t *testing.T) {

--- a/context_test.go
+++ b/context_test.go
@@ -8,22 +8,28 @@ import (
 )
 
 func TestContext(t *testing.T) {
-	// Call context multiple times making sure query options are persisted across calls.
-	ctx := Context(context.Background(), WithQueryID("a"))
-	ctx = Context(ctx, WithQuotaKey("b"))
-	ctx = Context(ctx, WithSettings(Settings{
-		"c": "d",
-	}))
+	t.Run("call context multiple times making sure query options are persisted across calls",
+		func(t *testing.T) {
+			ctx := Context(context.Background(), WithQueryID("a"))
+			ctx = Context(ctx, WithQuotaKey("b"))
+			ctx = Context(ctx, WithSettings(Settings{
+				"c": "d",
+			}))
 
-	opts := queryOptions(ctx)
-	require.Equal(t, "a", opts.queryID)
-	require.Equal(t, "b", opts.quotaKey)
-	require.Equal(t, "d", opts.settings["c"])
+			opts := queryOptions(ctx)
+			require.Equal(t, "a", opts.queryID)
+			require.Equal(t, "b", opts.quotaKey)
+			require.Equal(t, "d", opts.settings["c"])
+		},
+	)
 
-	// Call context multiple times with the same query options, making sure the latest is persisted.
-	ctx = Context(context.Background(), WithQueryID("a"))
-	ctx = Context(ctx, WithQueryID("b"))
+	t.Run("call context multiple times making sure query options are persisted across calls",
+		func(t *testing.T) {
+			ctx := Context(context.Background(), WithQueryID("a"))
+			ctx = Context(ctx, WithQueryID("b"))
 
-	opts = queryOptions(ctx)
-	require.Equal(t, "b", opts.queryID)
+			opts := queryOptions(ctx)
+			require.Equal(t, "b", opts.queryID)
+		},
+	)
 }

--- a/context_test.go
+++ b/context_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestContext(t *testing.T) {
@@ -17,9 +17,9 @@ func TestContext(t *testing.T) {
 			}))
 
 			opts := queryOptions(ctx)
-			require.Equal(t, "a", opts.queryID)
-			require.Equal(t, "b", opts.quotaKey)
-			require.Equal(t, "d", opts.settings["c"])
+			assert.Equal(t, "a", opts.queryID)
+			assert.Equal(t, "b", opts.quotaKey)
+			assert.Equal(t, "d", opts.settings["c"])
 		},
 	)
 
@@ -29,7 +29,7 @@ func TestContext(t *testing.T) {
 			ctx = Context(ctx, WithQueryID("b"))
 
 			opts := queryOptions(ctx)
-			require.Equal(t, "b", opts.queryID)
+			assert.Equal(t, "b", opts.queryID)
 		},
 	)
 }


### PR DESCRIPTION
Previously every time `clickhouse.Context(context.Context, QueryOption)` is called multiple times on the same context object, only the query options in the last call would used. For example:

```
ctx := Context(context.Background(), WithQueryID("a"))
ctx = Context(ctx, WithQuotaKey("b"))
```
would not persist the the query id. 

This PR changes the `clickhouse.Context()` logic to first attempt to load the existing `QueryOptions` when called so that query options append instead of overwrite existing ones.

It is possible that this is a breaking change for users that have become dependent on this behavior, however it is unlikely that someone is purposefully depending on it today. 