### PR TITLE
Allow `Auth.Database` option to be empty

### DIFF
--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -319,9 +319,6 @@ func (o *Options) fromDSN(in string) error {
 
 // receive copy of Options, so we don't modify original - so its reusable
 func (o Options) setDefaults() *Options {
-	if len(o.Auth.Database) == 0 {
-		o.Auth.Database = "default"
-	}
 	if len(o.Auth.Username) == 0 {
 		o.Auth.Username = "default"
 	}

--- a/clickhouse_options_test.go
+++ b/clickhouse_options_test.go
@@ -52,6 +52,30 @@ func TestParseDSN(t *testing.T) {
 		},
 		{
 			"native protocol",
+			"clickhouse://127.0.0.1/",
+			&Options{
+				Protocol: Native,
+				TLS:      nil,
+				Addr:     []string{"127.0.0.1"},
+				Settings: Settings{},
+				scheme:   "clickhouse",
+			},
+			"",
+		},
+		{
+			"http protocol",
+			"http://127.0.0.1/",
+			&Options{
+				Protocol: HTTP,
+				TLS:      nil,
+				Addr:     []string{"127.0.0.1"},
+				Settings: Settings{},
+				scheme:   "http",
+			},
+			"",
+		},
+		{
+			"native protocol",
 			"clickhouse://127.0.0.1/test_database",
 			&Options{
 				Protocol: Native,

--- a/tests/std/conn_test.go
+++ b/tests/std/conn_test.go
@@ -22,16 +22,14 @@ import (
 	"crypto/tls"
 	"database/sql"
 	"fmt"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"strconv"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ClickHouse/clickhouse-go/v2"
-	_ "github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStdConn(t *testing.T) {
@@ -285,4 +283,41 @@ func TestMaxExecutionTime(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEmptyDatabaseConfig(t *testing.T) {
+	env, err := GetStdTestEnvironment()
+	require.NoError(t, err)
+	dsns := map[string]string{
+		"Native": fmt.Sprintf("clickhouse://%s:%d?username=%s&password=%s", env.Host, env.Port, env.Username, env.Password),
+		"Http":   fmt.Sprintf("http://%s:%d?username=%s&password=%s", env.Host, env.HttpPort, env.Username, env.Password),
+	}
+	useSSL, err := strconv.ParseBool(clickhouse_tests.GetEnv("CLICKHOUSE_USE_SSL", "false"))
+	require.NoError(t, err)
+	if useSSL {
+		dsns = map[string]string{
+			"Native": fmt.Sprintf("clickhouse://%s:%d?username=%s&password=%s&secure=true", env.Host, env.Port, env.Username, env.Password),
+			"Http":   fmt.Sprintf("https://%s:%d?username=%s&password=%s&secure=true", env.Host, env.HttpPort, env.Username, env.Password),
+		}
+	}
+
+	setupConn, err := sql.Open("clickhouse", dsns["Native"])
+	require.NoError(t, err)
+
+	// Setup
+	_, err = setupConn.ExecContext(context.Background(), `DROP DATABASE IF EXISTS "default"`)
+	require.NoError(t, err)
+
+	for name, dsn := range dsns {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
+			conn, err := sql.Open("clickhouse", dsn)
+			require.NoError(t, err)
+			err = conn.Ping()
+			require.NoError(t, err)
+		})
+	}
+
+	// Tear down
+	_, err = setupConn.ExecContext(context.Background(), `CREATE DATABASE "default"`)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary
If we do not set the `Database` in `Option`, then it is assigned the value `default`. This PR aims to remove that and will keep the value of `Database` as it is.

Issue: #925 