### PR TITLE
Better handling for connection errors in the std interface

### DIFF
--- a/conn_query.go
+++ b/conn_query.go
@@ -33,6 +33,7 @@ func (c *connect) query(ctx context.Context, release func(*connect, error), quer
 	)
 
 	if err != nil {
+		c.debugf("[bindQuery] error: %v", err)
 		release(c, err)
 		return nil, err
 	}
@@ -54,6 +55,7 @@ func (c *connect) query(ctx context.Context, release func(*connect, error), quer
 	init, err := c.firstBlock(ctx, onProcess)
 
 	if err != nil {
+		c.debugf("[query] first block error: %v", err)
 		release(c, err)
 		return nil, err
 	}
@@ -73,6 +75,7 @@ func (c *connect) query(ctx context.Context, release func(*connect, error), quer
 		}
 		err := c.process(ctx, onProcess)
 		if err != nil {
+			c.debugf("[query] process error: %v", err)
 			errors <- err
 		}
 		close(stream)


### PR DESCRIPTION
- check for EOF/EPIPE errors in the major functions of clickhouse_std.go and explicitly return driver.ErrBadConn when we catch them

- add debug logging of most error conditions to the std interface, following the existing pattern for error handling

Signed-off-by: Nathan J. Mehl <n@oden.io>