### PR TITLE
feat: async insert as an option to standard batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The client is tested against the currently [supported versions](https://github.c
 * Connection pool
 * Failover and load balancing
 * [Bulk write support](examples/clickhouse_api/batch.go) (for `database/sql` [use](examples/std/batch.go) `begin->prepare->(in loop exec)->commit`)
-* [AsyncInsert](benchmark/v2/write-async/main.go)
+* [async insert](examples/clickhouse_api/async.go) (for `database/sql` [use](examples/std/async.go))
 * Named and numeric placeholders support
 * LZ4/ZSTD compression support
 * External data

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -240,11 +240,11 @@ func (std *stdDriver) Rollback() error {
 func (std *stdDriver) CheckNamedValue(nv *driver.NamedValue) error { return nil }
 
 func (std *stdDriver) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-	if options := queryOptions(ctx); options.async.ok {
+	if options := queryOptions(ctx); options.stdAsync.ok {
 		if len(args) != 0 {
 			return nil, errors.New("clickhouse: you can't use parameters in an asynchronous insert")
 		}
-		return driver.RowsAffected(0), std.conn.asyncInsert(ctx, query, options.async.wait)
+		return driver.RowsAffected(0), std.conn.asyncInsert(ctx, query, options.stdAsync.wait)
 	}
 	if err := std.conn.exec(ctx, query, rebind(args)...); err != nil {
 		if isConnBrokenError(err) {

--- a/conn_batch.go
+++ b/conn_batch.go
@@ -57,6 +57,12 @@ func (c *connect) prepareBatch(ctx context.Context, query string, release func(*
 		c.conn.SetDeadline(deadline)
 		defer c.conn.SetDeadline(time.Time{})
 	}
+
+	if options.async {
+		options.settings["async_insert"] = 1
+		options.settings["wait_for_async_insert"] = 0
+	}
+
 	if err := c.sendQuery(query, &options); err != nil {
 		release(c, err)
 		return nil, err

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -180,6 +180,11 @@ func (b *httpBatch) Send() (err error) {
 	}
 	options := queryOptions(b.ctx)
 
+	if options.async {
+		options.settings["async_insert"] = 1
+		options.settings["wait_for_async_insert"] = 0
+	}
+
 	headers := make(map[string]string)
 
 	r, pw := io.Pipe()

--- a/context.go
+++ b/context.go
@@ -36,11 +36,12 @@ type Parameters map[string]string
 type (
 	QueryOption  func(*QueryOptions) error
 	QueryOptions struct {
-		span  trace.SpanContext
-		async struct {
+		span     trace.SpanContext
+		stdAsync struct {
 			ok   bool
 			wait bool
 		}
+		async    bool
 		queryID  string
 		quotaKey string
 		events   struct {
@@ -135,7 +136,15 @@ func WithExternalTable(t ...*ext.Table) QueryOption {
 
 func WithStdAsync(wait bool) QueryOption {
 	return func(o *QueryOptions) error {
-		o.async.ok, o.async.wait = true, wait
+		o.stdAsync.ok, o.stdAsync.wait = true, wait
+		return nil
+	}
+}
+
+func WithAsync() QueryOption {
+	return func(o *QueryOptions) error {
+		o.async = true
+
 		return nil
 	}
 }

--- a/examples/clickhouse_api/async.go
+++ b/examples/clickhouse_api/async.go
@@ -19,9 +19,10 @@ package clickhouse_api
 
 import (
 	"context"
+	"time"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/google/uuid"
-	"time"
 )
 
 func AsyncInsert() error {

--- a/examples/std/async.go
+++ b/examples/std/async.go
@@ -19,7 +19,10 @@ package std
 
 import (
 	"context"
+	"time"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/google/uuid"
 )
 
 func AsyncInsert() error {

--- a/examples/std/main_test.go
+++ b/examples/std/main_test.go
@@ -155,3 +155,7 @@ func TestOpenDb(t *testing.T) {
 func TestConnectionSettings(t *testing.T) {
 	require.NoError(t, ConnectSettings())
 }
+
+func TestAsyncInsert(t *testing.T) {
+	require.NoError(t, AsyncInsert())
+}

--- a/tests/async_batch_test.go
+++ b/tests/async_batch_test.go
@@ -1,0 +1,82 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAsyncBatch(t *testing.T) {
+	conn, err := GetNativeConnection(nil, nil, &clickhouse.Compression{
+		Method: clickhouse.CompressionLZ4,
+	})
+	ctx := context.Background()
+	require.NoError(t, err)
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE example")
+	}()
+	conn.Exec(context.Background(), "DROP TABLE IF EXISTS example")
+	err = conn.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS example (
+			  Col1 UInt8
+			, Col2 String
+			, Col3 FixedString(3)
+			, Col4 UUID
+			, Col5 Map(String, UInt8)
+			, Col6 Array(String)
+			, Col7 Tuple(String, UInt8, Array(Map(String, String)))
+			, Col8 DateTime
+		) Engine = Memory
+	`)
+	require.NoError(t, err)
+
+	queryCtx := clickhouse.Context(ctx, clickhouse.WithAsync())
+
+	batch, err := conn.PrepareBatch(queryCtx, "INSERT INTO example")
+	assert.NoError(t, err)
+	for i := 0; i < 1000; i++ {
+		err := batch.Append(
+			uint8(42),
+			"ClickHouse",
+			"Inc",
+			uuid.New(),
+			map[string]uint8{"key": 1},             // Map(String, UInt8)
+			[]string{"Q", "W", "E", "R", "T", "Y"}, // Array(String)
+			[]interface{}{ // Tuple(String, UInt8, Array(Map(String, String)))
+				"String Value", uint8(5), []map[string]string{
+					{"key": "value"},
+					{"key": "value"},
+					{"key": "value"},
+				},
+			},
+			time.Now(),
+		)
+
+		assert.NoError(t, err)
+	}
+
+	assert.NoError(t, batch.Send())
+}

--- a/tests/std/async_batch_test.go
+++ b/tests/std/async_batch_test.go
@@ -1,0 +1,94 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package std
+
+import (
+	"context"
+	"fmt"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestAsyncBatch(t *testing.T) {
+	dsns := map[string]clickhouse.Protocol{"Native": clickhouse.Native, "Http": clickhouse.HTTP}
+	useSSL, err := strconv.ParseBool(clickhouse_tests.GetEnv("CLICKHOUSE_USE_SSL", "false"))
+	require.NoError(t, err)
+	for name, protocol := range dsns {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
+			conn, err := GetStdDSNConnection(protocol, useSSL, nil)
+			require.NoError(t, err)
+
+			if !CheckMinServerVersion(conn, 21, 12, 0) {
+				t.Skip(fmt.Errorf("unsupported clickhouse version"))
+				return
+			}
+
+			_, err = conn.Exec(`DROP TABLE IF EXISTS example`)
+			require.NoError(t, err)
+			_, err = conn.Exec(`
+		CREATE TABLE IF NOT EXISTS example (
+			  Col1 UInt8
+			, Col2 String
+			, Col3 FixedString(3)
+			, Col4 UUID
+			, Col5 Map(String, UInt8)
+			, Col6 Array(String)
+			, Col7 Tuple(String, UInt8, Array(Map(String, String)))
+			, Col8 DateTime
+		) Engine = Memory
+	`)
+			require.NoError(t, err)
+
+			queryCtx := clickhouse.Context(context.Background(), clickhouse.WithAsync())
+
+			scope, err := conn.Begin()
+
+			assert.NoError(t, err)
+			batch, err := scope.PrepareContext(queryCtx, "INSERT INTO example")
+			assert.NoError(t, err)
+			for i := 0; i < 1000; i++ {
+				_, err := batch.ExecContext(
+					queryCtx,
+					uint8(42),
+					"ClickHouse", "Inc",
+					uuid.New(),
+					map[string]uint8{"key": 1},             // Map(String, UInt8)
+					[]string{"Q", "W", "E", "R", "T", "Y"}, // Array(String)
+					[]interface{}{ // Tuple(String, UInt8, Array(Map(String, String)))
+						"String Value", uint8(5), []map[string]string{
+							map[string]string{"key": "value"},
+							map[string]string{"key": "value"},
+							map[string]string{"key": "value"},
+						},
+					},
+					time.Now(),
+				)
+
+				assert.NoError(t, err)
+			}
+
+			assert.NoError(t, scope.Commit())
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Introduce a context option that enables async insert for batch ingestions for HTTP protocol
https://github.com/ClickHouse/clickhouse-go/issues/896

`WithStdAsync` option is kept for a backward compatibility
