### PR TITLE
Change ClickHouse Docker repository.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ down:
 	@docker compose down
 
 cli:
-	docker run -it --rm --net clickhouse-go_clickhouse --link clickhouse:clickhouse-server yandex/clickhouse-client --host clickhouse-server
+	docker run -it --rm --net clickhouse-go_clickhouse --link clickhouse:clickhouse-server --host clickhouse-server
 
 test:
 	@go install -race -v


### PR DESCRIPTION
@gingerwizard I think it has a chance to work with the clickhouse-server package only because the client is also available inside it.