### PR TITLE
Support customized "url path" in http connection

### DIFF
--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -139,6 +139,7 @@ type Options struct {
 	ConnMaxLifetime      time.Duration // default 1 hour
 	ConnOpenStrategy     ConnOpenStrategy
 	HttpHeaders          map[string]string // set additional headers on HTTP requests
+	HttpUrlPath          string            // set additional URL path for HTTP requests
 	BlockBufferSize      uint8             // default 2 - can be overwritten on query
 	MaxCompressionBuffer int               // default 10485760 - measured in bytes  i.e. 10MiB
 

--- a/conn_http.go
+++ b/conn_http.go
@@ -147,6 +147,7 @@ func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpCon
 	u := &url.URL{
 		Scheme: opt.scheme,
 		Host:   addr,
+		Path:   opt.HttpUrlPath,
 	}
 
 	headers := make(map[string]string)

--- a/tests/resources/nginx.conf
+++ b/tests/resources/nginx.conf
@@ -1,0 +1,42 @@
+user  nginx;
+worker_processes  auto;
+
+#error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    access_log  /var/log/nginx/access.log;
+    sendfile        on;
+    keepalive_timeout  65;
+    server {
+        listen       80;
+        listen  [::]:80;
+        server_name  localhost;
+
+        #access_log  /var/log/nginx/host.access.log  main;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+
+        #error_page  404              /404.html;
+
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+
+        location /clickhouse {
+            proxy_pass   http://<upstream_http_endpoint>/;
+        }
+    }
+}

--- a/tests/std/conn_test.go
+++ b/tests/std/conn_test.go
@@ -286,3 +286,36 @@ func TestMaxExecutionTime(t *testing.T) {
 		})
 	}
 }
+
+func TestHttpConnWithOptions(t *testing.T) {
+	env, err := GetStdTestEnvironment()
+	require.NoError(t, err)
+	nginxEnv, err := clickhouse_tests.CreateNginxReverseProxyTestEnvironment(env)
+	defer func() {
+		if nginxEnv.NginxContainer != nil {
+			nginxEnv.NginxContainer.Terminate(context.Background())
+		}
+	}()
+	require.NoError(t, err)
+	conn := GetConnectionWithOptions(&clickhouse.Options{
+		Addr:     []string{fmt.Sprintf("%s:%d", env.Host, nginxEnv.HttpPort)},
+		Protocol: clickhouse.HTTP,
+		Auth: clickhouse.Auth{
+			Database: env.Database,
+			Username: env.Username,
+			Password: env.Password,
+		},
+		Settings: clickhouse.Settings{
+			"max_execution_time": 60,
+		},
+		DialTimeout: 5 * time.Second,
+		Compression: &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		},
+		HttpUrlPath: "clickhouse",
+	})
+	require.NoError(t, conn.Ping())
+	var one int
+	require.NoError(t, conn.QueryRow("SELECT 1").Scan(&one))
+	assert.NoError(t, conn.Close())
+}


### PR DESCRIPTION
## Summary

add a new `HttpUrlPath` field in `Clickhouse.Options` to support customize URL path used by HTTP connection ([#937](https://github.com/ClickHouse/clickhouse-go/issues/937))
