### PR TITLE
fix: small typo in the text of an error

### DIFF
--- a/lib/proto/block.go
+++ b/lib/proto/block.go
@@ -129,7 +129,7 @@ func (b *Block) EncodeHeader(buffer *proto.Buffer, revision uint64) (err error) 
 			if rows != cRows {
 				return &BlockError{
 					Op:  "Encode",
-					Err: fmt.Errorf("mismatched len of columns - expected %d, recieved %d for col %s", rows, cRows, c.Name()),
+					Err: fmt.Errorf("mismatched len of columns - expected %d, received %d for col %s", rows, cRows, c.Name()),
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

This changes the text of an error from `recieved` into `received`

## Checklist

NA
