### PR TITLE
Reset expired connections

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -21,14 +21,15 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2/resources"
-	"github.com/pkg/errors"
 	"io"
 	"log"
 	"net"
 	"os"
 	"syscall"
 	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/resources"
+	"github.com/pkg/errors"
 
 	"github.com/ClickHouse/ch-go/compress"
 	chproto "github.com/ClickHouse/ch-go/proto"
@@ -151,6 +152,11 @@ func (c *connect) isBad() bool {
 	case c.closed:
 		return true
 	}
+
+	if time.Since(c.connectedAt) >= c.opt.ConnMaxLifetime {
+		return true
+	}
+
 	if err := c.connCheck(); err != nil {
 		return true
 	}


### PR DESCRIPTION
## Summary
Ensure a connection is not used when its `ConnMaxLifetime` is exceeded

Currently, the `ConnMaxLifetime` is only checked in the `release` method. So a connection may be valid when added to the "idle" pool, but expired when "acquired".

In our application, the TCP socket is only alive for a few minutes, and I don't know why, but the `isBad()` method does not detect any issues.
But then when a query is sent to the ClickHouse server, we end up with `broken pipe` or `EOF` errors 