### PR TITLE
correct the wrong placeholder in log output

### DIFF
--- a/conn_send_query.go
+++ b/conn_send_query.go
@@ -24,7 +24,7 @@ import (
 // Connection::sendQuery
 // https://github.com/ClickHouse/ClickHouse/blob/master/src/Client/Connection.cpp
 func (c *connect) sendQuery(body string, o *QueryOptions) error {
-	c.debugf("[send query] compression=%d %s", c.compression, body)
+	c.debugf("[send query] compression=%q %s", c.compression, body)
 	c.buffer.PutByte(proto.ClientQuery)
 	q := proto.Query{
 		ClientName:     c.opt.ClientInfo.String(),

--- a/conn_send_query.go
+++ b/conn_send_query.go
@@ -24,7 +24,7 @@ import (
 // Connection::sendQuery
 // https://github.com/ClickHouse/ClickHouse/blob/master/src/Client/Connection.cpp
 func (c *connect) sendQuery(body string, o *QueryOptions) error {
-	c.debugf("[send query] compression=%t %s", c.compression, body)
+	c.debugf("[send query] compression=%d %s", c.compression, body)
 	c.buffer.PutByte(proto.ClientQuery)
 	q := proto.Query{
 		ClientName:     c.opt.ClientInfo.String(),


### PR DESCRIPTION
#883 
the type of ‘compression' field changed while the placeholder in log not changed