### PR TITLE
Revert "Expire idle connections no longer acquired during lifetime"

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -211,7 +211,6 @@ func (ch *clickhouse) dial(ctx context.Context) (conn *connect, err error) {
 	if err != nil {
 		return nil, err
 	}
-	go result.conn.closeAfterMaxLifeTime()
 	return result.conn, nil
 }
 

--- a/conn_handshake.go
+++ b/conn_handshake.go
@@ -26,9 +26,6 @@ import (
 )
 
 func (c *connect) handshake(database, username, password string) error {
-	c.rwLock.Lock()
-	defer c.rwLock.Unlock()
-
 	defer c.buffer.Reset()
 	c.debugf("[handshake] -> %s", proto.ClientHandshake{})
 	// set a read deadline - alternative to context.Read operation will fail if no data is received after deadline.
@@ -86,9 +83,6 @@ func (c *connect) handshake(database, username, password string) error {
 }
 
 func (c *connect) sendAddendum() error {
-	c.rwLock.Lock()
-	defer c.rwLock.Unlock()
-
 	if c.revision >= proto.DBMS_MIN_PROTOCOL_VERSION_WITH_QUOTA_KEY {
 		c.buffer.PutString("") // todo quota key support
 	}

--- a/conn_ping.go
+++ b/conn_ping.go
@@ -28,9 +28,6 @@ import (
 // Connection::ping
 // https://github.com/ClickHouse/ClickHouse/blob/master/src/Client/Connection.cpp
 func (c *connect) ping(ctx context.Context) (err error) {
-	c.rwLock.Lock()
-	defer c.rwLock.Unlock()
-
 	// set a read deadline - alternative to context.Read operation will fail if no data is received after deadline.
 	c.conn.SetReadDeadline(time.Now().Add(c.readTimeout))
 	defer c.conn.SetReadDeadline(time.Time{})

--- a/conn_process.go
+++ b/conn_process.go
@@ -66,9 +66,7 @@ func (c *connect) process(ctx context.Context, on *onProcess) error {
 			return ctx.Err()
 		default:
 		}
-		c.rwLock.Lock()
 		packet, err := c.reader.ReadByte()
-		c.rwLock.Unlock()
 		if err != nil {
 			return err
 		}
@@ -84,9 +82,6 @@ func (c *connect) process(ctx context.Context, on *onProcess) error {
 }
 
 func (c *connect) handle(ctx context.Context, packet byte, on *onProcess) error {
-	c.rwLock.Lock()
-	defer c.rwLock.Unlock()
-
 	switch packet {
 	case proto.ServerData, proto.ServerTotals, proto.ServerExtremes:
 		block, err := c.readData(ctx, packet, true)

--- a/conn_send_query.go
+++ b/conn_send_query.go
@@ -24,9 +24,6 @@ import (
 // Connection::sendQuery
 // https://github.com/ClickHouse/ClickHouse/blob/master/src/Client/Connection.cpp
 func (c *connect) sendQuery(body string, o *QueryOptions) error {
-	c.rwLock.Lock()
-	defer c.rwLock.Unlock()
-
 	c.debugf("[send query] compression=%q %s", c.compression, body)
 	c.buffer.PutByte(proto.ClientQuery)
 	q := proto.Query{


### PR DESCRIPTION
Reproduced with following test case that driver logic runs into race condition due to idle connection close:

```go
package issues

import (
	"context"
	"github.com/ClickHouse/clickhouse-go/v2"
	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
	"github.com/stretchr/testify/require"
	"testing"
	"time"
)

func Test957(t *testing.T) {
	// given
	ctx := context.Background()
	testEnv, err := clickhouse_tests.GetTestEnvironment(testSet)
	require.NoError(t, err)

	// when the client is configured to use the test environment
	opts := clickhouse_tests.ClientOptionsFromEnv(testEnv, clickhouse.Settings{})
	opts.Debug = true
	opts.Debugf = func(format string, v ...interface{}) {
		t.Logf(format, v...)
	}
	// and the client is configured to have only 1 connection
	opts.MaxIdleConns = 2
	opts.MaxOpenConns = 1
	// and the client is configured to have a connection lifetime of 1/10 of a second
	opts.ConnMaxLifetime = time.Second / 10
	conn, err := clickhouse.Open(&opts)
	require.NoError(t, err)

	// then the client should be able to execute queries for 1 second
	deadline := time.Now().Add(time.Second)
	for time.Now().Before(deadline) {
		_, err := conn.Query(ctx, "SELECT 1")
		require.NoError(t, err)
	}
}
```

Reverts ClickHouse/clickhouse-go#945