### PR TITLE
Support driver.Valuer in String and FixedString columns

### DIFF
--- a/lib/column/string.go
+++ b/lib/column/string.go
@@ -19,6 +19,7 @@ package column
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"encoding"
 	"fmt"
 	"github.com/ClickHouse/ch-go/proto"
@@ -115,14 +116,37 @@ func (col *String) AppendRow(v interface{}) error {
 	case nil:
 		col.col.Append("")
 	default:
-		if s, ok := v.(fmt.Stringer); ok {
-			return col.AppendRow(s.String())
-		} else {
+		if s, ok := v.(driver.Valuer); ok {
+			val, err := s.Value()
+			if err != nil {
+				return &ColumnConverterError{
+					Op:   "AppendRow",
+					To:   "String",
+					From: fmt.Sprintf("%T", s),
+					Hint: "could not get driver.Valuer value",
+				}
+			}
+
+			if s, ok := val.(string); ok {
+				return col.AppendRow(s)
+			}
+
 			return &ColumnConverterError{
 				Op:   "AppendRow",
 				To:   "String",
 				From: fmt.Sprintf("%T", v),
+				Hint: "driver.Valuer value is not a string",
 			}
+		}
+
+		if s, ok := v.(fmt.Stringer); ok {
+			return col.AppendRow(s.String())
+		}
+
+		return &ColumnConverterError{
+			Op:   "AppendRow",
+			To:   "String",
+			From: fmt.Sprintf("%T", v),
 		}
 	}
 	return nil

--- a/tests/string_test.go
+++ b/tests/string_test.go
@@ -20,6 +20,7 @@ package tests
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -308,4 +309,61 @@ func TestStringFlush(t *testing.T) {
 		i += 1
 	}
 	require.Equal(t, 1000, i)
+}
+
+type testStringSerializer struct {
+	val string
+}
+
+func (c testStringSerializer) Value() (driver.Value, error) {
+	return c.val, nil
+}
+
+func (c *testStringSerializer) Scan(src any) error {
+	if t, ok := src.(string); ok {
+		*c = testStringSerializer{val: t}
+		return nil
+	}
+	return fmt.Errorf("cannot scan %T into testStringSerializer", src)
+}
+
+func TestStringFromDriverValuerType(t *testing.T) {
+	conn, err := GetConnection("native", nil, nil, &clickhouse.Compression{
+		Method: clickhouse.CompressionLZ4,
+	})
+	ctx := context.Background()
+
+	require.NoError(t, err)
+	require.NoError(t, conn.Ping(ctx))
+	if !CheckMinServerServerVersion(conn, 21, 9, 0) {
+		t.Skip(fmt.Errorf("unsupported clickhouse version"))
+		return
+	}
+	const ddl = `
+		CREATE TABLE test_string (
+			  	  Col1 String
+		        , Col2 String
+		) Engine MergeTree() ORDER BY tuple()
+		`
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE test_string")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_string")
+	require.NoError(t, err)
+
+	type data struct {
+		Col1 string               `ch:"Col1"`
+		Col2 testStringSerializer `ch:"Col2"`
+	}
+	require.NoError(t, batch.AppendStruct(&data{
+		Col1: "Value",
+		Col2: testStringSerializer{"Value"},
+	}))
+	require.NoError(t, batch.Send())
+
+	var dest data
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_string").ScanStruct(&dest))
+	assert.Equal(t, "Value", dest.Col1)
+	assert.Equal(t, testStringSerializer{"Value"}, dest.Col2)
 }


### PR DESCRIPTION
## Summary
Support driver.Valuer in String and FixedString columns. The use case is explained at: https://github.com/ClickHouse/clickhouse-go/issues/939. This is blocking GORM integration.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
  - Support driver.Valuer in String and FixedString columns

