### PR TITLE
Add extra padding for strings shorter than FixedString length

### DIFF
--- a/lib/binary/string_unsafe.go
+++ b/lib/binary/string_unsafe.go
@@ -20,6 +20,14 @@
 
 package binary
 
-func Str2Bytes(str string) []byte {
-	return unsafeStr2Bytes(str)
+func Str2Bytes(str string, expectedLen int) []byte {
+	b := unsafeStr2Bytes(str)
+
+	if len(str) < expectedLen {
+		extended := make([]byte, expectedLen)
+		copy(extended, b)
+		return extended
+	}
+
+	return b
 }

--- a/lib/column/fixed_string.go
+++ b/lib/column/fixed_string.go
@@ -97,7 +97,7 @@ func (col *FixedString) Append(v interface{}) (nulls []uint8, err error) {
 			if v == "" {
 				col.col.Append(make([]byte, col.col.Size))
 			} else {
-				col.col.Append(binary.Str2Bytes(v))
+				col.col.Append(binary.Str2Bytes(v, col.col.Size))
 			}
 		}
 	case []*string:
@@ -113,7 +113,7 @@ func (col *FixedString) Append(v interface{}) (nulls []uint8, err error) {
 				if *v == "" {
 					col.col.Append(make([]byte, col.col.Size))
 				} else {
-					col.col.Append(binary.Str2Bytes(*v))
+					col.col.Append(binary.Str2Bytes(*v, col.col.Size))
 				}
 			}
 		}
@@ -139,12 +139,12 @@ func (col *FixedString) AppendRow(v interface{}) (err error) {
 	switch v := v.(type) {
 	case string:
 		if v != "" {
-			data = binary.Str2Bytes(v)
+			data = binary.Str2Bytes(v, col.col.Size)
 		}
 	case *string:
 		if v != nil {
 			if *v != "" {
-				data = binary.Str2Bytes(*v)
+				data = binary.Str2Bytes(*v, col.col.Size)
 			}
 		}
 	case nil:

--- a/lib/column/string.go
+++ b/lib/column/string.go
@@ -71,7 +71,7 @@ func (col *String) ScanRow(dest interface{}, row int) error {
 	case *sql.NullString:
 		return d.Scan(val)
 	case encoding.BinaryUnmarshaler:
-		return d.UnmarshalBinary(binary.Str2Bytes(val))
+		return d.UnmarshalBinary(binary.Str2Bytes(val, len(val)))
 	default:
 		if scan, ok := dest.(sql.Scanner); ok {
 			return scan.Scan(val)

--- a/tests/issues/904_test.go
+++ b/tests/issues/904_test.go
@@ -1,0 +1,62 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package issues
+
+import (
+	"context"
+	"fmt"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test904(t *testing.T) {
+	var (
+		conn, err = clickhouse_tests.GetConnection("issues", clickhouse.Settings{
+			"max_execution_time": 60,
+			"flatten_nested":     0,
+		}, nil, &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		})
+	)
+
+	ctx := context.Background()
+	require.NoError(t, err)
+	env, err := clickhouse_tests.GetTestEnvironment(testSet)
+	require.NoError(t, err)
+
+	ddl := fmt.Sprintf("CREATE TABLE `%s`.`test_904` (Col1 FixedString(6)) Engine MergeTree() ORDER BY tuple()", env.Database)
+	defer func() {
+		conn.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS `%s`.`test_904`", env.Database))
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+
+	batch, err := conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO `%s`.`test_904` (Col1)", env.Database))
+	require.NoError(t, err)
+	require.NoError(t, batch.Append("foo"))
+	require.NoError(t, batch.Send())
+
+	var col1 string
+	row := conn.QueryRow(ctx, fmt.Sprintf("SELECT Col1 FROM `%s`.`test_904`", env.Database))
+	require.NoError(t, row.Err())
+	require.NoError(t, row.Scan(&col1))
+
+	assert.Equal(t, "foo"+string([]byte{0, 0, 0}), col1)
+}


### PR DESCRIPTION
## Summary

Currently, appending string shorter than `FixedString` column length results in a panic. ClickHouse default behaviour is to append null bytes: https://clickhouse.com/docs/en/sql-reference/data-types/fixedstring/

This PR adds an extra byte array initialisation if the length does not match. 

This fixes #904 

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
