### PR TITLE
fix: Return ErrBadConn in stdDriver Prepare if connection is broken

### DIFF
--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -277,6 +277,7 @@ func (std *stdDriver) PrepareContext(ctx context.Context, query string) (driver.
 	if err != nil {
 		if isConnBrokenError(err) {
 			std.debugf("PrepareContext got a fatal error, resetting connection: %v\n", err)
+			return nil, driver.ErrBadConn
 		}
 		std.debugf("PrepareContext error: %v\n", err)
 		return nil, err


### PR DESCRIPTION
## Summary
I've noticed that `Prepare` sometimes returns an `EOF` error although this is the error that can be retried by the `database/sql` package by returning `ErrBadConn`. I think it was missed during the changes in https://github.com/ClickHouse/clickhouse-go/pull/879 as `ErrBadConn` is returned in the case of `isConnBrokenError(err)` in every other primary `stdDriver` function.

```
// ErrBadConn should be returned by a driver to signal to the sql
// package that a driver.Conn is in a bad state (such as the server
// having earlier closed the connection) and the sql package should
// retry on a new connection.
```
https://cs.opensource.google/go/go/+/refs/tags/go1.20.3:src/database/sql/driver/driver.go;l=162

CC @jkaflik 

<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
