### PR TITLE
Handle epipe errors

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -26,6 +26,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"syscall"
 	"time"
 
 	"github.com/ClickHouse/ch-go/compress"
@@ -226,6 +227,10 @@ func (c *connect) sendData(block *proto.Block, name string) error {
 		return err
 	}
 	if err := c.flush(); err != nil {
+		if errors.Is(err, syscall.EPIPE) {
+			c.debugf("[send data] pipe is broken, closing connection")
+			c.closed = true
+		}
 		return err
 	}
 	defer func() {


### PR DESCRIPTION
Presently, if the tcp session to the server closes remotely (e.g. if the clickhouse-server process restarts), we will emit broken pipe errors potentially until we reach ConnMaxLifetime.

Since EPIPE means that the tcp session is dead (ie we received a RST packet from the server), there is no point in attempting to proceed past that point: set the connection as closed.