### PR TITLE
Reset the pointer to the nullable field

### DIFF
--- a/lib/column/nullable.go
+++ b/lib/column/nullable.go
@@ -90,6 +90,32 @@ func (col *Nullable) ScanRow(dest interface{}, row int) error {
 	if col.enable {
 		switch col.nulls.Row(row) {
 		case 1:
+			switch v := dest.(type) {
+			case **uint64:
+				*v = nil
+			case **int64:
+				*v = nil
+			case **uint32:
+				*v = nil
+			case **int32:
+				*v = nil
+			case **uint16:
+				*v = nil
+			case **int16:
+				*v = nil
+			case **uint8:
+				*v = nil
+			case **int8:
+				*v = nil
+			case **string:
+				*v = nil
+			case **float32:
+				*v = nil
+			case **float64:
+				*v = nil
+			case **time.Time:
+				*v = nil
+			}
 			if scan, ok := dest.(sql.Scanner); ok {
 				return scan.Scan(nil)
 			}

--- a/tests/issues/955_test.go
+++ b/tests/issues/955_test.go
@@ -1,0 +1,58 @@
+package issues
+
+import (
+	"context"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"reflect"
+	"testing"
+)
+
+func Test955(t *testing.T) {
+	var (
+		conn, err = clickhouse_tests.GetConnection("issues", clickhouse.Settings{
+			"max_execution_time": 60,
+		}, nil, &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		})
+	)
+	ctx := context.Background()
+	require.NoError(t, err)
+	const ddl = `
+		CREATE TABLE test_955 (
+			Col1 Nullable(UInt64)
+		) Engine MergeTree() ORDER BY tuple()
+		`
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE IF EXISTS test_955")
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	const baseValues = `
+		INSERT INTO test_955 VALUES (123), (NULL)
+		`
+	require.NoError(t, conn.Exec(ctx, baseValues))
+
+	rows, err := conn.Query(ctx, "SELECT * FROM test_955")
+	require.NoError(t, err)
+	defer func(rows driver.Rows) {
+		_ = rows.Close()
+	}(rows)
+
+	records := make([][]any, 0)
+	for rows.Next() {
+		record := make([]any, 0, len(rows.ColumnTypes()))
+		for _, ct := range rows.ColumnTypes() {
+			record = append(record, reflect.New(ct.ScanType()).Interface())
+		}
+		err = rows.Scan(record...)
+		require.NoError(t, err)
+
+		records = append(records, record)
+	}
+	var value *uint64
+	value = nil
+	assert.Equal(t, value, *records[1][0].(**uint64))
+}


### PR DESCRIPTION
## Summary
When the field is nullable type, the pointer is not reset after calling the scan method,, this pull
request manually resets the pointer to fix this bug

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
