### PR TITLE
support query with external tables via http connection

### DIFF
--- a/conn_http_async_insert.go
+++ b/conn_http_async_insert.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
-	"strings"
 )
 
 func (h *httpConnect) asyncInsert(ctx context.Context, query string, wait bool) error {
@@ -32,7 +31,7 @@ func (h *httpConnect) asyncInsert(ctx context.Context, query string, wait bool) 
 	if wait {
 		options.settings["wait_for_async_insert"] = 1
 	}
-	res, err := h.sendQuery(ctx, strings.NewReader(query), &options, h.headers)
+	res, err := h.sendQueryString(ctx, query, &options, h.headers)
 	if res != nil {
 		defer res.Body.Close()
 		// we don't care about result, so just discard it to reuse connection

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -188,13 +188,7 @@ func (b *httpBatch) Send() (err error) {
 
 	defer b.conn.compressionPool.Put(crw)
 
-	switch b.conn.compression {
-	case CompressionGZIP, CompressionDeflate, CompressionBrotli:
-		headers["Content-Encoding"] = b.conn.compression.String()
-	case CompressionZSTD, CompressionLZ4:
-		options.settings["decompress"] = "1"
-	}
-
+	b.conn.setCompressionRequestOptions(&options, headers)
 	go func() {
 		var err error = nil
 		defer pw.CloseWithError(err)
@@ -218,7 +212,7 @@ func (b *httpBatch) Send() (err error) {
 	for k, v := range b.conn.headers {
 		headers[k] = v
 	}
-	res, err := b.conn.sendQuery(b.ctx, r, &options, headers)
+	res, err := b.conn.sendQueryBody(b.ctx, r, &options, headers)
 
 	if res != nil {
 		defer res.Body.Close()

--- a/conn_http_exec.go
+++ b/conn_http_exec.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
-	"strings"
 )
 
 func (h *httpConnect) exec(ctx context.Context, query string, args ...interface{}) error {
@@ -31,7 +30,7 @@ func (h *httpConnect) exec(ctx context.Context, query string, args ...interface{
 		return err
 	}
 
-	res, err := h.sendQuery(ctx, strings.NewReader(query), &options, h.headers)
+	res, err := h.sendQueryString(ctx, query, &options, h.headers)
 	if res != nil {
 		defer res.Body.Close()
 		// we don't care about result, so just discard it to reuse connection

--- a/conn_http_query.go
+++ b/conn_http_query.go
@@ -21,11 +21,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io"
-	"strings"
-
 	chproto "github.com/ClickHouse/ch-go/proto"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"io"
 )
 
 // release is ignored, because http used by std with empty release function
@@ -48,7 +46,7 @@ func (h *httpConnect) query(ctx context.Context, release func(*connect, error), 
 		headers[k] = v
 	}
 
-	res, err := h.sendQuery(ctx, strings.NewReader(query), &options, headers)
+	res, err := h.sendQueryString(ctx, query, &options, headers)
 	if err != nil {
 		return nil, err
 	}

--- a/ext/ext.go
+++ b/ext/ext.go
@@ -18,8 +18,10 @@
 package ext
 
 import (
+	"fmt"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"strings"
 )
 
 func NewTable(name string, columns ...func(t *Table) error) (*Table, error) {
@@ -42,6 +44,14 @@ type Table struct {
 
 func (tbl *Table) Name() string {
 	return tbl.name
+}
+
+func (tbl *Table) Structure() string {
+	columnStructure := make([]string, 0, len(tbl.block.Columns))
+	for _, c := range tbl.block.Columns {
+		columnStructure = append(columnStructure, fmt.Sprintf("%v %v", c.Name(), c.Type()))
+	}
+	return strings.Join(columnStructure, ", ")
 }
 
 func (tbl *Table) Block() *proto.Block {

--- a/tests/std/external_table_test.go
+++ b/tests/std/external_table_test.go
@@ -78,3 +78,51 @@ func TestStdExternalTable(t *testing.T) {
 	require.NoError(t, conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM (SELECT * FROM external_table_1 UNION ALL SELECT * FROM external_table_2)").Scan(&count))
 	assert.Equal(t, uint64(20), count)
 }
+
+func TestStdHttpConnectionExternalTable(t *testing.T) {
+	table1, err := ext.NewTable("external_table_1",
+		ext.Column("col1", "UInt8"),
+		ext.Column("col2", "String"),
+		ext.Column("col3", "DateTime"),
+	)
+	require.NoError(t, err)
+	for i := 0; i < 10; i++ {
+		assert.NoError(t, table1.Append(uint8(i), fmt.Sprintf("value_%d", i), time.Now()))
+	}
+	table2, err := ext.NewTable("external_table_2",
+		ext.Column("col1", "UInt8"),
+		ext.Column("col2", "String"),
+		ext.Column("col3", "DateTime"),
+	)
+	require.NoError(t, err)
+	for i := 0; i < 10; i++ {
+		assert.NoError(t, table2.Append(uint8(i), fmt.Sprintf("value_%d", i), time.Now()))
+	}
+	useSSL, err := strconv.ParseBool(clickhouse_tests.GetEnv("CLICKHOUSE_USE_SSL", "false"))
+	require.NoError(t, err)
+	conn, err := GetStdDSNConnection(clickhouse.HTTP, useSSL, nil)
+	require.NoError(t, err)
+	ctx := clickhouse.Context(context.Background(),
+		clickhouse.WithExternalTable(table1, table2),
+	)
+	rows, err := conn.QueryContext(ctx, "SELECT * FROM external_table_1")
+	require.NoError(t, err)
+	for rows.Next() {
+		var (
+			col1 uint8
+			col2 string
+			col3 time.Time
+		)
+		require.NoError(t, rows.Scan(&col1, &col2, &col3))
+		t.Logf("row: col1=%d, col2=%s, col3=%s\n", col1, col2, col3)
+	}
+	rows.Close()
+
+	var count uint64
+	require.NoError(t, conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM external_table_1").Scan(&count))
+	assert.Equal(t, uint64(10), count)
+	require.NoError(t, conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM external_table_2").Scan(&count))
+	assert.Equal(t, uint64(10), count)
+	require.NoError(t, conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM (SELECT * FROM external_table_1 UNION ALL SELECT * FROM external_table_2)").Scan(&count))
+	assert.Equal(t, uint64(20), count)
+}


### PR DESCRIPTION
## Summary
use mutipart http request to send both external tables and query

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
