### PR TITLE
Fix idle connection check for TLS connections

### DIFF
--- a/conn_check.go
+++ b/conn_check.go
@@ -21,14 +21,20 @@
 package clickhouse
 
 import (
+	"crypto/tls"
 	"errors"
 	"io"
 	"syscall"
 )
 
 func (c *connect) connCheck() error {
+	conn := c.conn
+	if tlsConn, ok := c.conn.(*tls.Conn); ok {
+		conn = tlsConn.NetConn()
+	}
+
 	var sysErr error
-	sysConn, ok := c.conn.(syscall.Conn)
+	sysConn, ok := conn.(syscall.Conn)
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
## Summary

When using TLS connection, the idle connection is not correctly checked for liveness. It's because tls.Conn does not implement syscall.Conn which is used to read raw from socket:
https://github.com/ClickHouse/clickhouse-go/blob/main/conn_check.go#L31

Add a additional type cast to detect TLS conn and get underlying connection.

Changelog: Fix idle connection liveness check for TLS connections

