### PR TITLE
chore: update GH Actions CH/Go matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,12 +22,9 @@ jobs:
         go:
           - "1.19"
           - "1.20"
-        clickhouse:
+        clickhouse: # https://github.com/ClickHouse/ClickHouse/blob/master/SECURITY.md#scope-and-supported-versions
           - "22.3"
           - "22.8"
-          - "22.9"
-          - "22.10"
-          - "22.11"
           - "22.12"
           - "23.1"
           - "23.2"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,15 +20,18 @@ jobs:
       max-parallel: 1
       matrix:
         go:
-          - 1.18
-          - 1.19
+          - "1.19"
+          - "1.20"
         clickhouse:
-          - 22.3
-          - 22.8
-          - 22.9
-          - '22.10'
-          - 22.11
-          - latest
+          - "22.3"
+          - "22.8"
+          - "22.9"
+          - "22.10"
+          - "22.11"
+          - "22.12"
+          - "23.1"
+          - "23.2"
+          - "latest"
     steps:
       - uses: actions/checkout@main
 
@@ -49,8 +52,8 @@ jobs:
       fail-fast: true
       matrix:
         go:
-          - 1.18
-          - 1.19
+          - "1.19"
+          - "1.20"
     steps:
       - uses: actions/checkout@main
 


### PR DESCRIPTION
## Summary
Update ClickHouse versions run in actions. Drop Go 1.18 and use 1
