### PR TITLE
Do not return hard error on unparsable version in HTTP proto

### DIFF
--- a/conn_http.go
+++ b/conn_http.go
@@ -292,10 +292,7 @@ func (h *httpConnect) readVersion(ctx context.Context) (proto.Version, error) {
 	for rows.Next() {
 		var v string
 		rows.Scan(&v)
-		version, err := proto.ParseVersion(v)
-		if err != nil {
-			return proto.Version{}, err
-		}
+		version := proto.ParseVersion(v)
 		return version, nil
 	}
 	return proto.Version{}, errors.New("unable to determine version")

--- a/lib/proto/handshake.go
+++ b/lib/proto/handshake.go
@@ -60,21 +60,22 @@ type Version struct {
 	Patch uint64
 }
 
-func ParseVersion(v string) (ver Version, err error) {
+func ParseVersion(v string) (ver Version) {
+	var err error
 	parts := strings.Split(v, ".")
 	if len(parts) < 3 {
-		return Version{}, fmt.Errorf("%s is not a valid version", v)
+		return ver
 	}
 	if ver.Major, err = strconv.ParseUint(parts[0], 10, 8); err != nil {
-		return Version{}, err
+		return ver
 	}
 	if ver.Minor, err = strconv.ParseUint(parts[1], 10, 8); err != nil {
-		return Version{}, err
+		return ver
 	}
 	if ver.Patch, err = strconv.ParseUint(parts[2], 10, 8); err != nil {
-		return Version{}, err
+		return ver
 	}
-	return ver, nil
+	return ver
 }
 
 func CheckMinVersion(constraint Version, version Version) bool {


### PR DESCRIPTION
## Summary

Currently, if the ClickHouse server returns a version number that cannot be parsed, clickhouse-go returns an error and refuses to continue. This change makes clickhouse-go more relaxed when the server has a non-regular non-official version: it treats unparseable parts as 0 in the version number and still works after printing a warning.