### PR TITLE
feat: Use `any` instead of `interface{}`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ coverage.txt
 .idea/**
 dev/*
 .run/**
+
+vendor

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ staticcheck:
 	staticcheck ./...
 
 codegen: contributors
-	@cd lib/column && go run codegen/main.go
+	@go run lib/column/codegen/main.go
 	@go-licenser -licensor "ClickHouse, Inc."
 
 .PHONY: contributors

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Support for the ClickHouse protocol advanced features using `Context`:
 			return d.DialContext(ctx, "tcp", addr)
 		},
 		Debug: true,
-		Debugf: func(format string, v ...interface{}) {
+		Debugf: func(format string, v ...any) {
 			fmt.Printf(format, v)
 		},
 		Settings: clickhouse.Settings{

--- a/bind.go
+++ b/bind.go
@@ -28,7 +28,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
-func Named(name string, value interface{}) driver.NamedValue {
+func Named(name string, value any) driver.NamedValue {
 	return driver.NamedValue{
 		Name:  name,
 		Value: value,
@@ -45,10 +45,10 @@ const (
 )
 
 type GroupSet struct {
-	Value []interface{}
+	Value []any
 }
 
-type ArraySet []interface{}
+type ArraySet []any
 
 func DateNamed(name string, value time.Time, scale TimeUnit) driver.NamedDateValue {
 	return driver.NamedDateValue{
@@ -61,7 +61,7 @@ func DateNamed(name string, value time.Time, scale TimeUnit) driver.NamedDateVal
 var bindNumericRe = regexp.MustCompile(`\$[0-9]+`)
 var bindPositionalRe = regexp.MustCompile(`[^\\][?]`)
 
-func bind(tz *time.Location, query string, args ...interface{}) (string, error) {
+func bind(tz *time.Location, query string, args ...any) (string, error) {
 	if len(args) == 0 {
 		return query, nil
 	}
@@ -90,7 +90,7 @@ func bind(tz *time.Location, query string, args ...interface{}) (string, error) 
 	return bindPositional(tz, query, args...)
 }
 
-func checkAllNamedArguments(args ...interface{}) (bool, error) {
+func checkAllNamedArguments(args ...any) (bool, error) {
 	var (
 		haveNamed     bool
 		haveAnonymous bool
@@ -111,7 +111,7 @@ func checkAllNamedArguments(args ...interface{}) (bool, error) {
 
 var bindPositionCharRe = regexp.MustCompile(`[?]`)
 
-func bindPositional(tz *time.Location, query string, args ...interface{}) (_ string, err error) {
+func bindPositional(tz *time.Location, query string, args ...any) (_ string, err error) {
 	var (
 		unbind = make(map[int]struct{})
 		params = make([]string, len(args))
@@ -146,7 +146,7 @@ func bindPositional(tz *time.Location, query string, args ...interface{}) (_ str
 	return strings.ReplaceAll(query, "\\?", "?"), nil
 }
 
-func bindNumeric(tz *time.Location, query string, args ...interface{}) (_ string, err error) {
+func bindNumeric(tz *time.Location, query string, args ...any) (_ string, err error) {
 	var (
 		unbind = make(map[string]struct{})
 		params = make(map[string]string)
@@ -178,7 +178,7 @@ func bindNumeric(tz *time.Location, query string, args ...interface{}) (_ string
 
 var bindNamedRe = regexp.MustCompile(`@[a-zA-Z0-9\_]+`)
 
-func bindNamed(tz *time.Location, query string, args ...interface{}) (_ string, err error) {
+func bindNamed(tz *time.Location, query string, args ...any) (_ string, err error) {
 	var (
 		unbind = make(map[string]struct{})
 		params = make(map[string]string)
@@ -243,7 +243,7 @@ func formatTime(tz *time.Location, scale TimeUnit, value time.Time) (string, err
 	return fmt.Sprintf("toDateTime64('%s', %d, '%s')", value.Format(fmt.Sprintf("2006-01-02 15:04:05.%0*d", int(scale*3), 0)), int(scale*3), value.Location().String()), nil
 }
 
-func format(tz *time.Location, scale TimeUnit, v interface{}) (string, error) {
+func format(tz *time.Location, scale TimeUnit, v any) (string, error) {
 	quote := func(v string) string {
 		return "'" + strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(v) + "'"
 	}
@@ -328,8 +328,8 @@ func join[E any](tz *time.Location, scale TimeUnit, values []E) (string, error) 
 	return strings.Join(items, ", "), nil
 }
 
-func rebind(in []std_driver.NamedValue) []interface{} {
-	args := make([]interface{}, 0, len(in))
+func rebind(in []std_driver.NamedValue) []any {
+	args := make([]any, 0, len(in))
 	for _, v := range in {
 		switch {
 		case len(v.Name) != 0:

--- a/bind_test.go
+++ b/bind_test.go
@@ -35,9 +35,9 @@ func TestBindNumeric(t *testing.T) {
 	)
 	`, 1, 2, "I'm a string param", nil)
 	var nilPtr *bool = nil
-	var nilPtrPtr **interface{} = nil
-	valuedPtr := &([]interface{}{123}[0])
-	nilValuePtr := &([]interface{}{nil}[0])
+	var nilPtrPtr **any = nil
+	valuedPtr := &([]any{123}[0])
+	nilValuePtr := &([]any{nil}[0])
 	_, err = bind(time.Local, `
 	SELECT * FROM t WHERE col = $5
 		AND col2 = $2
@@ -50,27 +50,27 @@ func TestBindNumeric(t *testing.T) {
 	if assert.NoError(t, err) {
 		assets := []struct {
 			query    string
-			params   []interface{}
+			params   []any
 			expected string
 		}{
 			{
 				query:    "SELECT $1",
-				params:   []interface{}{1},
+				params:   []any{1},
 				expected: "SELECT 1",
 			},
 			{
 				query:    "SELECT $2 $1 $3",
-				params:   []interface{}{1, 2, 3},
+				params:   []any{1, 2, 3},
 				expected: "SELECT 2 1 3",
 			},
 			{
 				query:    "SELECT $2 $1 $3",
-				params:   []interface{}{"a", "b", "c"},
+				params:   []any{"a", "b", "c"},
 				expected: "SELECT 'b' 'a' 'c'",
 			},
 			{
 				query:    "SELECT $2 $1",
-				params:   []interface{}{true, false},
+				params:   []any{true, false},
 				expected: "SELECT 0 1",
 			},
 		}
@@ -99,9 +99,9 @@ func TestBindNamed(t *testing.T) {
 		Named("col4", nil),
 	)
 	var nilPtr *bool = nil
-	var nilPtrPtr **interface{} = nil
-	valuedPtr := &([]interface{}{123}[0])
-	nilValuePtr := &([]interface{}{nil}[0])
+	var nilPtrPtr **any = nil
+	valuedPtr := &([]any{123}[0])
+	nilValuePtr := &([]any{nil}[0])
 	_, err = bind(time.Local, `
 	SELECT * FROM t WHERE col =  @col1
 		AND col2 =  @col2
@@ -119,19 +119,19 @@ func TestBindNamed(t *testing.T) {
 	if assert.NoError(t, err) {
 		assets := []struct {
 			query    string
-			params   []interface{}
+			params   []any
 			expected string
 		}{
 			{
 				query: "SELECT @col1",
-				params: []interface{}{
+				params: []any{
 					Named("col1", 1),
 				},
 				expected: "SELECT 1",
 			},
 			{
 				query: "SELECT @col2 @col1 @col3",
-				params: []interface{}{
+				params: []any{
 					Named("col1", 1),
 					Named("col2", 2),
 					Named("col3", 3),
@@ -140,7 +140,7 @@ func TestBindNamed(t *testing.T) {
 			},
 			{
 				query: "SELECT @col2 @col1 @col3",
-				params: []interface{}{
+				params: []any{
 					Named("col1", "a"),
 					Named("col2", "b"),
 					Named("col3", "c"),
@@ -149,7 +149,7 @@ func TestBindNamed(t *testing.T) {
 			},
 			{
 				query: "SELECT @col2 @col1",
-				params: []interface{}{
+				params: []any{
 					Named("col1", true),
 					Named("col2", false),
 				},
@@ -176,37 +176,37 @@ func TestBindPositional(t *testing.T) {
 	if assert.NoError(t, err) {
 		assets := []struct {
 			query    string
-			params   []interface{}
+			params   []any
 			expected string
 		}{
 			{
 				query:    "SELECT ?",
-				params:   []interface{}{1},
+				params:   []any{1},
 				expected: "SELECT 1",
 			},
 			{
 				query:    "SELECT ? ? ?",
-				params:   []interface{}{1, 2, 3},
+				params:   []any{1, 2, 3},
 				expected: "SELECT 1 2 3",
 			},
 			{
 				query:    "SELECT ? ? ?",
-				params:   []interface{}{"a", "b", "c"},
+				params:   []any{"a", "b", "c"},
 				expected: "SELECT 'a' 'b' 'c'",
 			},
 			{
 				query:    "SELECT ? ? '\\?'",
-				params:   []interface{}{"a", "b"},
+				params:   []any{"a", "b"},
 				expected: "SELECT 'a' 'b' '?'",
 			},
 			{
 				query:    "SELECT x where col = 'blah\\?' AND col2 = ?",
-				params:   []interface{}{"a"},
+				params:   []any{"a"},
 				expected: "SELECT x where col = 'blah?' AND col2 = 'a'",
 			},
 			{
 				query:    "SELECT ? ?",
-				params:   []interface{}{true, false},
+				params:   []any{true, false},
 				expected: "SELECT 1 0",
 			},
 		}
@@ -229,9 +229,9 @@ func TestBindPositional(t *testing.T) {
 	assert.Error(t, err)
 
 	var nilPtr *bool = nil
-	var nilPtrPtr **interface{} = nil
-	valuedPtr := &([]interface{}{123}[0])
-	nilValuePtr := &([]interface{}{nil}[0])
+	var nilPtrPtr **any = nil
+	valuedPtr := &([]any{123}[0])
+	nilValuePtr := &([]any{nil}[0])
 
 	_, err = bind(time.Local, `
 	SELECT * FROM t WHERE col = ?
@@ -307,13 +307,13 @@ func TestStringBasedType(t *testing.T) {
 }
 
 func TestFormatGroup(t *testing.T) {
-	groupSet := GroupSet{Value: []interface{}{"A", 1}}
+	groupSet := GroupSet{Value: []any{"A", 1}}
 	val, _ := format(time.UTC, Seconds, groupSet)
 	assert.Equal(t, "('A', 1)", val)
 	{
 		tuples := []GroupSet{
-			{Value: []interface{}{"A", 1}},
-			{Value: []interface{}{"B", 2}},
+			{Value: []any{"A", 1}},
+			{Value: []any{"B", 2}},
 		}
 		val, _ = format(time.UTC, Seconds, tuples)
 		assert.Equal(t, "('A', 1), ('B', 2)", val)

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -113,7 +113,7 @@ func (ch *clickhouse) ServerVersion() (*driver.ServerVersion, error) {
 	return &conn.server, nil
 }
 
-func (ch *clickhouse) Query(ctx context.Context, query string, args ...interface{}) (rows driver.Rows, err error) {
+func (ch *clickhouse) Query(ctx context.Context, query string, args ...any) (rows driver.Rows, err error) {
 	conn, err := ch.acquire(ctx)
 	if err != nil {
 		return nil, err
@@ -122,7 +122,7 @@ func (ch *clickhouse) Query(ctx context.Context, query string, args ...interface
 	return conn.query(ctx, ch.release, query, args...)
 }
 
-func (ch *clickhouse) QueryRow(ctx context.Context, query string, args ...interface{}) (rows driver.Row) {
+func (ch *clickhouse) QueryRow(ctx context.Context, query string, args ...any) (rows driver.Row) {
 	conn, err := ch.acquire(ctx)
 	if err != nil {
 		return &row{
@@ -133,7 +133,7 @@ func (ch *clickhouse) QueryRow(ctx context.Context, query string, args ...interf
 	return conn.queryRow(ctx, ch.release, query, args...)
 }
 
-func (ch *clickhouse) Exec(ctx context.Context, query string, args ...interface{}) error {
+func (ch *clickhouse) Exec(ctx context.Context, query string, args ...any) error {
 	conn, err := ch.acquire(ctx)
 	if err != nil {
 		return err

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -130,7 +130,7 @@ type Options struct {
 	DialContext          func(ctx context.Context, addr string) (net.Conn, error)
 	DialStrategy         func(ctx context.Context, connID int, options *Options, dial Dial) (DialResult, error)
 	Debug                bool
-	Debugf               func(format string, v ...interface{}) // only works when Debug is true
+	Debugf               func(format string, v ...any) // only works when Debug is true
 	Settings             Settings
 	Compression          *Compression
 	DialTimeout          time.Duration // default 30 second

--- a/clickhouse_rows.go
+++ b/clickhouse_rows.go
@@ -68,14 +68,14 @@ next:
 	return r.row <= r.block.Rows()
 }
 
-func (r *rows) Scan(dest ...interface{}) error {
+func (r *rows) Scan(dest ...any) error {
 	if r.block == nil || (r.row == 0 && r.row >= r.block.Rows()) { // call without next when result is empty
 		return io.EOF
 	}
 	return scan(r.block, r.row, dest...)
 }
 
-func (r *rows) ScanStruct(dest interface{}) error {
+func (r *rows) ScanStruct(dest any) error {
 	values, err := r.structMap.Map("ScanStruct", r.columns, dest, true)
 	if err != nil {
 		return err
@@ -83,7 +83,7 @@ func (r *rows) ScanStruct(dest interface{}) error {
 	return r.Scan(values...)
 }
 
-func (r *rows) Totals(dest ...interface{}) error {
+func (r *rows) Totals(dest ...any) error {
 	if r.totals == nil {
 		return sql.ErrNoRows
 	}
@@ -132,7 +132,7 @@ func (r *row) Err() error {
 	return r.err
 }
 
-func (r *row) ScanStruct(dest interface{}) error {
+func (r *row) ScanStruct(dest any) error {
 	if r.err != nil {
 		return r.err
 	}
@@ -143,7 +143,7 @@ func (r *row) ScanStruct(dest interface{}) error {
 	return r.Scan(values...)
 }
 
-func (r *row) Scan(dest ...interface{}) error {
+func (r *row) Scan(dest ...any) error {
 	if r.err != nil {
 		return r.err
 	}

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -40,11 +40,11 @@ var globalConnID int64
 type stdConnOpener struct {
 	err    error
 	opt    *Options
-	debugf func(format string, v ...interface{})
+	debugf func(format string, v ...any)
 }
 
 func (o *stdConnOpener) Driver() driver.Driver {
-	var debugf = func(format string, v ...interface{}) {}
+	var debugf = func(format string, v ...any) {}
 	if o.opt.Debug {
 		debugf = log.New(os.Stdout, fmt.Sprintf("[clickhouse-std] "), 0).Printf
 	}
@@ -86,7 +86,7 @@ func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) 
 			num = (int(connID) + i) % len(o.opt.Addr)
 		}
 		if conn, err = dialFunc(ctx, o.opt.Addr[num], connID, o.opt); err == nil {
-			var debugf = func(format string, v ...interface{}) {}
+			var debugf = func(format string, v ...any) {}
 			if o.opt.Debug {
 				debugf = log.New(os.Stdout, fmt.Sprintf("[clickhouse-std][conn=%d][%s] ", num, o.opt.Addr[num]), 0).Printf
 			}
@@ -103,7 +103,7 @@ func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) 
 }
 
 func init() {
-	var debugf = func(format string, v ...interface{}) {}
+	var debugf = func(format string, v ...any) {}
 	sql.Register("clickhouse", &stdDriver{debugf: debugf})
 }
 
@@ -123,7 +123,7 @@ func Connector(opt *Options) driver.Connector {
 
 	o := opt.setDefaults()
 
-	var debugf = func(format string, v ...interface{}) {}
+	var debugf = func(format string, v ...any) {}
 	if o.Debug {
 		debugf = log.New(os.Stdout, fmt.Sprintf("[clickhouse-std][opener] "), 0).Printf
 	}
@@ -134,7 +134,7 @@ func Connector(opt *Options) driver.Connector {
 }
 
 func OpenDB(opt *Options) *sql.DB {
-	var debugf = func(format string, v ...interface{}) {}
+	var debugf = func(format string, v ...any) {}
 	if opt == nil {
 		opt = &Options{}
 	}
@@ -167,8 +167,8 @@ func OpenDB(opt *Options) *sql.DB {
 type stdConnect interface {
 	isBad() bool
 	close() error
-	query(ctx context.Context, release func(*connect, error), query string, args ...interface{}) (*rows, error)
-	exec(ctx context.Context, query string, args ...interface{}) error
+	query(ctx context.Context, release func(*connect, error), query string, args ...any) (*rows, error)
+	exec(ctx context.Context, query string, args ...any) error
 	ping(ctx context.Context) (err error)
 	prepareBatch(ctx context.Context, query string, release func(*connect, error)) (ldriver.Batch, error)
 	asyncInsert(ctx context.Context, query string, wait bool) error
@@ -177,7 +177,7 @@ type stdConnect interface {
 type stdDriver struct {
 	conn   stdConnect
 	commit func() error
-	debugf func(format string, v ...interface{})
+	debugf func(format string, v ...any)
 }
 
 func (std *stdDriver) Open(dsn string) (_ driver.Conn, err error) {
@@ -187,7 +187,7 @@ func (std *stdDriver) Open(dsn string) (_ driver.Conn, err error) {
 		return nil, err
 	}
 	o := opt.setDefaults()
-	var debugf = func(format string, v ...interface{}) {}
+	var debugf = func(format string, v ...any) {}
 	if o.Debug {
 		debugf = log.New(os.Stdout, fmt.Sprintf("[clickhouse-std][opener] "), 0).Printf
 	}
@@ -303,12 +303,12 @@ func (std *stdDriver) Close() error {
 
 type stdBatch struct {
 	batch  ldriver.Batch
-	debugf func(format string, v ...interface{})
+	debugf func(format string, v ...any)
 }
 
 func (s *stdBatch) NumInput() int { return -1 }
 func (s *stdBatch) Exec(args []driver.Value) (driver.Result, error) {
-	values := make([]interface{}, 0, len(args))
+	values := make([]any, 0, len(args))
 	for _, v := range args {
 		values = append(values, v)
 	}
@@ -335,7 +335,7 @@ func (s *stdBatch) Close() error { return nil }
 
 type stdRows struct {
 	rows   *rows
-	debugf func(format string, v ...interface{})
+	debugf func(format string, v ...any)
 }
 
 func (r *stdRows) Columns() []string {

--- a/conn.go
+++ b/conn.go
@@ -40,7 +40,7 @@ func dial(ctx context.Context, addr string, num int, opt *Options) (*connect, er
 	var (
 		err    error
 		conn   net.Conn
-		debugf = func(format string, v ...interface{}) {}
+		debugf = func(format string, v ...any) {}
 	)
 	switch {
 	case opt.DialContext != nil:
@@ -114,7 +114,7 @@ type connect struct {
 	id                   int
 	opt                  *Options
 	conn                 net.Conn
-	debugf               func(format string, v ...interface{})
+	debugf               func(format string, v ...any)
 	server               ServerVersion
 	closed               bool
 	buffer               *chproto.Buffer

--- a/conn_batch.go
+++ b/conn_batch.go
@@ -112,7 +112,7 @@ func (b *batch) Abort() error {
 	return nil
 }
 
-func (b *batch) Append(v ...interface{}) error {
+func (b *batch) Append(v ...any) error {
 	if b.sent {
 		return ErrBatchAlreadySent
 	}
@@ -127,7 +127,7 @@ func (b *batch) Append(v ...interface{}) error {
 	return nil
 }
 
-func (b *batch) AppendStruct(v interface{}) error {
+func (b *batch) AppendStruct(v any) error {
 	if b.err != nil {
 		return b.err
 	}
@@ -210,7 +210,7 @@ type batchColumn struct {
 	release func(error)
 }
 
-func (b *batchColumn) Append(v interface{}) (err error) {
+func (b *batchColumn) Append(v any) (err error) {
 	if b.batch.IsSent() {
 		return ErrBatchAlreadySent
 	}
@@ -225,7 +225,7 @@ func (b *batchColumn) Append(v interface{}) (err error) {
 	return nil
 }
 
-func (b *batchColumn) AppendRow(v interface{}) (err error) {
+func (b *batchColumn) AppendRow(v any) (err error) {
 	if b.batch.IsSent() {
 		return ErrBatchAlreadySent
 	}

--- a/conn_exec.go
+++ b/conn_exec.go
@@ -23,7 +23,7 @@ import (
 	"time"
 )
 
-func (c *connect) exec(ctx context.Context, query string, args ...interface{}) error {
+func (c *connect) exec(ctx context.Context, query string, args ...any) error {
 	var (
 		options                    = queryOptions(ctx)
 		queryParamsProtocolSupport = c.revision >= proto.DBMS_MIN_PROTOCOL_VERSION_WITH_PARAMETERS

--- a/conn_http.go
+++ b/conn_http.go
@@ -54,7 +54,7 @@ type Pool[T any] struct {
 
 func NewPool[T any](fn func() T) Pool[T] {
 	return Pool[T]{
-		pool: &sync.Pool{New: func() interface{} { return fn() }},
+		pool: &sync.Pool{New: func() any { return fn() }},
 	}
 }
 

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -128,7 +128,7 @@ func (b *httpBatch) Abort() error {
 	return nil
 }
 
-func (b *httpBatch) Append(v ...interface{}) error {
+func (b *httpBatch) Append(v ...any) error {
 	if b.sent {
 		return ErrBatchAlreadySent
 	}
@@ -138,7 +138,7 @@ func (b *httpBatch) Append(v ...interface{}) error {
 	return nil
 }
 
-func (b *httpBatch) AppendStruct(v interface{}) error {
+func (b *httpBatch) AppendStruct(v any) error {
 	values, err := b.structMap.Map("AppendStruct", b.block.ColumnsNames(), v, false)
 	if err != nil {
 		return err

--- a/conn_http_exec.go
+++ b/conn_http_exec.go
@@ -23,7 +23,7 @@ import (
 	"io/ioutil"
 )
 
-func (h *httpConnect) exec(ctx context.Context, query string, args ...interface{}) error {
+func (h *httpConnect) exec(ctx context.Context, query string, args ...any) error {
 	options := queryOptions(ctx)
 	query, err := bindQueryOrAppendParameters(true, &options, query, h.location, args...)
 	if err != nil {

--- a/conn_http_query.go
+++ b/conn_http_query.go
@@ -27,7 +27,7 @@ import (
 )
 
 // release is ignored, because http used by std with empty release function
-func (h *httpConnect) query(ctx context.Context, release func(*connect, error), query string, args ...interface{}) (*rows, error) {
+func (h *httpConnect) query(ctx context.Context, release func(*connect, error), query string, args ...any) (*rows, error) {
 	options := queryOptions(ctx)
 	query, err := bindQueryOrAppendParameters(true, &options, query, h.location, args...)
 	if err != nil {

--- a/conn_query.go
+++ b/conn_query.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
-func (c *connect) query(ctx context.Context, release func(*connect, error), query string, args ...interface{}) (*rows, error) {
+func (c *connect) query(ctx context.Context, release func(*connect, error), query string, args ...any) (*rows, error) {
 	var (
 		options                    = queryOptions(ctx)
 		onProcess                  = options.onProcess()
@@ -92,7 +92,7 @@ func (c *connect) query(ctx context.Context, release func(*connect, error), quer
 	}, nil
 }
 
-func (c *connect) queryRow(ctx context.Context, release func(*connect, error), query string, args ...interface{}) *row {
+func (c *connect) queryRow(ctx context.Context, release func(*connect, error), query string, args ...any) *row {
 	rows, err := c.query(ctx, release, query, args...)
 	if err != nil {
 		return &row{

--- a/context.go
+++ b/context.go
@@ -31,7 +31,7 @@ var _contextOptionKey = &QueryOptions{
 	},
 }
 
-type Settings map[string]interface{}
+type Settings map[string]any
 type Parameters map[string]string
 type (
 	QueryOption  func(*QueryOptions) error

--- a/context_test.go
+++ b/context_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package clickhouse
 
 import (

--- a/contributors/list
+++ b/contributors/list
@@ -18,9 +18,7 @@ Benjamin Rupp <brupp@ciena.com>
 Cem Sancak <cem.sancak.90@gmail.com>
 Chao Wang <chaowang@uber.com>
 Chris Duncan <veqryn@hotmail.com>
-Daguang <28806852+DGuang21@users.noreply.github.com>
 Dale McDiarmid <dale@clickhouse.com>
-Dale Mcdiarmid <dale@clickhouse.com>
 Damir Sayfutdinov <sayfutdinov@selectel.ru>
 Dan Walters <dan@walters.io>
 Daniel Bershatsky <daniel.bershatsky@skolkovotech.ru>
@@ -44,7 +42,6 @@ Félix Mattrat <felix@messagebird.com>
 Geoff Genz <geoff@clickhouse.com>
 Gregory Petrosyan <gregory.petrosyan@gmail.com>
 Ian McGraw <ian@arthur.ai>
-Ivan <pikot@users.noreply.github.com>
 Ivan Blinkov <github@blinkov.ru>
 Ivan Blinkov <ivan@clickhouse.com>
 Ivan Ivanov <ivanov@corp.mail.ru>
@@ -55,16 +52,11 @@ Jan Was <j.was@f5.com>
 Jeehoon Kim <jeehooni@gmail.com>
 John Troy <john@noxi.us>
 Jon Aquino <jonathan.aquino@adroll.com>
-Kirill Shvakov <shvakov@gmail.com>
 Kuba Kaflik <kuba.kaflik@clickhouse.com>
 LI Tao <litao.91@bytedance.com>
-LIU Chao <42240939+xiaochaoren1@users.noreply.github.com>
-Louis <lspgn@users.noreply.github.com>
 Luc Vieillescazes <luc@vieillescazes.net>
 LuoJi Zhu <lianjie1949@gmail.com>
 Maksim Sokolnikov <stuffsweep@gmail.com>
-Marek Vavrusa <marek@vavrusa.com>
-Marek Vavruša <mvavrusa@cloudflare.com>
 Marek Vavruša <marek@vavrusa.com>
 Marek Vavruša <mvavrusa@cloudflare.com>
 Mark Andrus Roberts <markandrusroberts@gmail.com>
@@ -73,7 +65,6 @@ Michael Vigovsky <upliner@gmail.com>
 Michail Safronov <msaf1980@gmail.com>
 Miel Donkers <miel@clickhouse.com>
 Mikhail Shustov <restrry@gmail.com>
-Nathan J Mehl <70606471+n-oden@users.noreply.github.com>
 Nay Linn <nlinn@arista.com>
 Nikita Mikhaylov <nikitamikhaylov@clickhouse.com>
 Oleg Strokachuk <oleg.strokachuk@vizor-games.com>
@@ -89,6 +80,7 @@ Sergey Melekhin <sergey@melekhin.me>
 Stephane Moreau <stephane.moreau@imagino.com>
 Taras Matsyk <taras@mm.st>
 Thibault Deutsch <thibault@arista.com>
+Tomasz Czubocha <tomasz.czubocha@gmail.com>
 Tsimafei Bredau <t.bredau@affise.com>
 Varun Vasan V <varunvasan91@gmail.com>
 Vespertinus <rrvespertinus@gmail.com>
@@ -101,20 +93,18 @@ a-dot <ehdot795@gmail.com>
 albertlockett <albert.lockett@gmail.com>
 alex <alex@localhost.localdomain>
 anton troyanov <anton@troyanov.net>
-astduman <41344369+Astemirdum@users.noreply.github.com>
+candiduslynx <candiduslynx@gmail.com>
 chengzhi <chengzhi@shinnytech.com>
 chenlujjj <953546398@qq.com>
 coldWater <forsaken628@gmail.com>
 count <count@bchat.io>
 daguang <daguang830@gmail.com>
 daguang <lianghuanan1997@gmail.com>
-dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 derN3rd <max@dern3rd.de>
 dmitry kuzmin <dmitry.kuzmin@exness.com>
 fengberlin <fengberlin@qq.com>
 gaetan.rizio <gaetan.rizio@contentsquare-ext.com>
 hulb <hulb@live.cn>
-ianmcgraw <ian@arthur.ai>
 ilker moral <ilker.moral@comodo.com>
 jiyongwang <jiyongwang@freewheel.tv>
 kshvakov <shvakov@gmail.com>
@@ -122,13 +112,10 @@ neverlee <neverlea@foxmail.com>
 nevseliev <nevseliev@life-team.net>
 ortyomka <iurin.art@gmail.com>
 pavel raskin <f0ma@inbox.ru>
-restrry <restrry@gmail.com>
-rtkaratekid <42547811+rtkaratekid@users.noreply.github.com>
 sundy-li <543950155@qq.com>
 vahid sohrabloo <vahid4134@gmail.com>
 vasily.popov <vasily.popov@arrival.com>
 viktorzaharov <viktorzahar@gmail.com>
-vl4deee11 <44677024+vl4deee11@users.noreply.github.com>
 vl4deee11 <boi4enkovlad@yandex>
 vl4deee11 <vl4deee11@gmail.com>
 vladislav doster <mvdoster@gmail.com>
@@ -136,5 +123,4 @@ vogrelord <mail@vogre.ru>
 vvoronin <voronin@x12.su>
 yuankun <rogeryk@outlook.com>
 zxc111 <zxc9007@gmail.com>
-zxc9007 <zxc9007@gmail.com>
 李盼 <lipan@sunteng.com>

--- a/examples/clickhouse_api/batch.go
+++ b/examples/clickhouse_api/batch.go
@@ -61,7 +61,7 @@ func BatchInsert() error {
 			uuid.New(),
 			map[string]uint8{"key": 1},             // Map(String, UInt8)
 			[]string{"Q", "W", "E", "R", "T", "Y"}, // Array(String)
-			[]interface{}{ // Tuple(String, UInt8, Array(Map(String, String)))
+			[]any{ // Tuple(String, UInt8, Array(Map(String, String)))
 				"String Value", uint8(5), []map[string]string{
 					{"key": "value"},
 					{"key": "value"},

--- a/examples/clickhouse_api/bind_special.go
+++ b/examples/clickhouse_api/bind_special.go
@@ -73,12 +73,12 @@ func SpecialBind() error {
 	}
 	fmt.Printf("Array count: %d\n", count)
 	// Group sets allow us to form ( ) lists
-	if err = conn.QueryRow(ctx, "SELECT count() FROM example WHERE Col1 IN ?", clickhouse.GroupSet{[]interface{}{100, 200, 300, 400, 500}}).Scan(&count); err != nil {
+	if err = conn.QueryRow(ctx, "SELECT count() FROM example WHERE Col1 IN ?", clickhouse.GroupSet{[]any{100, 200, 300, 400, 500}}).Scan(&count); err != nil {
 		return err
 	}
 	fmt.Printf("Group count: %d\n", count)
 	// More useful when we need nesting
-	if err = conn.QueryRow(ctx, "SELECT count() FROM example WHERE (Col1, Col5) IN (?)", []clickhouse.GroupSet{{[]interface{}{100, 101}}, {[]interface{}{200, 201}}}).Scan(&count); err != nil {
+	if err = conn.QueryRow(ctx, "SELECT count() FROM example WHERE (Col1, Col5) IN (?)", []clickhouse.GroupSet{{[]any{100, 101}}, {[]any{200, 201}}}).Scan(&count); err != nil {
 		return err
 	}
 	fmt.Printf("Group count: %d\n", count)

--- a/examples/clickhouse_api/connect_settings.go
+++ b/examples/clickhouse_api/connect_settings.go
@@ -44,7 +44,7 @@ func PingWithSettings() error {
 			return d.DialContext(ctx, "tcp", addr)
 		},
 		Debug: true,
-		Debugf: func(format string, v ...interface{}) {
+		Debugf: func(format string, v ...any) {
 			fmt.Printf(format, v)
 		},
 		Settings: clickhouse.Settings{

--- a/examples/clickhouse_api/dynamic_scan_types.go
+++ b/examples/clickhouse_api/dynamic_scan_types.go
@@ -39,7 +39,7 @@ func DynamicScan() error {
 	}
 	var (
 		columnTypes = rows.ColumnTypes()
-		vars        = make([]interface{}, len(columnTypes))
+		vars        = make([]any, len(columnTypes))
 	)
 	for i := range columnTypes {
 		vars[i] = reflect.New(columnTypes[i].ScanType()).Interface()

--- a/examples/clickhouse_api/json.go
+++ b/examples/clickhouse_api/json.go
@@ -71,7 +71,7 @@ func InsertReadJSON() error {
 		Age:      uint8(80),
 		Password: "random",
 	}
-	col3Data := map[string]interface{}{
+	col3Data := map[string]any{
 		"name":     "Clicky McClickHouse Jnr",
 		"age":      uint8(10),
 		"password": "clicky",
@@ -86,8 +86,8 @@ func InsertReadJSON() error {
 	}
 	// we can scan JSON into either a map or struct
 	var (
-		col1 map[string]interface{}
-		col2 map[string]interface{}
+		col1 map[string]any
+		col2 map[string]any
 		col3 User
 	)
 	// named tuples can be retrieved into a map or slices, unnamed just slices
@@ -131,10 +131,10 @@ func ReadComplexJSON() error {
 		Releases []Releases
 	}
 
-	row := map[string]interface{}{
+	row := map[string]any{
 		"title": "Document JSON support",
 		"type":  "Issue",
-		"assignee": map[string]interface{}{
+		"assignee": map[string]any{
 			"id":   int16(0),
 			"name": "Dale",
 			"repositories": []Repository{
@@ -144,8 +144,8 @@ func ReadComplexJSON() error {
 			"organizations": []string{},
 		},
 		"labels": []string{},
-		"contributors": []map[string]interface{}{
-			{"Id": int16(2244), "Name": "Dale", "orgs": []string{"Support Engineer", "Consulting", "PM", "Integrations"}, "Repositories": []map[string]interface{}{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]interface{}{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}}},
+		"contributors": []map[string]any{
+			{"Id": int16(2244), "Name": "Dale", "orgs": []string{"Support Engineer", "Consulting", "PM", "Integrations"}, "Repositories": []map[string]any{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]any{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}}},
 		},
 	}
 	batch, err := conn.PrepareBatch(ctx, "INSERT INTO example")
@@ -161,7 +161,7 @@ func ReadComplexJSON() error {
 		return err
 	}
 
-	var event map[string]interface{}
+	var event map[string]any
 
 	if err = conn.QueryRow(ctx, "SELECT * FROM example").Scan(&event); err != nil {
 		return err

--- a/examples/clickhouse_api/nested.go
+++ b/examples/clickhouse_api/nested.go
@@ -59,7 +59,7 @@ func NestedUnFlattened() error {
 	var i int64
 	for i = 0; i < 10; i++ {
 		err := batch.Append(
-			[]map[string]interface{}{
+			[]map[string]any{
 				{
 					"Col1_1": strconv.Itoa(int(i)),
 					"Col1_2": uint8(i),
@@ -73,9 +73,9 @@ func NestedUnFlattened() error {
 					"Col1_2": uint8(i + 2),
 				},
 			},
-			[]map[string]interface{}{
+			[]map[string]any{
 				{
-					"Col2_2": []map[string]interface{}{
+					"Col2_2": []map[string]any{
 						{
 							"Col2_2_1": uint8(i),
 							"Col2_2_2": uint8(i + 1),
@@ -84,7 +84,7 @@ func NestedUnFlattened() error {
 					"Col2_1": uint8(i),
 				},
 				{
-					"Col2_2": []map[string]interface{}{
+					"Col2_2": []map[string]any{
 						{
 							"Col2_2_1": uint8(i + 2),
 							"Col2_2_2": uint8(i + 3),
@@ -102,8 +102,8 @@ func NestedUnFlattened() error {
 		return err
 	}
 	var (
-		col1 []map[string]interface{}
-		col2 []map[string]interface{}
+		col1 []map[string]any
+		col2 []map[string]any
 	)
 	rows, err := conn.Query(ctx, "SELECT * FROM example")
 	if err != nil {
@@ -154,7 +154,7 @@ func NestedFlattened() error {
 		col1_1_data := []string{strconv.Itoa(int(i)), strconv.Itoa(int(i + 1)), strconv.Itoa(int(i + 2))}
 		col1_2_data := []uint8{i, i + 1, i + 2}
 		col2_1_data := []uint8{i, i + 1, i + 2}
-		col2_2_data := [][][]interface{}{
+		col2_2_data := [][][]any{
 			{
 				{i, i + 1},
 			},

--- a/examples/clickhouse_api/query_row.go
+++ b/examples/clickhouse_api/query_row.go
@@ -61,7 +61,7 @@ func QueryRow() error {
 			uuid.New(),
 			map[string]uint8{"key": uint8(i)},
 			[]string{strconv.Itoa(i), strconv.Itoa(i + 1), strconv.Itoa(i + 2), strconv.Itoa(i + 3), strconv.Itoa(i + 4), strconv.Itoa(i + 5)},
-			[]interface{}{
+			[]any{
 				strconv.Itoa(i), uint8(i), []map[string]string{
 					{"key": strconv.Itoa(i)},
 					{"key": strconv.Itoa(i + 1)},
@@ -82,7 +82,7 @@ func QueryRow() error {
 		col2, col3, col4 string
 		col5             map[string]uint8
 		col6             []string
-		col7             []interface{}
+		col7             []any
 		col8             time.Time
 	)
 	if err := row.Scan(&col1, &col2, &col3, &col4, &col5, &col6, &col7, &col8); err != nil {

--- a/examples/clickhouse_api/tuple.go
+++ b/examples/clickhouse_api/tuple.go
@@ -49,18 +49,18 @@ func TupleInsertRead() error {
 		return err
 	}
 	// both named and unnamed can be added with slices. Note we can use strongly typed lists and maps if all elements are the same type
-	if err = batch.Append([]interface{}{"Clicky McClickHouse", uint8(42)}, []interface{}{"Clicky McClickHouse Snr", uint8(78)}, []string{"Dale", "521211"}); err != nil {
+	if err = batch.Append([]any{"Clicky McClickHouse", uint8(42)}, []any{"Clicky McClickHouse Snr", uint8(78)}, []string{"Dale", "521211"}); err != nil {
 		return err
 	}
-	if err = batch.Append(map[string]interface{}{"name": "Clicky McClickHouse Jnr", "age": uint8(20)}, []interface{}{"Baby Clicky McClickHouse", uint8(1)}, map[string]string{"name": "Geoff", "id": "12123"}); err != nil {
+	if err = batch.Append(map[string]any{"name": "Clicky McClickHouse Jnr", "age": uint8(20)}, []any{"Baby Clicky McClickHouse", uint8(1)}, map[string]string{"name": "Geoff", "id": "12123"}); err != nil {
 		return err
 	}
 	if err = batch.Send(); err != nil {
 		return err
 	}
 	var (
-		col1 map[string]interface{}
-		col2 []interface{}
+		col1 map[string]any
+		col2 []any
 		col3 map[string]string
 	)
 	// named tuples can be retrieved into a map or slices, unnamed just slices

--- a/examples/clickhouse_api/utils.go
+++ b/examples/clickhouse_api/utils.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package clickhouse_api
 
 import (

--- a/examples/std/batch.go
+++ b/examples/std/batch.go
@@ -67,7 +67,7 @@ func BatchInsert() error {
 			uuid.New(),
 			map[string]uint8{"key": 1},             // Map(String, UInt8)
 			[]string{"Q", "W", "E", "R", "T", "Y"}, // Array(String)
-			[]interface{}{ // Tuple(String, UInt8, Array(Map(String, String)))
+			[]any{ // Tuple(String, UInt8, Array(Map(String, String)))
 				"String Value", uint8(5), []map[string]string{
 					map[string]string{"key": "value"},
 					map[string]string{"key": "value"},

--- a/examples/std/context.go
+++ b/examples/std/context.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package std
 
 import (

--- a/examples/std/dynamic_scan_types.go
+++ b/examples/std/dynamic_scan_types.go
@@ -42,7 +42,7 @@ func DynamicScan() error {
 	if err != nil {
 		return err
 	}
-	vars := make([]interface{}, len(columnTypes))
+	vars := make([]any, len(columnTypes))
 	for i := range columnTypes {
 		vars[i] = reflect.New(columnTypes[i].ScanType()).Interface()
 	}

--- a/examples/std/json.go
+++ b/examples/std/json.go
@@ -107,22 +107,22 @@ func JSONInsertRead() error {
 	if err = scope.Commit(); err != nil {
 		return err
 	}
-	// must pass interface{} - maps must be strongly typed so map[string]interface{} wont work - it wont convert
-	var event interface{}
+	// must pass any - maps must be strongly typed so map[string]any wont work - it wont convert
+	var event any
 	rows := conn.QueryRow("SELECT * FROM example")
 	if err = rows.Scan(&event); err != nil {
 		return err
 	}
 	fmt.Println(clickhouse_tests.ToJson(event))
-	// again pass interface{} for anthing other than primitives
+	// again pass any for anthing other than primitives
 	rows = conn.QueryRow("SELECT event.assignee.Achievement FROM example")
-	var achievement interface{}
+	var achievement any
 	if err = rows.Scan(&achievement); err != nil {
 		return err
 	}
 	fmt.Println(clickhouse_tests.ToJson(event))
 	rows = conn.QueryRow("SELECT event.assignee.Repositories FROM example")
-	var repositories interface{}
+	var repositories any
 	if err = rows.Scan(&repositories); err != nil {
 		return err
 	}

--- a/examples/std/json.go
+++ b/examples/std/json.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package std
 
 import (

--- a/examples/std/map.go
+++ b/examples/std/map.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package std
 
 import (

--- a/examples/std/map.go
+++ b/examples/std/map.go
@@ -80,7 +80,7 @@ func MapInsertRead() error {
 		return err
 	}
 	var (
-		col1 interface{}
+		col1 any
 		col2 map[string]uint64
 		col3 map[string]uint64
 		col4 []map[string]string

--- a/examples/std/query_row.go
+++ b/examples/std/query_row.go
@@ -68,7 +68,7 @@ func QueryRow() error {
 			uuid.New(),
 			map[string]uint8{"key": uint8(i)},
 			[]string{strconv.Itoa(i), strconv.Itoa(i + 1), strconv.Itoa(i + 2), strconv.Itoa(i + 3), strconv.Itoa(i + 4), strconv.Itoa(i + 5)},
-			[]interface{}{
+			[]any{
 				strconv.Itoa(i), uint8(i), []map[string]string{
 					{"key": strconv.Itoa(i)},
 					{"key": strconv.Itoa(i + 1)},
@@ -89,7 +89,7 @@ func QueryRow() error {
 		col2, col3, col4 string
 		col5             map[string]uint8
 		col6             []string
-		col7             interface{}
+		col7             any
 		col8             time.Time
 	)
 	if err := row.Scan(&col1, &col2, &col3, &col4, &col5, &col6, &col7, &col8); err != nil {

--- a/examples/std/query_rows.go
+++ b/examples/std/query_rows.go
@@ -71,7 +71,7 @@ func QueryRows() error {
 			uuid.New(),
 			map[string]uint8{"key": uint8(i)},
 			[]string{strconv.Itoa(i), strconv.Itoa(i + 1), strconv.Itoa(i + 2), strconv.Itoa(i + 3), strconv.Itoa(i + 4), strconv.Itoa(i + 5)},
-			[]interface{}{
+			[]any{
 				strconv.Itoa(i), uint8(i), []map[string]string{
 					{"key": strconv.Itoa(i)},
 					{"key": strconv.Itoa(i + 1)},
@@ -95,7 +95,7 @@ func QueryRows() error {
 		col2, col3, col4 string
 		col5             map[string]uint8
 		col6             []string
-		col7             interface{}
+		col7             any
 		col8             time.Time
 	)
 	for rows.Next() {

--- a/ext/ext.go
+++ b/ext/ext.go
@@ -58,7 +58,7 @@ func (tbl *Table) Block() *proto.Block {
 	return tbl.block
 }
 
-func (tbl *Table) Append(v ...interface{}) error {
+func (tbl *Table) Append(v ...any) error {
 	return tbl.block.Append(v...)
 }
 

--- a/internal/cmd/release_prep/main.go
+++ b/internal/cmd/release_prep/main.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package main
 
 import (

--- a/lib/column/array.go
+++ b/lib/column/array.go
@@ -106,7 +106,7 @@ func (col *Array) Rows() int {
 	return 0
 }
 
-func (col *Array) Row(i int, ptr bool) interface{} {
+func (col *Array) Row(i int, ptr bool) any {
 	value, err := col.scan(col.ScanType(), i)
 	if err != nil {
 		fmt.Println(err)
@@ -114,7 +114,7 @@ func (col *Array) Row(i int, ptr bool) interface{} {
 	return value.Interface()
 }
 
-func (col *Array) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Array) Append(v any) (nulls []uint8, err error) {
 	value := reflect.Indirect(reflect.ValueOf(v))
 	if value.Kind() != reflect.Slice {
 		return nil, &ColumnConverterError{
@@ -132,7 +132,7 @@ func (col *Array) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *Array) AppendRow(v interface{}) error {
+func (col *Array) AppendRow(v any) error {
 	var elem reflect.Value
 	switch v := v.(type) {
 	case reflect.Value:
@@ -215,7 +215,7 @@ func (col *Array) WriteStatePrefix(buffer *proto.Buffer) error {
 	return nil
 }
 
-func (col *Array) ScanRow(dest interface{}, row int) error {
+func (col *Array) ScanRow(dest any, row int) error {
 	elem := reflect.Indirect(reflect.ValueOf(dest))
 	value, err := col.scan(elem.Type(), row)
 	if err != nil {
@@ -265,7 +265,7 @@ func (col *Array) scanSlice(sliceType reflect.Type, row int, level int) (reflect
 	default:
 		return reflect.Value{}, &Error{
 			ColumnType: fmt.Sprint(sliceType.Kind()),
-			Err:        fmt.Errorf("column %s - needs a slice or interface{}", col.Name()),
+			Err:        fmt.Errorf("column %s - needs a slice or any", col.Name()),
 		}
 	}
 
@@ -325,8 +325,8 @@ func (col *Array) scanSlice(sliceType reflect.Type, row int, level int) (reflect
 
 func (col *Array) scanSliceOfObjects(sliceType reflect.Type, row int) (reflect.Value, error) {
 	if sliceType.Kind() == reflect.Interface {
-		// catches interface{} - Note this swallows custom interfaces to which maps couldn't conform
-		subMap := make(map[string]interface{})
+		// catches any - Note this swallows custom interfaces to which maps couldn't conform
+		subMap := make(map[string]any)
 		return col.scanSliceOfMaps(reflect.SliceOf(reflect.TypeOf(subMap)), row)
 	} else if sliceType.Kind() == reflect.Slice {
 		// make a slice of the right type - we need this to be a slice of a type capable of taking an object as nested
@@ -339,19 +339,19 @@ func (col *Array) scanSliceOfObjects(sliceType reflect.Type, row int) (reflect.V
 			// tuples can be read as arrays
 			return col.scanSlice(sliceType, row, 0)
 		case reflect.Interface:
-			// catches []interface{} - Note this swallows custom interfaces to which maps could never conform
-			subMap := make(map[string]interface{})
+			// catches []any - Note this swallows custom interfaces to which maps could never conform
+			subMap := make(map[string]any)
 			return col.scanSliceOfMaps(reflect.SliceOf(reflect.TypeOf(subMap)), row)
 		default:
 			return reflect.Value{}, &Error{
 				ColumnType: fmt.Sprint(sliceType.Elem().Kind()),
-				Err:        fmt.Errorf("column %s - needs a slice of objects or an interface{}", col.Name()),
+				Err:        fmt.Errorf("column %s - needs a slice of objects or an any", col.Name()),
 			}
 		}
 	}
 	return reflect.Value{}, &Error{
 		ColumnType: fmt.Sprint(sliceType.Kind()),
-		Err:        fmt.Errorf("column %s - needs a slice or interface{}", col.Name()),
+		Err:        fmt.Errorf("column %s - needs a slice or any", col.Name()),
 	}
 }
 
@@ -419,7 +419,7 @@ func (col *Array) scanSliceOfStructs(sliceType reflect.Type, row int) (reflect.V
 		start = offset.values.col.Row(row - 1)
 	}
 	if end-start > 0 {
-		// create a slice of the type from the sliceType - if this might be interface{} as its driven by the target datastructure
+		// create a slice of the type from the sliceType - if this might be any as its driven by the target datastructure
 		rSlice := reflect.MakeSlice(sliceType, 0, int(end-start))
 		for i := start; i < end; i++ {
 			sStruct := reflect.New(sliceType.Elem()).Elem()

--- a/lib/column/bigint.go
+++ b/lib/column/bigint.go
@@ -53,7 +53,7 @@ func (col *BigInt) Rows() int {
 	return col.col.Rows()
 }
 
-func (col *BigInt) Row(i int, ptr bool) interface{} {
+func (col *BigInt) Row(i int, ptr bool) any {
 	value := col.row(i)
 	if ptr {
 		return value
@@ -61,7 +61,7 @@ func (col *BigInt) Row(i int, ptr bool) interface{} {
 	return *value
 }
 
-func (col *BigInt) ScanRow(dest interface{}, row int) error {
+func (col *BigInt) ScanRow(dest any, row int) error {
 	switch d := dest.(type) {
 	case *big.Int:
 		*d = *col.row(row)
@@ -78,7 +78,7 @@ func (col *BigInt) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *BigInt) Append(v interface{}) (nulls []uint8, err error) {
+func (col *BigInt) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []big.Int:
 		nulls = make([]uint8, len(v))
@@ -106,7 +106,7 @@ func (col *BigInt) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *BigInt) AppendRow(v interface{}) error {
+func (col *BigInt) AppendRow(v any) error {
 	switch v := v.(type) {
 	case big.Int:
 		col.append(&v)

--- a/lib/column/bool.go
+++ b/lib/column/bool.go
@@ -49,7 +49,7 @@ func (col *Bool) Rows() int {
 	return col.col.Rows()
 }
 
-func (col *Bool) Row(i int, ptr bool) interface{} {
+func (col *Bool) Row(i int, ptr bool) any {
 	val := col.row(i)
 	if ptr {
 		return &val
@@ -57,7 +57,7 @@ func (col *Bool) Row(i int, ptr bool) interface{} {
 	return val
 }
 
-func (col *Bool) ScanRow(dest interface{}, row int) error {
+func (col *Bool) ScanRow(dest any, row int) error {
 	switch d := dest.(type) {
 	case *bool:
 		*d = col.row(row)
@@ -76,7 +76,7 @@ func (col *Bool) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *Bool) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Bool) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []bool:
 		for _, v := range v {
@@ -119,7 +119,7 @@ func (col *Bool) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *Bool) AppendRow(v interface{}) error {
+func (col *Bool) AppendRow(v any) error {
 	var value bool
 	switch v := v.(type) {
 	case bool:

--- a/lib/column/codegen/column.tpl
+++ b/lib/column/codegen/column.tpl
@@ -31,6 +31,7 @@ import (
 	"github.com/paulmach/orb"
 	"github.com/shopspring/decimal"
 	"database/sql"
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 func (t Type) Column(name string, tz *time.Location) (Interface, error) {

--- a/lib/column/codegen/column.tpl
+++ b/lib/column/codegen/column.tpl
@@ -183,8 +183,8 @@ var (
 		scanTypeTime    = reflect.TypeOf(time.Time{})
 		scanTypeRing    = reflect.TypeOf(orb.Ring{})
 		scanTypePoint   = reflect.TypeOf(orb.Point{})
-		scanTypeSlice   = reflect.TypeOf([]interface{}{})
-		scanTypeMap	    = reflect.TypeOf(map[string]interface{}{})
+		scanTypeSlice   = reflect.TypeOf([]any{})
+		scanTypeMap	    = reflect.TypeOf(map[string]any{})
 		scanTypeBigInt  = reflect.TypeOf(&big.Int{})
 		scanTypeString  = reflect.TypeOf("")
 		scanTypePolygon = reflect.TypeOf(orb.Polygon{})
@@ -214,7 +214,7 @@ func (col *{{ .ChType }}) Reset() {
     col.col.Reset()
 }
 
-func (col *{{ .ChType }}) ScanRow(dest interface{}, row int) error {
+func (col *{{ .ChType }}) ScanRow(dest any, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
 	case *{{ .GoType }}:
@@ -253,7 +253,7 @@ func (col *{{ .ChType }}) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *{{ .ChType }}) Row(i int, ptr bool) interface{} {
+func (col *{{ .ChType }}) Row(i int, ptr bool) any {
 	value := col.col.Row(i)
 	if ptr {
 		return &value
@@ -261,7 +261,7 @@ func (col *{{ .ChType }}) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *{{ .ChType }}) Append(v interface{}) (nulls []uint8,err error) {
+func (col *{{ .ChType }}) Append(v any) (nulls []uint8,err error) {
 	switch v := v.(type) {
 	case []{{ .GoType }}:
 		nulls =  make([]uint8, len(v))
@@ -324,7 +324,7 @@ func (col *{{ .ChType }}) Append(v interface{}) (nulls []uint8,err error) {
 	return
 }
 
-func (col *{{ .ChType }}) AppendRow(v interface{}) error {
+func (col *{{ .ChType }}) AppendRow(v any) error {
 	switch v := v.(type) {
 	case {{ .GoType }}:
 		col.col.Append(v)

--- a/lib/column/codegen/main.go
+++ b/lib/column/codegen/main.go
@@ -66,7 +66,7 @@ func init() {
 		return sequenceKey(types[i].ChType) < sequenceKey(types[j].ChType)
 	})
 }
-func write(name string, v interface{}, t *template.Template) error {
+func write(name string, v any, t *template.Template) error {
 	out := new(bytes.Buffer)
 	if err := t.Execute(out, v); err != nil {
 		return err

--- a/lib/column/column.go
+++ b/lib/column/column.go
@@ -78,10 +78,10 @@ type Interface interface {
 	Name() string
 	Type() Type
 	Rows() int
-	Row(i int, ptr bool) interface{}
-	ScanRow(dest interface{}, row int) error
-	Append(v interface{}) (nulls []uint8, err error)
-	AppendRow(v interface{}) error
+	Row(i int, ptr bool) any
+	ScanRow(dest any, row int) error
+	Append(v any) (nulls []uint8, err error)
+	AppendRow(v any) error
 	Decode(reader *proto.Reader, rows int) error
 	Encode(buffer *proto.Buffer)
 	ScanType() reflect.Type

--- a/lib/column/column_gen.go
+++ b/lib/column/column_gen.go
@@ -247,8 +247,8 @@ var (
 	scanTypeTime         = reflect.TypeOf(time.Time{})
 	scanTypeRing         = reflect.TypeOf(orb.Ring{})
 	scanTypePoint        = reflect.TypeOf(orb.Point{})
-	scanTypeSlice        = reflect.TypeOf([]interface{}{})
-	scanTypeMap          = reflect.TypeOf(map[string]interface{}{})
+	scanTypeSlice        = reflect.TypeOf([]any{})
+	scanTypeMap          = reflect.TypeOf(map[string]any{})
 	scanTypeBigInt       = reflect.TypeOf(&big.Int{})
 	scanTypeString       = reflect.TypeOf("")
 	scanTypePolygon      = reflect.TypeOf(orb.Polygon{})
@@ -276,7 +276,7 @@ func (col *Float32) Reset() {
 	col.col.Reset()
 }
 
-func (col *Float32) ScanRow(dest interface{}, row int) error {
+func (col *Float32) ScanRow(dest any, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
 	case *float32:
@@ -298,7 +298,7 @@ func (col *Float32) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *Float32) Row(i int, ptr bool) interface{} {
+func (col *Float32) Row(i int, ptr bool) any {
 	value := col.col.Row(i)
 	if ptr {
 		return &value
@@ -306,7 +306,7 @@ func (col *Float32) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *Float32) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Float32) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []float32:
 		nulls = make([]uint8, len(v))
@@ -334,7 +334,7 @@ func (col *Float32) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *Float32) AppendRow(v interface{}) error {
+func (col *Float32) AppendRow(v any) error {
 	switch v := v.(type) {
 	case float32:
 		col.col.Append(v)
@@ -389,7 +389,7 @@ func (col *Float64) Reset() {
 	col.col.Reset()
 }
 
-func (col *Float64) ScanRow(dest interface{}, row int) error {
+func (col *Float64) ScanRow(dest any, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
 	case *float64:
@@ -413,7 +413,7 @@ func (col *Float64) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *Float64) Row(i int, ptr bool) interface{} {
+func (col *Float64) Row(i int, ptr bool) any {
 	value := col.col.Row(i)
 	if ptr {
 		return &value
@@ -421,7 +421,7 @@ func (col *Float64) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *Float64) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Float64) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []float64:
 		nulls = make([]uint8, len(v))
@@ -462,7 +462,7 @@ func (col *Float64) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *Float64) AppendRow(v interface{}) error {
+func (col *Float64) AppendRow(v any) error {
 	switch v := v.(type) {
 	case float64:
 		col.col.Append(v)
@@ -531,7 +531,7 @@ func (col *Int8) Reset() {
 	col.col.Reset()
 }
 
-func (col *Int8) ScanRow(dest interface{}, row int) error {
+func (col *Int8) ScanRow(dest any, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
 	case *int8:
@@ -560,7 +560,7 @@ func (col *Int8) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *Int8) Row(i int, ptr bool) interface{} {
+func (col *Int8) Row(i int, ptr bool) any {
 	value := col.col.Row(i)
 	if ptr {
 		return &value
@@ -568,7 +568,7 @@ func (col *Int8) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *Int8) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Int8) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []int8:
 		nulls = make([]uint8, len(v))
@@ -614,7 +614,7 @@ func (col *Int8) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *Int8) AppendRow(v interface{}) error {
+func (col *Int8) AppendRow(v any) error {
 	switch v := v.(type) {
 	case int8:
 		col.col.Append(v)
@@ -681,7 +681,7 @@ func (col *Int16) Reset() {
 	col.col.Reset()
 }
 
-func (col *Int16) ScanRow(dest interface{}, row int) error {
+func (col *Int16) ScanRow(dest any, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
 	case *int16:
@@ -705,7 +705,7 @@ func (col *Int16) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *Int16) Row(i int, ptr bool) interface{} {
+func (col *Int16) Row(i int, ptr bool) any {
 	value := col.col.Row(i)
 	if ptr {
 		return &value
@@ -713,7 +713,7 @@ func (col *Int16) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *Int16) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Int16) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []int16:
 		nulls = make([]uint8, len(v))
@@ -754,7 +754,7 @@ func (col *Int16) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *Int16) AppendRow(v interface{}) error {
+func (col *Int16) AppendRow(v any) error {
 	switch v := v.(type) {
 	case int16:
 		col.col.Append(v)
@@ -823,7 +823,7 @@ func (col *Int32) Reset() {
 	col.col.Reset()
 }
 
-func (col *Int32) ScanRow(dest interface{}, row int) error {
+func (col *Int32) ScanRow(dest any, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
 	case *int32:
@@ -847,7 +847,7 @@ func (col *Int32) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *Int32) Row(i int, ptr bool) interface{} {
+func (col *Int32) Row(i int, ptr bool) any {
 	value := col.col.Row(i)
 	if ptr {
 		return &value
@@ -855,7 +855,7 @@ func (col *Int32) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *Int32) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Int32) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []int32:
 		nulls = make([]uint8, len(v))
@@ -896,7 +896,7 @@ func (col *Int32) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *Int32) AppendRow(v interface{}) error {
+func (col *Int32) AppendRow(v any) error {
 	switch v := v.(type) {
 	case int32:
 		col.col.Append(v)
@@ -965,7 +965,7 @@ func (col *Int64) Reset() {
 	col.col.Reset()
 }
 
-func (col *Int64) ScanRow(dest interface{}, row int) error {
+func (col *Int64) ScanRow(dest any, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
 	case *int64:
@@ -991,7 +991,7 @@ func (col *Int64) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *Int64) Row(i int, ptr bool) interface{} {
+func (col *Int64) Row(i int, ptr bool) any {
 	value := col.col.Row(i)
 	if ptr {
 		return &value
@@ -999,7 +999,7 @@ func (col *Int64) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *Int64) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Int64) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []int64:
 		nulls = make([]uint8, len(v))
@@ -1040,7 +1040,7 @@ func (col *Int64) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *Int64) AppendRow(v interface{}) error {
+func (col *Int64) AppendRow(v any) error {
 	switch v := v.(type) {
 	case int64:
 		col.col.Append(v)
@@ -1113,7 +1113,7 @@ func (col *UInt8) Reset() {
 	col.col.Reset()
 }
 
-func (col *UInt8) ScanRow(dest interface{}, row int) error {
+func (col *UInt8) ScanRow(dest any, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
 	case *uint8:
@@ -1135,7 +1135,7 @@ func (col *UInt8) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *UInt8) Row(i int, ptr bool) interface{} {
+func (col *UInt8) Row(i int, ptr bool) any {
 	value := col.col.Row(i)
 	if ptr {
 		return &value
@@ -1143,7 +1143,7 @@ func (col *UInt8) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *UInt8) Append(v interface{}) (nulls []uint8, err error) {
+func (col *UInt8) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []uint8:
 		nulls = make([]uint8, len(v))
@@ -1171,7 +1171,7 @@ func (col *UInt8) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *UInt8) AppendRow(v interface{}) error {
+func (col *UInt8) AppendRow(v any) error {
 	switch v := v.(type) {
 	case uint8:
 		col.col.Append(v)
@@ -1232,7 +1232,7 @@ func (col *UInt16) Reset() {
 	col.col.Reset()
 }
 
-func (col *UInt16) ScanRow(dest interface{}, row int) error {
+func (col *UInt16) ScanRow(dest any, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
 	case *uint16:
@@ -1254,7 +1254,7 @@ func (col *UInt16) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *UInt16) Row(i int, ptr bool) interface{} {
+func (col *UInt16) Row(i int, ptr bool) any {
 	value := col.col.Row(i)
 	if ptr {
 		return &value
@@ -1262,7 +1262,7 @@ func (col *UInt16) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *UInt16) Append(v interface{}) (nulls []uint8, err error) {
+func (col *UInt16) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []uint16:
 		nulls = make([]uint8, len(v))
@@ -1290,7 +1290,7 @@ func (col *UInt16) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *UInt16) AppendRow(v interface{}) error {
+func (col *UInt16) AppendRow(v any) error {
 	switch v := v.(type) {
 	case uint16:
 		col.col.Append(v)
@@ -1345,7 +1345,7 @@ func (col *UInt32) Reset() {
 	col.col.Reset()
 }
 
-func (col *UInt32) ScanRow(dest interface{}, row int) error {
+func (col *UInt32) ScanRow(dest any, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
 	case *uint32:
@@ -1367,7 +1367,7 @@ func (col *UInt32) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *UInt32) Row(i int, ptr bool) interface{} {
+func (col *UInt32) Row(i int, ptr bool) any {
 	value := col.col.Row(i)
 	if ptr {
 		return &value
@@ -1375,7 +1375,7 @@ func (col *UInt32) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *UInt32) Append(v interface{}) (nulls []uint8, err error) {
+func (col *UInt32) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []uint32:
 		nulls = make([]uint8, len(v))
@@ -1403,7 +1403,7 @@ func (col *UInt32) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *UInt32) AppendRow(v interface{}) error {
+func (col *UInt32) AppendRow(v any) error {
 	switch v := v.(type) {
 	case uint32:
 		col.col.Append(v)
@@ -1458,7 +1458,7 @@ func (col *UInt64) Reset() {
 	col.col.Reset()
 }
 
-func (col *UInt64) ScanRow(dest interface{}, row int) error {
+func (col *UInt64) ScanRow(dest any, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
 	case *uint64:
@@ -1480,7 +1480,7 @@ func (col *UInt64) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *UInt64) Row(i int, ptr bool) interface{} {
+func (col *UInt64) Row(i int, ptr bool) any {
 	value := col.col.Row(i)
 	if ptr {
 		return &value
@@ -1488,7 +1488,7 @@ func (col *UInt64) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *UInt64) Append(v interface{}) (nulls []uint8, err error) {
+func (col *UInt64) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []uint64:
 		nulls = make([]uint8, len(v))
@@ -1516,7 +1516,7 @@ func (col *UInt64) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *UInt64) AppendRow(v interface{}) error {
+func (col *UInt64) AppendRow(v any) error {
 	switch v := v.(type) {
 	case uint64:
 		col.col.Append(v)

--- a/lib/column/date.go
+++ b/lib/column/date.go
@@ -66,7 +66,7 @@ func (col *Date) Rows() int {
 	return col.col.Rows()
 }
 
-func (col *Date) Row(i int, ptr bool) interface{} {
+func (col *Date) Row(i int, ptr bool) any {
 	value := col.row(i)
 	if ptr {
 		return &value
@@ -74,7 +74,7 @@ func (col *Date) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *Date) ScanRow(dest interface{}, row int) error {
+func (col *Date) ScanRow(dest any, row int) error {
 	switch d := dest.(type) {
 	case *time.Time:
 		*d = col.row(row)
@@ -96,7 +96,7 @@ func (col *Date) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *Date) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Date) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []time.Time:
 		for _, t := range v {
@@ -165,7 +165,7 @@ func (col *Date) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *Date) AppendRow(v interface{}) error {
+func (col *Date) AppendRow(v any) error {
 	switch v := v.(type) {
 	case time.Time:
 		if err := dateOverflow(minDate, maxDate, v, defaultDateFormatNoZone); err != nil {

--- a/lib/column/date32.go
+++ b/lib/column/date32.go
@@ -56,7 +56,7 @@ func (col *Date32) Rows() int {
 	return col.col.Rows()
 }
 
-func (col *Date32) Row(i int, ptr bool) interface{} {
+func (col *Date32) Row(i int, ptr bool) any {
 	value := col.row(i)
 	if ptr {
 		return &value
@@ -64,7 +64,7 @@ func (col *Date32) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *Date32) ScanRow(dest interface{}, row int) error {
+func (col *Date32) ScanRow(dest any, row int) error {
 	switch d := dest.(type) {
 	case *time.Time:
 		*d = col.row(row)
@@ -86,7 +86,7 @@ func (col *Date32) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *Date32) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Date32) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []time.Time:
 		for _, t := range v {
@@ -155,7 +155,7 @@ func (col *Date32) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *Date32) AppendRow(v interface{}) error {
+func (col *Date32) AppendRow(v any) error {
 	switch v := v.(type) {
 	case time.Time:
 		if err := dateOverflow(minDate32, maxDate32, v, "2006-01-02"); err != nil {

--- a/lib/column/datetime.go
+++ b/lib/column/datetime.go
@@ -78,7 +78,7 @@ func (col *DateTime) Rows() int {
 	return col.col.Rows()
 }
 
-func (col *DateTime) Row(i int, ptr bool) interface{} {
+func (col *DateTime) Row(i int, ptr bool) any {
 	value := col.row(i)
 	if ptr {
 		return &value
@@ -86,7 +86,7 @@ func (col *DateTime) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *DateTime) ScanRow(dest interface{}, row int) error {
+func (col *DateTime) ScanRow(dest any, row int) error {
 	switch d := dest.(type) {
 	case *time.Time:
 		*d = col.row(row)
@@ -108,7 +108,7 @@ func (col *DateTime) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *DateTime) Append(v interface{}) (nulls []uint8, err error) {
+func (col *DateTime) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	// we assume int64 is in seconds and don't currently scale to the precision
 	case []int64:
@@ -197,7 +197,7 @@ func (col *DateTime) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *DateTime) AppendRow(v interface{}) error {
+func (col *DateTime) AppendRow(v any) error {
 	switch v := v.(type) {
 	// we assume int64 is in seconds and don't currently scale to the precision
 	case int64:

--- a/lib/column/datetime64.go
+++ b/lib/column/datetime64.go
@@ -98,7 +98,7 @@ func (col *DateTime64) Rows() int {
 	return col.col.Rows()
 }
 
-func (col *DateTime64) Row(i int, ptr bool) interface{} {
+func (col *DateTime64) Row(i int, ptr bool) any {
 	value := col.row(i)
 	if ptr {
 		return &value
@@ -106,7 +106,7 @@ func (col *DateTime64) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *DateTime64) ScanRow(dest interface{}, row int) error {
+func (col *DateTime64) ScanRow(dest any, row int) error {
 	switch d := dest.(type) {
 	case *time.Time:
 		*d = col.row(row)
@@ -128,7 +128,7 @@ func (col *DateTime64) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *DateTime64) Append(v interface{}) (nulls []uint8, err error) {
+func (col *DateTime64) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	// we assume int64 is in milliseconds and don't currently scale to the precision - no tests to indicate intended
 	// historical behaviour
@@ -202,7 +202,7 @@ func (col *DateTime64) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *DateTime64) AppendRow(v interface{}) error {
+func (col *DateTime64) AppendRow(v any) error {
 	switch v := v.(type) {
 	case int64:
 		col.col.Append(time.UnixMilli(v))

--- a/lib/column/decimal.go
+++ b/lib/column/decimal.go
@@ -93,7 +93,7 @@ func (col *Decimal) Rows() int {
 	return col.col.Rows()
 }
 
-func (col *Decimal) Row(i int, ptr bool) interface{} {
+func (col *Decimal) Row(i int, ptr bool) any {
 	value := col.row(i)
 	if ptr {
 		return value
@@ -130,7 +130,7 @@ func (col *Decimal) row(i int) *decimal.Decimal {
 	return &value
 }
 
-func (col *Decimal) ScanRow(dest interface{}, row int) error {
+func (col *Decimal) ScanRow(dest any, row int) error {
 	switch d := dest.(type) {
 	case *decimal.Decimal:
 		*d = *col.row(row)
@@ -150,7 +150,7 @@ func (col *Decimal) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *Decimal) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Decimal) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []decimal.Decimal:
 		nulls = make([]uint8, len(v))
@@ -179,7 +179,7 @@ func (col *Decimal) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *Decimal) AppendRow(v interface{}) error {
+func (col *Decimal) AppendRow(v any) error {
 	value := decimal.New(0, 0)
 	switch v := v.(type) {
 	case decimal.Decimal:

--- a/lib/column/enum16.go
+++ b/lib/column/enum16.go
@@ -52,7 +52,7 @@ func (col *Enum16) Rows() int {
 	return col.col.Rows()
 }
 
-func (col *Enum16) Row(i int, ptr bool) interface{} {
+func (col *Enum16) Row(i int, ptr bool) any {
 	value := col.vi[col.col.Row(i)]
 	if ptr {
 		return &value
@@ -60,7 +60,7 @@ func (col *Enum16) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *Enum16) ScanRow(dest interface{}, row int) error {
+func (col *Enum16) ScanRow(dest any, row int) error {
 	value := col.col.Row(row)
 	switch d := dest.(type) {
 	case *string:
@@ -81,7 +81,7 @@ func (col *Enum16) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *Enum16) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Enum16) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []int16:
 		nulls = make([]uint8, len(v))
@@ -157,7 +157,7 @@ func (col *Enum16) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *Enum16) AppendRow(elem interface{}) error {
+func (col *Enum16) AppendRow(elem any) error {
 	switch elem := elem.(type) {
 	case int16:
 		return col.AppendRow(int(elem))

--- a/lib/column/enum8.go
+++ b/lib/column/enum8.go
@@ -52,7 +52,7 @@ func (col *Enum8) Rows() int {
 	return col.col.Rows()
 }
 
-func (col *Enum8) Row(i int, ptr bool) interface{} {
+func (col *Enum8) Row(i int, ptr bool) any {
 	value := col.vi[col.col.Row(i)]
 	if ptr {
 		return &value
@@ -60,7 +60,7 @@ func (col *Enum8) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *Enum8) ScanRow(dest interface{}, row int) error {
+func (col *Enum8) ScanRow(dest any, row int) error {
 	v := col.col.Row(row)
 	switch d := dest.(type) {
 	case *string:
@@ -81,7 +81,7 @@ func (col *Enum8) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *Enum8) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Enum8) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []int8:
 		nulls = make([]uint8, len(v))
@@ -163,7 +163,7 @@ func (col *Enum8) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *Enum8) AppendRow(elem interface{}) error {
+func (col *Enum8) AppendRow(elem any) error {
 	switch elem := elem.(type) {
 	case int8:
 		return col.AppendRow(int(elem))

--- a/lib/column/fixed_string.go
+++ b/lib/column/fixed_string.go
@@ -60,7 +60,7 @@ func (col *FixedString) Rows() int {
 	return col.col.Rows()
 }
 
-func (col *FixedString) Row(i int, ptr bool) interface{} {
+func (col *FixedString) Row(i int, ptr bool) any {
 	value := col.row(i)
 	if ptr {
 		return &value
@@ -68,7 +68,7 @@ func (col *FixedString) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *FixedString) ScanRow(dest interface{}, row int) error {
+func (col *FixedString) ScanRow(dest any, row int) error {
 	switch d := dest.(type) {
 	case *string:
 		*d = col.row(row)
@@ -90,7 +90,7 @@ func (col *FixedString) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *FixedString) Append(v interface{}) (nulls []uint8, err error) {
+func (col *FixedString) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []string:
 		nulls = make([]uint8, len(v))
@@ -135,7 +135,7 @@ func (col *FixedString) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *FixedString) AppendRow(v interface{}) (err error) {
+func (col *FixedString) AppendRow(v any) (err error) {
 	data := make([]byte, col.col.Size)
 	switch v := v.(type) {
 	case string:

--- a/lib/column/geo_multi_polygon.go
+++ b/lib/column/geo_multi_polygon.go
@@ -50,7 +50,7 @@ func (col *MultiPolygon) Rows() int {
 	return col.set.Rows()
 }
 
-func (col *MultiPolygon) Row(i int, ptr bool) interface{} {
+func (col *MultiPolygon) Row(i int, ptr bool) any {
 	value := col.row(i)
 	if ptr {
 		return &value
@@ -58,7 +58,7 @@ func (col *MultiPolygon) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *MultiPolygon) ScanRow(dest interface{}, row int) error {
+func (col *MultiPolygon) ScanRow(dest any, row int) error {
 	switch d := dest.(type) {
 	case *orb.MultiPolygon:
 		*d = col.row(row)
@@ -76,7 +76,7 @@ func (col *MultiPolygon) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *MultiPolygon) Append(v interface{}) (nulls []uint8, err error) {
+func (col *MultiPolygon) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []orb.MultiPolygon:
 		values := make([][]orb.Polygon, 0, len(v))
@@ -99,7 +99,7 @@ func (col *MultiPolygon) Append(v interface{}) (nulls []uint8, err error) {
 	}
 }
 
-func (col *MultiPolygon) AppendRow(v interface{}) error {
+func (col *MultiPolygon) AppendRow(v any) error {
 	switch v := v.(type) {
 	case orb.MultiPolygon:
 		return col.set.AppendRow([]orb.Polygon(v))

--- a/lib/column/geo_point.go
+++ b/lib/column/geo_point.go
@@ -50,7 +50,7 @@ func (col *Point) Rows() int {
 	return col.col.Rows()
 }
 
-func (col *Point) Row(i int, ptr bool) interface{} {
+func (col *Point) Row(i int, ptr bool) any {
 	value := col.row(i)
 	if ptr {
 		return &value
@@ -58,7 +58,7 @@ func (col *Point) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *Point) ScanRow(dest interface{}, row int) error {
+func (col *Point) ScanRow(dest any, row int) error {
 	switch d := dest.(type) {
 	case *orb.Point:
 		*d = col.row(row)
@@ -76,7 +76,7 @@ func (col *Point) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *Point) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Point) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []orb.Point:
 		nulls = make([]uint8, len(v))
@@ -103,7 +103,7 @@ func (col *Point) Append(v interface{}) (nulls []uint8, err error) {
 	}
 	return
 }
-func (col *Point) AppendRow(v interface{}) error {
+func (col *Point) AppendRow(v any) error {
 	switch v := v.(type) {
 	case orb.Point:
 		col.col.Append(proto.Point{

--- a/lib/column/geo_polygon.go
+++ b/lib/column/geo_polygon.go
@@ -50,7 +50,7 @@ func (col *Polygon) Rows() int {
 	return col.set.Rows()
 }
 
-func (col *Polygon) Row(i int, ptr bool) interface{} {
+func (col *Polygon) Row(i int, ptr bool) any {
 	value := col.row(i)
 	if ptr {
 		return &value
@@ -58,7 +58,7 @@ func (col *Polygon) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *Polygon) ScanRow(dest interface{}, row int) error {
+func (col *Polygon) ScanRow(dest any, row int) error {
 	switch d := dest.(type) {
 	case *orb.Polygon:
 		*d = col.row(row)
@@ -76,7 +76,7 @@ func (col *Polygon) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *Polygon) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Polygon) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []orb.Polygon:
 		values := make([][]orb.Ring, 0, len(v))
@@ -99,7 +99,7 @@ func (col *Polygon) Append(v interface{}) (nulls []uint8, err error) {
 	}
 }
 
-func (col *Polygon) AppendRow(v interface{}) error {
+func (col *Polygon) AppendRow(v any) error {
 	switch v := v.(type) {
 	case orb.Polygon:
 		return col.set.AppendRow([]orb.Ring(v))

--- a/lib/column/geo_ring.go
+++ b/lib/column/geo_ring.go
@@ -50,7 +50,7 @@ func (col *Ring) Rows() int {
 	return col.set.Rows()
 }
 
-func (col *Ring) Row(i int, ptr bool) interface{} {
+func (col *Ring) Row(i int, ptr bool) any {
 	value := col.row(i)
 	if ptr {
 		return &value
@@ -58,7 +58,7 @@ func (col *Ring) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *Ring) ScanRow(dest interface{}, row int) error {
+func (col *Ring) ScanRow(dest any, row int) error {
 	switch d := dest.(type) {
 	case *orb.Ring:
 		*d = col.row(row)
@@ -76,7 +76,7 @@ func (col *Ring) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *Ring) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Ring) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []orb.Ring:
 		values := make([][]orb.Point, 0, len(v))
@@ -99,7 +99,7 @@ func (col *Ring) Append(v interface{}) (nulls []uint8, err error) {
 	}
 }
 
-func (col *Ring) AppendRow(v interface{}) error {
+func (col *Ring) AppendRow(v any) error {
 	switch v := v.(type) {
 	case orb.Ring:
 		return col.set.AppendRow([]orb.Point(v))

--- a/lib/column/interval.go
+++ b/lib/column/interval.go
@@ -52,14 +52,14 @@ func (col *Interval) parse(t Type) (Interface, error) {
 func (col *Interval) Type() Type             { return col.chType }
 func (col *Interval) ScanType() reflect.Type { return scanTypeString }
 func (col *Interval) Rows() int              { return col.col.Rows() }
-func (col *Interval) Row(i int, ptr bool) interface{} {
+func (col *Interval) Row(i int, ptr bool) any {
 	val := col.row(i)
 	if ptr {
 		return &val
 	}
 	return val
 }
-func (col *Interval) ScanRow(dest interface{}, row int) error {
+func (col *Interval) ScanRow(dest any, row int) error {
 	switch d := dest.(type) {
 	case *string:
 		*d = col.row(row)
@@ -76,14 +76,14 @@ func (col *Interval) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (Interval) Append(interface{}) ([]uint8, error) {
+func (Interval) Append(any) ([]uint8, error) {
 	return nil, &Error{
 		ColumnType: "Interval",
 		Err:        errors.New("data type values can't be stored in tables"),
 	}
 }
 
-func (Interval) AppendRow(interface{}) error {
+func (Interval) AppendRow(any) error {
 	return &Error{
 		ColumnType: "Interval",
 		Err:        errors.New("data type values can't be stored in tables"),

--- a/lib/column/ipv4.go
+++ b/lib/column/ipv4.go
@@ -51,7 +51,7 @@ func (col *IPv4) Rows() int {
 	return col.col.Rows()
 }
 
-func (col *IPv4) Row(i int, ptr bool) interface{} {
+func (col *IPv4) Row(i int, ptr bool) any {
 	value := col.row(i)
 	if ptr {
 		return &value
@@ -59,7 +59,7 @@ func (col *IPv4) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *IPv4) ScanRow(dest interface{}, row int) error {
+func (col *IPv4) ScanRow(dest any, row int) error {
 	switch d := dest.(type) {
 	case *string:
 		*d = col.row(row).String()
@@ -120,7 +120,7 @@ func (col *IPv4) AppendV4IPs(ips []netip.Addr) {
 	}
 }
 
-func (col *IPv4) Append(v interface{}) (nulls []uint8, err error) {
+func (col *IPv4) Append(v any) (nulls []uint8, err error) {
 
 	switch v := v.(type) {
 	case []string:
@@ -208,7 +208,7 @@ func (col *IPv4) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *IPv4) AppendRow(v interface{}) (err error) {
+func (col *IPv4) AppendRow(v any) (err error) {
 	switch v := v.(type) {
 	case string:
 		ip, err := strToIPV4(v)

--- a/lib/column/ipv6.go
+++ b/lib/column/ipv6.go
@@ -50,7 +50,7 @@ func (col *IPv6) Rows() int {
 	return col.col.Rows()
 }
 
-func (col *IPv6) Row(i int, ptr bool) interface{} {
+func (col *IPv6) Row(i int, ptr bool) any {
 	value := col.row(i)
 	if ptr {
 		return &value
@@ -58,7 +58,7 @@ func (col *IPv6) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *IPv6) ScanRow(dest interface{}, row int) error {
+func (col *IPv6) ScanRow(dest any, row int) error {
 	switch d := dest.(type) {
 	case *string:
 		*d = col.row(row).String()
@@ -94,7 +94,7 @@ func (col *IPv6) AppendV6IPs(ips []netip.Addr) {
 	}
 }
 
-func (col *IPv6) Append(v interface{}) (nulls []uint8, err error) {
+func (col *IPv6) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []string:
 		nulls = make([]uint8, len(v))
@@ -175,7 +175,7 @@ func (col *IPv6) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *IPv6) AppendRow(v interface{}) (err error) {
+func (col *IPv6) AppendRow(v any) (err error) {
 	switch v := v.(type) {
 	case string:
 		ip, err := strToIPV6(v)

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -66,7 +66,7 @@ type JSONParent interface {
 	rows() int
 }
 
-func parseType(name string, vType reflect.Type, values interface{}, isArray bool, jCol JSONParent, numEmpty int) error {
+func parseType(name string, vType reflect.Type, values any, isArray bool, jCol JSONParent, numEmpty int) error {
 	_, ok := typeMappings[vType.String()]
 	if !ok {
 		return &UnsupportedColumnTypeError{
@@ -107,7 +107,7 @@ func parseType(name string, vType reflect.Type, values interface{}, isArray bool
 	return col.AppendRow(fmt.Sprint(values))
 }
 
-func parsePrimitive(name string, kind reflect.Kind, values interface{}, isArray bool, jCol JSONParent, numEmpty int) error {
+func parsePrimitive(name string, kind reflect.Kind, values any, isArray bool, jCol JSONParent, numEmpty int) error {
 	ct, ok := kindMappings[kind]
 	if !ok {
 		return &UnsupportedColumnTypeError{
@@ -117,7 +117,7 @@ func parsePrimitive(name string, kind reflect.Kind, values interface{}, isArray 
 	var err error
 	if isArray {
 		ct = fmt.Sprintf("Array(%s)", ct)
-		// if we have a []interface{} we will need to cast to the target column type - this will be based on the first
+		// if we have a []any we will need to cast to the target column type - this will be based on the first
 		// values types. Inconsistent slices will fail.
 		values, err = convertSlice(values)
 		if err != nil {
@@ -145,11 +145,11 @@ func parsePrimitive(name string, kind reflect.Kind, values interface{}, isArray 
 	return col.AppendRow(values)
 }
 
-// converts a []interface{} of primitives to a typed slice
+// converts a []any of primitives to a typed slice
 // maybe this can be done with reflection but likely slower. investigate.
 // this uses the first value to determine the type - subsequent values must currently be of the same type - we might cast later
 // but wider driver doesn't support e.g. int to int64
-func convertSlice(values interface{}) (interface{}, error) {
+func convertSlice(values any) (any, error) {
 	rValues := reflect.ValueOf(values)
 	if rValues.Len() == 0 || rValues.Index(0).Kind() != reflect.Interface {
 		return values, nil
@@ -163,7 +163,7 @@ func convertSlice(values interface{}) (interface{}, error) {
 		}
 	}
 	if fType == nil {
-		return []interface{}{}, nil
+		return []any{}, nil
 	}
 	typedSlice := reflect.MakeSlice(reflect.SliceOf(fType), 0, rValues.Len())
 	for i := 0; i < rValues.Len(); i++ {
@@ -225,7 +225,7 @@ func getMapFieldName(name string) string {
 	return colEscape.Replace(name)
 }
 
-func parseSlice(name string, values interface{}, jCol JSONParent, preFill int) error {
+func parseSlice(name string, values any, jCol JSONParent, preFill int) error {
 	fType := reflect.TypeOf(values).Elem()
 	sKind := fType.Kind()
 	rValues := reflect.ValueOf(values)
@@ -284,7 +284,7 @@ func parseSlice(name string, values interface{}, jCol JSONParent, preFill int) e
 					return err
 				}
 			default:
-				// only happens if slice has a primitive mixed with complex types in a []interface{}
+				// only happens if slice has a primitive mixed with complex types in a []any
 				return &Error{
 					ColumnType: fmt.Sprint(sKind),
 					Err:        fmt.Errorf("slices must be same dimension in column %s", col.Name()),
@@ -305,10 +305,10 @@ func parseStruct(name string, structVal reflect.Value, jCol JSONParent, preFill 
 }
 
 func iterateStruct(structVal reflect.Value, col JSONParent, preFill int) error {
-	// structs generally have consistent field counts but we ignore nil values that are interface{} as we can't infer from
+	// structs generally have consistent field counts but we ignore nil values that are any as we can't infer from
 	// these until they occur - so we might need to either backfill when to do occur or insert empty based on previous
 	if structVal.Kind() == reflect.Interface {
-		// can happen if passed from []interface{}
+		// can happen if passed from []any
 		structVal = structVal.Elem()
 	}
 
@@ -412,7 +412,7 @@ func iterateMap(mapVal reflect.Value, col JSONParent, preFill int) error {
 	// two inconsistent options - 1. new - map has new columns 2. massing - map has missing columns
 	// for (1) we need to update previous, for (2) we need to ensure we add a null entry
 	if mapVal.Kind() == reflect.Interface {
-		// can happen if passed from []interface{}
+		// can happen if passed from []any
 		mapVal = mapVal.Elem()
 	}
 
@@ -488,7 +488,7 @@ func iterateMap(mapVal reflect.Value, col JSONParent, preFill int) error {
 	return nil
 }
 
-func appendStructOrMap(jCol *JSONObject, data interface{}) error {
+func appendStructOrMap(jCol *JSONObject, data any) error {
 	vData := reflect.ValueOf(data)
 	kind := vData.Kind()
 	if kind == reflect.Struct {
@@ -848,15 +848,15 @@ func (jCol *JSONObject) Rows() int {
 
 // ClickHouse returns JSON as a tuple i.e. these will never be invoked
 
-func (jCol *JSONObject) Row(i int, ptr bool) interface{} {
+func (jCol *JSONObject) Row(i int, ptr bool) any {
 	panic("Not implemented")
 }
 
-func (jCol *JSONObject) ScanRow(dest interface{}, row int) error {
+func (jCol *JSONObject) ScanRow(dest any, row int) error {
 	panic("Not implemented")
 }
 
-func (jCol *JSONObject) Append(v interface{}) (nulls []uint8, err error) {
+func (jCol *JSONObject) Append(v any) (nulls []uint8, err error) {
 	jSlice := reflect.ValueOf(v)
 	if jSlice.Kind() != reflect.Slice {
 		return nil, &ColumnConverterError{
@@ -873,7 +873,7 @@ func (jCol *JSONObject) Append(v interface{}) (nulls []uint8, err error) {
 	return nil, nil
 }
 
-func (jCol *JSONObject) AppendRow(v interface{}) error {
+func (jCol *JSONObject) AppendRow(v any) error {
 	if reflect.ValueOf(v).Kind() == reflect.Struct || reflect.ValueOf(v).Kind() == reflect.Map {
 		if jCol.columns != nil && jCol.encoding == 1 {
 			return &Error{

--- a/lib/column/lowcardinality.go
+++ b/lib/column/lowcardinality.go
@@ -64,7 +64,7 @@ type LowCardinality struct {
 
 	append struct {
 		keys  []int
-		index map[interface{}]int
+		index map[any]int
 	}
 	name string
 }
@@ -76,7 +76,7 @@ func (col *LowCardinality) Reset() {
 	col.keys16.Reset()
 	col.keys32.Reset()
 	col.keys64.Reset()
-	col.append.index = make(map[interface{}]int)
+	col.append.index = make(map[any]int)
 	col.append.keys = col.append.keys[:0]
 }
 
@@ -86,7 +86,7 @@ func (col *LowCardinality) Name() string {
 
 func (col *LowCardinality) parse(t Type, tz *time.Location) (_ *LowCardinality, err error) {
 	col.chType = t
-	col.append.index = make(map[interface{}]int)
+	col.append.index = make(map[any]int)
 	if col.index, err = Type(t.params()).Column(col.name, tz); err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (col *LowCardinality) Rows() int {
 	return col.rows
 }
 
-func (col *LowCardinality) Row(i int, ptr bool) interface{} {
+func (col *LowCardinality) Row(i int, ptr bool) any {
 	idx := col.indexRowNum(i)
 	if idx == 0 && col.nullable {
 		return nil
@@ -116,7 +116,7 @@ func (col *LowCardinality) Row(i int, ptr bool) interface{} {
 	return col.index.Row(idx, ptr)
 }
 
-func (col *LowCardinality) ScanRow(dest interface{}, row int) error {
+func (col *LowCardinality) ScanRow(dest any, row int) error {
 	idx := col.indexRowNum(row)
 	if idx == 0 && col.nullable {
 		return nil
@@ -124,7 +124,7 @@ func (col *LowCardinality) ScanRow(dest interface{}, row int) error {
 	return col.index.ScanRow(dest, idx)
 }
 
-func (col *LowCardinality) Append(v interface{}) (nulls []uint8, err error) {
+func (col *LowCardinality) Append(v any) (nulls []uint8, err error) {
 	value := reflect.Indirect(reflect.ValueOf(v))
 	if value.Kind() != reflect.Slice {
 		return nil, &ColumnConverterError{
@@ -141,7 +141,7 @@ func (col *LowCardinality) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *LowCardinality) AppendRow(v interface{}) error {
+func (col *LowCardinality) AppendRow(v any) error {
 	col.rows++
 	if col.index.Rows() == 0 { // init
 		if col.index.AppendRow(nil); col.nullable {

--- a/lib/column/map.go
+++ b/lib/column/map.go
@@ -36,9 +36,9 @@ type Map struct {
 }
 
 type OrderedMap interface {
-	Get(key interface{}) (interface{}, bool)
-	Put(key interface{}, value interface{})
-	Keys() <-chan interface{}
+	Get(key any) (any, bool)
+	Put(key any, value any)
+	Keys() <-chan any
 }
 
 func (col *Map) Reset() {
@@ -83,11 +83,11 @@ func (col *Map) Rows() int {
 	return col.offsets.col.Rows()
 }
 
-func (col *Map) Row(i int, ptr bool) interface{} {
+func (col *Map) Row(i int, ptr bool) any {
 	return col.row(i).Interface()
 }
 
-func (col *Map) ScanRow(dest interface{}, i int) error {
+func (col *Map) ScanRow(dest any, i int) error {
 	value := reflect.Indirect(reflect.ValueOf(dest))
 	if value.Type() == col.scanType {
 		value.Set(col.row(i))
@@ -108,7 +108,7 @@ func (col *Map) ScanRow(dest interface{}, i int) error {
 	}
 }
 
-func (col *Map) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Map) Append(v any) (nulls []uint8, err error) {
 	value := reflect.Indirect(reflect.ValueOf(v))
 	if value.Kind() != reflect.Slice {
 		return nil, &ColumnConverterError{
@@ -126,7 +126,7 @@ func (col *Map) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *Map) AppendRow(v interface{}) error {
+func (col *Map) AppendRow(v any) error {
 	value := reflect.Indirect(reflect.ValueOf(v))
 	if value.Type() == col.scanType {
 		var (
@@ -251,7 +251,7 @@ func (col *Map) row(n int) reflect.Value {
 	return value
 }
 
-func (col *Map) orderedRow(n int) ([]interface{}, []interface{}) {
+func (col *Map) orderedRow(n int) ([]any, []any) {
 	var prev int64
 	if n != 0 {
 		prev = col.offsets.col.Row(n - 1)
@@ -260,8 +260,8 @@ func (col *Map) orderedRow(n int) ([]interface{}, []interface{}) {
 		size = int(col.offsets.col.Row(n) - prev)
 		from = int(prev)
 	)
-	keys := make([]interface{}, size)
-	values := make([]interface{}, size)
+	keys := make([]any, size)
+	values := make([]any, size)
 	for next := 0; next < size; next++ {
 		keys[next] = col.keys.Row(from+next, false)
 		values[next] = col.values.Row(from+next, false)

--- a/lib/column/nothing.go
+++ b/lib/column/nothing.go
@@ -36,20 +36,20 @@ func (col Nothing) Name() string {
 	return col.name
 }
 
-func (Nothing) Type() Type                { return "Nothing" }
-func (Nothing) ScanType() reflect.Type    { return reflect.TypeOf((*interface{})(nil)) }
-func (Nothing) Rows() int                 { return 0 }
-func (Nothing) Row(int, bool) interface{} { return nil }
-func (Nothing) ScanRow(interface{}, int) error {
+func (Nothing) Type() Type             { return "Nothing" }
+func (Nothing) ScanType() reflect.Type { return reflect.TypeOf((*any)(nil)) }
+func (Nothing) Rows() int              { return 0 }
+func (Nothing) Row(int, bool) any      { return nil }
+func (Nothing) ScanRow(any, int) error {
 	return nil
 }
-func (Nothing) Append(interface{}) ([]uint8, error) {
+func (Nothing) Append(any) ([]uint8, error) {
 	return nil, &Error{
 		ColumnType: "Nothing",
 		Err:        errors.New("data type values can't be stored in tables"),
 	}
 }
-func (col Nothing) AppendRow(interface{}) error {
+func (col Nothing) AppendRow(any) error {
 	return &Error{
 		ColumnType: "Nothing",
 		Err:        errors.New("data type values can't be stored in tables"),

--- a/lib/column/nullable.go
+++ b/lib/column/nullable.go
@@ -77,7 +77,7 @@ func (col *Nullable) Rows() int {
 	return col.nulls.Rows()
 }
 
-func (col *Nullable) Row(i int, ptr bool) interface{} {
+func (col *Nullable) Row(i int, ptr bool) any {
 	if col.enable {
 		if col.nulls.Row(i) == 1 {
 			return nil
@@ -86,7 +86,7 @@ func (col *Nullable) Row(i int, ptr bool) interface{} {
 	return col.base.Row(i, true)
 }
 
-func (col *Nullable) ScanRow(dest interface{}, row int) error {
+func (col *Nullable) ScanRow(dest any, row int) error {
 	if col.enable {
 		switch col.nulls.Row(row) {
 		case 1:
@@ -125,7 +125,7 @@ func (col *Nullable) ScanRow(dest interface{}, row int) error {
 	return col.base.ScanRow(dest, row)
 }
 
-func (col *Nullable) Append(v interface{}) ([]uint8, error) {
+func (col *Nullable) Append(v any) ([]uint8, error) {
 	nulls, err := col.base.Append(v)
 	if err != nil {
 		return nil, err
@@ -136,7 +136,7 @@ func (col *Nullable) Append(v interface{}) ([]uint8, error) {
 	return nulls, nil
 }
 
-func (col *Nullable) AppendRow(v interface{}) error {
+func (col *Nullable) AppendRow(v any) error {
 	// Might receive double pointers like **String, because of how Nullable columns are read
 	// Unpack because we can't write double pointers
 	rv := reflect.ValueOf(v)

--- a/lib/column/simple_aggregate_function.go
+++ b/lib/column/simple_aggregate_function.go
@@ -58,16 +58,16 @@ func (col *SimpleAggregateFunction) ScanType() reflect.Type {
 func (col *SimpleAggregateFunction) Rows() int {
 	return col.base.Rows()
 }
-func (col *SimpleAggregateFunction) Row(i int, ptr bool) interface{} {
+func (col *SimpleAggregateFunction) Row(i int, ptr bool) any {
 	return col.base.Row(i, ptr)
 }
-func (col *SimpleAggregateFunction) ScanRow(dest interface{}, rows int) error {
+func (col *SimpleAggregateFunction) ScanRow(dest any, rows int) error {
 	return col.base.ScanRow(dest, rows)
 }
-func (col *SimpleAggregateFunction) Append(v interface{}) ([]uint8, error) {
+func (col *SimpleAggregateFunction) Append(v any) ([]uint8, error) {
 	return col.base.Append(v)
 }
-func (col *SimpleAggregateFunction) AppendRow(v interface{}) error {
+func (col *SimpleAggregateFunction) AppendRow(v any) error {
 	return col.base.AppendRow(v)
 }
 func (col *SimpleAggregateFunction) Decode(reader *proto.Reader, rows int) error {

--- a/lib/column/string.go
+++ b/lib/column/string.go
@@ -53,7 +53,7 @@ func (col *String) Rows() int {
 	return col.col.Rows()
 }
 
-func (col *String) Row(i int, ptr bool) interface{} {
+func (col *String) Row(i int, ptr bool) any {
 	val := col.col.Row(i)
 	if ptr {
 		return &val
@@ -61,7 +61,7 @@ func (col *String) Row(i int, ptr bool) interface{} {
 	return val
 }
 
-func (col *String) ScanRow(dest interface{}, row int) error {
+func (col *String) ScanRow(dest any, row int) error {
 	val := col.Row(row, false).(string)
 	switch d := dest.(type) {
 	case *string:
@@ -86,7 +86,7 @@ func (col *String) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *String) AppendRow(v interface{}) error {
+func (col *String) AppendRow(v any) error {
 	switch v := v.(type) {
 	case string:
 		col.col.Append(v)
@@ -152,7 +152,7 @@ func (col *String) AppendRow(v interface{}) error {
 	return nil
 }
 
-func (col *String) Append(v interface{}) (nulls []uint8, err error) {
+func (col *String) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []string:
 		col.col.AppendArr(v)

--- a/lib/column/tuple.go
+++ b/lib/column/tuple.go
@@ -130,7 +130,7 @@ func (col *Tuple) Rows() int {
 	return 0
 }
 
-func (col *Tuple) Row(i int, ptr bool) interface{} {
+func (col *Tuple) Row(i int, ptr bool) any {
 	tuple := reflect.New(col.ScanType())
 	value := tuple.Interface()
 	if err := col.ScanRow(value, i); err != nil {
@@ -262,8 +262,8 @@ func (col *Tuple) scanMap(targetMap reflect.Value, row int) error {
 				}
 				targetMap.SetMapIndex(reflect.ValueOf(colName), newMap)
 			case reflect.Interface:
-				// catches interface{} - Note this swallows custom interfaces to which maps couldn't conform
-				newMap := reflect.ValueOf(make(map[string]interface{}))
+				// catches any - Note this swallows custom interfaces to which maps couldn't conform
+				newMap := reflect.ValueOf(make(map[string]any))
 				if err := dCol.scanMap(newMap, row); err != nil {
 					return err
 				}
@@ -271,7 +271,7 @@ func (col *Tuple) scanMap(targetMap reflect.Value, row int) error {
 			default:
 				return &Error{
 					ColumnType: fmt.Sprint(targetMap.Type().Elem().Kind()),
-					Err:        fmt.Errorf("column %s - needs a map/struct or interface{}", col.Name()),
+					Err:        fmt.Errorf("column %s - needs a map/struct or any", col.Name()),
 				}
 			}
 		case *Nested:
@@ -280,7 +280,7 @@ func (col *Tuple) scanMap(targetMap reflect.Value, row int) error {
 			if err != nil {
 				return err
 			}
-			// this wont work if targetMap is a map[string][]interface{} and we try to set a typed slice
+			// this wont work if targetMap is a map[string][]any and we try to set a typed slice
 			targetMap.SetMapIndex(reflect.ValueOf(colName), subSlice)
 		case *Array:
 			subSlice, err := dCol.scan(targetMap.Type().Elem(), row)
@@ -332,8 +332,8 @@ func (col *Tuple) scanStruct(targetStruct reflect.Value, row int) error {
 				}
 				sField.Set(newMap)
 			case reflect.Interface:
-				// catches []interface{} -Note this swallows custom interfaces to which maps couldn't conform
-				newMap := reflect.ValueOf(make(map[string]interface{}))
+				// catches []any -Note this swallows custom interfaces to which maps couldn't conform
+				newMap := reflect.ValueOf(make(map[string]any))
 				if err := dCol.scanMap(newMap, row); err != nil {
 					return err
 				}
@@ -341,7 +341,7 @@ func (col *Tuple) scanStruct(targetStruct reflect.Value, row int) error {
 			default:
 				return &Error{
 					ColumnType: fmt.Sprint(sField.Kind()),
-					Err:        fmt.Errorf("column %s - needs a map/struct/slice or interface{}", col.Name()),
+					Err:        fmt.Errorf("column %s - needs a map/struct/slice or any", col.Name()),
 				}
 			}
 		case *Nested:
@@ -436,7 +436,7 @@ func (col *Tuple) scan(targetType reflect.Type, row int) (reflect.Value, error) 
 		}
 		return rSlice, nil
 	case reflect.Interface:
-		// catches interface{} -Note this swallows custom interfaces to which maps couldn't conform
+		// catches any -Note this swallows custom interfaces to which maps couldn't conform
 		if !col.isNamed {
 			return reflect.Value{}, &ColumnConverterError{
 				Op:   "ScanRow",
@@ -445,7 +445,7 @@ func (col *Tuple) scan(targetType reflect.Type, row int) (reflect.Value, error) 
 				Hint: "cannot use interface for unnamed tuples, use slice",
 			}
 		}
-		rMap := reflect.ValueOf(make(map[string]interface{}))
+		rMap := reflect.ValueOf(make(map[string]any))
 		if err := col.scanMap(rMap, row); err != nil {
 			return reflect.Value{}, err
 		}
@@ -453,11 +453,11 @@ func (col *Tuple) scan(targetType reflect.Type, row int) (reflect.Value, error) 
 	}
 	return reflect.Value{}, &Error{
 		ColumnType: fmt.Sprint(targetType.Kind()),
-		Err:        fmt.Errorf("column %s - needs a map/struct/slice or interface{}", col.Name()),
+		Err:        fmt.Errorf("column %s - needs a map/struct/slice or any", col.Name()),
 	}
 }
 
-func (col *Tuple) ScanRow(dest interface{}, row int) error {
+func (col *Tuple) ScanRow(dest any, row int) error {
 	value := reflect.Indirect(reflect.ValueOf(dest))
 	tuple, err := col.scan(value.Type(), row)
 	if err != nil {
@@ -467,7 +467,7 @@ func (col *Tuple) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *Tuple) Append(v interface{}) (nulls []uint8, err error) {
+func (col *Tuple) Append(v any) (nulls []uint8, err error) {
 	value := reflect.ValueOf(v)
 	if value.Kind() == reflect.Slice {
 		for i := 0; i < value.Len(); i++ {
@@ -484,8 +484,8 @@ func (col *Tuple) Append(v interface{}) (nulls []uint8, err error) {
 	}
 }
 
-func (col *Tuple) AppendRow(v interface{}) error {
-	// allows support of tuples where map or slice is typed and NOT interface{}. Will fail if tuple isn't consistent
+func (col *Tuple) AppendRow(v any) error {
+	// allows support of tuples where map or slice is typed and NOT any. Will fail if tuple isn't consistent
 	value := reflect.ValueOf(v)
 	if value.Kind() == reflect.Pointer {
 		value = value.Elem()

--- a/lib/column/uuid.go
+++ b/lib/column/uuid.go
@@ -51,7 +51,7 @@ func (col *UUID) Rows() int {
 	return col.col.Rows()
 }
 
-func (col *UUID) Row(i int, ptr bool) interface{} {
+func (col *UUID) Row(i int, ptr bool) any {
 	value := col.row(i)
 	if ptr {
 		return &value
@@ -59,7 +59,7 @@ func (col *UUID) Row(i int, ptr bool) interface{} {
 	return value
 }
 
-func (col *UUID) ScanRow(dest interface{}, row int) error {
+func (col *UUID) ScanRow(dest any, row int) error {
 	switch d := dest.(type) {
 	case *string:
 		*d = col.row(row).String()
@@ -85,7 +85,7 @@ func (col *UUID) ScanRow(dest interface{}, row int) error {
 	return nil
 }
 
-func (col *UUID) Append(v interface{}) (nulls []uint8, err error) {
+func (col *UUID) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []string:
 		nulls = make([]uint8, len(v))
@@ -139,7 +139,7 @@ func (col *UUID) Append(v interface{}) (nulls []uint8, err error) {
 	return
 }
 
-func (col *UUID) AppendRow(v interface{}) error {
+func (col *UUID) AppendRow(v any) error {
 	switch v := v.(type) {
 	case string:
 		u, err := uuid.Parse(v)

--- a/lib/driver/driver.go
+++ b/lib/driver/driver.go
@@ -30,7 +30,7 @@ type ServerVersion = proto.ServerHandshake
 type (
 	NamedValue struct {
 		Name  string
-		Value interface{}
+		Value any
 	}
 
 	NamedDateValue struct {
@@ -51,11 +51,11 @@ type (
 	Conn interface {
 		Contributors() []string
 		ServerVersion() (*ServerVersion, error)
-		Select(ctx context.Context, dest interface{}, query string, args ...interface{}) error
-		Query(ctx context.Context, query string, args ...interface{}) (Rows, error)
-		QueryRow(ctx context.Context, query string, args ...interface{}) Row
+		Select(ctx context.Context, dest any, query string, args ...any) error
+		Query(ctx context.Context, query string, args ...any) (Rows, error)
+		QueryRow(ctx context.Context, query string, args ...any) Row
 		PrepareBatch(ctx context.Context, query string) (Batch, error)
-		Exec(ctx context.Context, query string, args ...interface{}) error
+		Exec(ctx context.Context, query string, args ...any) error
 		AsyncInsert(ctx context.Context, query string, wait bool) error
 		Ping(context.Context) error
 		Stats() Stats
@@ -63,31 +63,31 @@ type (
 	}
 	Row interface {
 		Err() error
-		Scan(dest ...interface{}) error
-		ScanStruct(dest interface{}) error
+		Scan(dest ...any) error
+		ScanStruct(dest any) error
 	}
 	Rows interface {
 		Next() bool
-		Scan(dest ...interface{}) error
-		ScanStruct(dest interface{}) error
+		Scan(dest ...any) error
+		ScanStruct(dest any) error
 		ColumnTypes() []ColumnType
-		Totals(dest ...interface{}) error
+		Totals(dest ...any) error
 		Columns() []string
 		Close() error
 		Err() error
 	}
 	Batch interface {
 		Abort() error
-		Append(v ...interface{}) error
-		AppendStruct(v interface{}) error
+		Append(v ...any) error
+		AppendStruct(v any) error
 		Column(int) BatchColumn
 		Flush() error
 		Send() error
 		IsSent() bool
 	}
 	BatchColumn interface {
-		Append(interface{}) error
-		AppendRow(interface{}) error
+		Append(any) error
+		AppendRow(any) error
 	}
 	ColumnType interface {
 		Name() string

--- a/lib/proto/block.go
+++ b/lib/proto/block.go
@@ -50,7 +50,7 @@ func (b *Block) AddColumn(name string, ct column.Type) error {
 	return nil
 }
 
-func (b *Block) Append(v ...interface{}) (err error) {
+func (b *Block) Append(v ...any) (err error) {
 	columns := b.Columns
 	if len(columns) != len(v) {
 		return &BlockError{

--- a/lib/proto/query.go
+++ b/lib/proto/query.go
@@ -143,7 +143,7 @@ type Settings []Setting
 
 type Setting struct {
 	Key   string
-	Value interface{}
+	Value any
 }
 
 func (s Settings) Encode(buffer *chproto.Buffer, revision uint64) error {

--- a/query_parameters.go
+++ b/query_parameters.go
@@ -30,14 +30,14 @@ var (
 	hasQueryParamsRe = regexp.MustCompile("{.+:.+}")
 )
 
-func bindQueryOrAppendParameters(paramsProtocolSupport bool, options *QueryOptions, query string, timezone *time.Location, args ...interface{}) (string, error) {
+func bindQueryOrAppendParameters(paramsProtocolSupport bool, options *QueryOptions, query string, timezone *time.Location, args ...any) (string, error) {
 	// prefer native query parameters over legacy bind if query parameters provided explicit
 	if len(options.parameters) > 0 {
 		return query, nil
 	}
 
 	// validate if query contains a {<name>:<data type>} syntax, so it's intentional use of query parameters
-	// parameter values will be loaded from `args ...interface{}` for compatibility
+	// parameter values will be loaded from `args ...any` for compatibility
 	if paramsProtocolSupport &&
 		len(args) > 0 &&
 		hasQueryParamsRe.MatchString(query) {

--- a/scan.go
+++ b/scan.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
-func (ch *clickhouse) Select(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+func (ch *clickhouse) Select(ctx context.Context, dest any, query string, args ...any) error {
 	value := reflect.ValueOf(dest)
 	if value.Kind() != reflect.Ptr {
 		return &OpError{
@@ -70,7 +70,7 @@ func (ch *clickhouse) Select(ctx context.Context, dest interface{}, query string
 	return rows.Err()
 }
 
-func scan(block *proto.Block, row int, dest ...interface{}) error {
+func scan(block *proto.Block, row int, dest ...any) error {
 	columns := block.Columns
 	if len(columns) != len(dest) {
 		return &OpError{

--- a/struct_map.go
+++ b/struct_map.go
@@ -27,7 +27,7 @@ type structMap struct {
 	cache sync.Map
 }
 
-func (m *structMap) Map(op string, columns []string, s interface{}, ptr bool) ([]interface{}, error) {
+func (m *structMap) Map(op string, columns []string, s any, ptr bool) ([]any, error) {
 	v := reflect.ValueOf(s)
 	if v.Kind() != reflect.Ptr {
 		return nil, &OpError{
@@ -54,7 +54,7 @@ func (m *structMap) Map(op string, columns []string, s interface{}, ptr bool) ([
 
 	var (
 		index  map[string][]int
-		values = make([]interface{}, 0, len(columns))
+		values = make([]any, 0, len(columns))
 	)
 
 	switch idx, found := m.cache.Load(t); {

--- a/tests/array_test.go
+++ b/tests/array_test.go
@@ -138,7 +138,7 @@ func TestInterfaceArray(t *testing.T) {
 	require.NoError(t, err)
 	for rows.Next() {
 		var (
-			col1 interface{}
+			col1 any
 		)
 		require.NoError(t, rows.Scan(&col1))
 		assert.ObjectsAreEqual(col1Data, col1)

--- a/tests/client_info_test.go
+++ b/tests/client_info_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package tests
 
 import (

--- a/tests/compression_test.go
+++ b/tests/compression_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package tests
 
 import (

--- a/tests/float_test.go
+++ b/tests/float_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package tests
 
 import (

--- a/tests/flush_test.go
+++ b/tests/flush_test.go
@@ -84,7 +84,7 @@ func insertWithFlush(t *testing.T, conn driver.Conn, flush bool) {
 			uuid.New(),
 			map[string]uint64{"key": uint64(i)}, // Map(String, UInt64)
 			[]string{RandAsciiString(1), RandAsciiString(1), RandAsciiString(1), RandAsciiString(1), RandAsciiString(1), RandAsciiString(1)}, // Array(String)
-			[]interface{}{ // Tuple(String, UInt64, Array(Map(String, UInt64)))
+			[]any{ // Tuple(String, UInt64, Array(Map(String, UInt64)))
 				RandAsciiString(10), uint64(i), []map[string]uint64{
 					{"key": uint64(i)},
 					{"key": uint64(i + 1)},

--- a/tests/insert_bind_test.go
+++ b/tests/insert_bind_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package tests
 
 import (

--- a/tests/int64_test.go
+++ b/tests/int64_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package tests
 
 import (

--- a/tests/issues/164_test.go
+++ b/tests/issues/164_test.go
@@ -49,7 +49,7 @@ func TestIssue164(t *testing.T) {
 	require.NoError(t, err)
 	batch, err := scope.Prepare("INSERT INTO issue_164")
 	require.NoError(t, err)
-	stmtParams := make([]interface{}, 0)
+	stmtParams := make([]any, 0)
 	stmtParams = append(stmtParams, sql.NamedArg{Name: "id", Value: int32(10)})
 	stmtParams = append(stmtParams, sql.NamedArg{Name: "anything", Value: nil})
 	_, err = batch.ExecContext(context.Background(), stmtParams...)

--- a/tests/issues/406_test.go
+++ b/tests/issues/406_test.go
@@ -52,16 +52,16 @@ func TestIssue406(t *testing.T) {
 	batch, err := conn.PrepareBatch(ctx, "INSERT INTO issue_406")
 	require.NoError(t, err)
 	require.NoError(t, batch.Append(
-		[]interface{}{
+		[]any{
 			[]int32{1, 2, 3, 4, 5},
 			[]int32{5, 1, 2, 3, 4},
 		},
 	))
 	require.NoError(t, batch.Send())
-	var col1 []interface{}
+	var col1 []any
 	require.NoError(t,
 		conn.QueryRow(ctx, "SELECT * FROM issue_406").Scan(&col1))
-	assert.Equal(t, []interface{}{
+	assert.Equal(t, []any{
 		[]int32{1, 2, 3, 4, 5},
 		[]int32{5, 1, 2, 3, 4},
 	}, col1)

--- a/tests/issues/470/main.go
+++ b/tests/issues/470/main.go
@@ -32,7 +32,7 @@ type DatabaseFrame struct {
 	ColumnNames []string
 	rows        *sql.Rows
 	columnTypes []*sql.ColumnType
-	vars        []interface{}
+	vars        []any
 }
 
 func NewDatabaseFrame(name string, rows *sql.Rows) (DatabaseFrame, error) {
@@ -43,7 +43,7 @@ func NewDatabaseFrame(name string, rows *sql.Rows) (DatabaseFrame, error) {
 	}
 	databaseFrame.columnTypes = columnTypes
 	databaseFrame.name = name
-	vars := make([]interface{}, len(columnTypes), len(columnTypes))
+	vars := make([]any, len(columnTypes), len(columnTypes))
 	columnNames := make([]string, len(columnTypes), len(columnTypes))
 	for i := range columnTypes {
 		value := reflect.Zero(columnTypes[i].ScanType()).Interface()
@@ -56,8 +56,8 @@ func NewDatabaseFrame(name string, rows *sql.Rows) (DatabaseFrame, error) {
 	return databaseFrame, nil
 }
 
-func (f DatabaseFrame) Next() ([]interface{}, bool, error) {
-	values := make([]interface{}, len(f.columnTypes), len(f.columnTypes))
+func (f DatabaseFrame) Next() ([]any, bool, error) {
+	values := make([]any, len(f.columnTypes), len(f.columnTypes))
 	for f.rows.Next() {
 		if err := f.rows.Scan(f.vars...); err != nil {
 			return nil, false, err

--- a/tests/issues/476/main.go
+++ b/tests/issues/476/main.go
@@ -49,7 +49,7 @@ func main() {
 		log.Printf("Can't get column types")
 		log.Fatal(err)
 	}
-	vars := make([]interface{}, len(columnTypes), len(columnTypes))
+	vars := make([]any, len(columnTypes), len(columnTypes))
 	for i := range columnTypes {
 		value := reflect.Zero(columnTypes[i].ScanType()).Interface()
 		vars[i] = &value

--- a/tests/issues/483_test.go
+++ b/tests/issues/483_test.go
@@ -62,9 +62,9 @@ func TestIssue483(t *testing.T) {
 	require.NoError(t, batch.Send())
 	var (
 		col1 uint8
-		col2 []uint8           // steps.duration
-		col3 [][][]interface{} // steps.result
-		col4 []string          //  steps.keyword
+		col2 []uint8   // steps.duration
+		col3 [][][]any // steps.result
+		col4 []string  //  steps.keyword
 		col5 uint8
 	)
 	require.NoError(t, conn.QueryRow(ctx, `SELECT * FROM issue_483`).Scan(&col1, &col2, &col3, &col4, &col5))

--- a/tests/issues/485/main.go
+++ b/tests/issues/485/main.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package main
 
 import (

--- a/tests/issues/504_test.go
+++ b/tests/issues/504_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/504_test.go
+++ b/tests/issues/504_test.go
@@ -57,8 +57,8 @@ func TestIssue504(t *testing.T) {
 		WHERE (Col1, Col2) IN (@GS)
 		`
 	err = conn.Select(ctx, &result, query, clickhouse.Named("GS", []clickhouse.GroupSet{
-		{Value: []interface{}{"A", 2}},
-		{Value: []interface{}{"A", 4}},
+		{Value: []any{"A", 2}},
+		{Value: []any{"A", 4}},
 	}))
 	require.NoError(t, err)
 	assert.Equal(t, []struct {

--- a/tests/issues/506_test.go
+++ b/tests/issues/506_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/546_test.go
+++ b/tests/issues/546_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/548_test.go
+++ b/tests/issues/548_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/570_test.go
+++ b/tests/issues/570_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/578_test.go
+++ b/tests/issues/578_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/584_test.go
+++ b/tests/issues/584_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/592_test.go
+++ b/tests/issues/592_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/615_test.go
+++ b/tests/issues/615_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/647_test.go
+++ b/tests/issues/647_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/648_test.go
+++ b/tests/issues/648_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/655_test.go
+++ b/tests/issues/655_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/692_test.go
+++ b/tests/issues/692_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/692_test.go
+++ b/tests/issues/692_test.go
@@ -83,7 +83,7 @@ func TestIssue692(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, scope.Commit())
 	var (
-		col1 interface{}
+		col1 any
 		col2 map[string]uint64
 		col3 map[string]uint64
 		col4 []map[string]string

--- a/tests/issues/693_test.go
+++ b/tests/issues/693_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/741_test.go
+++ b/tests/issues/741_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/741_test.go
+++ b/tests/issues/741_test.go
@@ -90,8 +90,8 @@ func TestIssue741SingleColumn(t *testing.T) {
 	}
 }
 
-func generateRandomInsert(tableName string) (string, string, []interface{}) {
-	columns := map[string]interface{}{
+func generateRandomInsert(tableName string) (string, string, []any) {
+	columns := map[string]any{
 		"Col1 String":       "a",
 		"Col2 Int64":        int64(1),
 		"Col3 Int32":        int32(2),
@@ -123,7 +123,7 @@ func generateRandomInsert(tableName string) (string, string, []interface{}) {
 		placeholders[i] = "?"
 	}
 	insertStatement := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", tableName, strings.Join(names, ", "), strings.Join(placeholders, ", "))
-	values := make([]interface{}, len(colNames))
+	values := make([]any, len(colNames))
 	for i, colName := range colNames {
 		values[i] = columns[colName]
 	}

--- a/tests/issues/751_test.go
+++ b/tests/issues/751_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/759_test.go
+++ b/tests/issues/759_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/762_test.go
+++ b/tests/issues/762_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/762_test.go
+++ b/tests/issues/762_test.go
@@ -37,10 +37,10 @@ func Test762(t *testing.T) {
 	require.NoError(t, err)
 	for rows.Next() {
 		var (
-			n []interface{}
+			n []any
 		)
 		require.NoError(t, rows.Scan(&n))
-		require.Equal(t, []interface{}{(*interface{})(nil), (*interface{})(nil)}, n)
+		require.Equal(t, []any{(*any)(nil), (*any)(nil)}, n)
 	}
 
 }
@@ -53,10 +53,10 @@ func Test762Std(t *testing.T) {
 	require.NoError(t, err)
 	for rows.Next() {
 		var (
-			n interface{}
+			n any
 		)
 		require.NoError(t, rows.Scan(&n))
-		expected := []interface{}{(*interface{})(nil)}
+		expected := []any{(*any)(nil)}
 		require.Equal(t, &expected, n)
 	}
 }

--- a/tests/issues/777_test.go
+++ b/tests/issues/777_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/783_test.go
+++ b/tests/issues/783_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/783_test.go
+++ b/tests/issues/783_test.go
@@ -38,9 +38,9 @@ func Test783(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, err)
 	row := conn.QueryRow(ctx, "SELECT groupArray(('a', ['time1', 'time2'])) as val")
-	var x [][]interface{}
+	var x [][]any
 	require.NoError(t, row.Scan(&x))
-	require.Equal(t, [][]interface{}{{"a", []string{"time1", "time2"}}}, x)
+	require.Equal(t, [][]any{{"a", []string{"time1", "time2"}}}, x)
 }
 
 func TestStd783(t *testing.T) {
@@ -49,7 +49,7 @@ func TestStd783(t *testing.T) {
 	conn, err := clickhouse_std_tests.GetDSNConnection("issues", clickhouse.Native, useSSL, nil)
 	require.NoError(t, err)
 	row := conn.QueryRow("SELECT groupArray(('a', ['time1', 'time2'])) as val")
-	var x [][]interface{}
+	var x [][]any
 	require.NoError(t, row.Scan(&x))
-	require.Equal(t, [][]interface{}{{"a", []string{"time1", "time2"}}}, x)
+	require.Equal(t, [][]any{{"a", []string{"time1", "time2"}}}, x)
 }

--- a/tests/issues/798_test.go
+++ b/tests/issues/798_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/798_test.go
+++ b/tests/issues/798_test.go
@@ -71,7 +71,7 @@ func Test798(t *testing.T) {
 	require.ErrorIs(t, batch.Append(true, false, []bool{true, false, true}), clickhouse.ErrBatchAlreadySent)
 }
 
-func writeRows(prepareSQL string, rows [][]interface{}, conn clickhouse.Conn) (err error) {
+func writeRows(prepareSQL string, rows [][]any, conn clickhouse.Conn) (err error) {
 	batch, err := conn.PrepareBatch(context.Background(), prepareSQL)
 	if err != nil {
 		return err
@@ -120,7 +120,7 @@ func Test798Concurrent(t *testing.T) {
 					wg.Done()
 					break
 				}
-				writeRows("INSERT INTO test_issue_798", [][]interface{}{{true, false}, {false, true}}, conn)
+				writeRows("INSERT INTO test_issue_798", [][]any{{true, false}, {false, true}}, conn)
 			}
 		}()
 	}

--- a/tests/issues/812_test.go
+++ b/tests/issues/812_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/812_test.go
+++ b/tests/issues/812_test.go
@@ -51,12 +51,12 @@ func Test812(t *testing.T) {
 	require.NoError(t, conn.Exec(ctx, ddl))
 	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_812")
 	require.NoError(t, batch.Append(
-		map[string]interface{}{"name": "Clicky McClickHouse Jnr", "age": uint8(20)},
-		[]interface{}{"Baby Clicky McClickHouse", uint8(1)},
+		map[string]any{"name": "Clicky McClickHouse Jnr", "age": uint8(20)},
+		[]any{"Baby Clicky McClickHouse", uint8(1)},
 		map[string]string{"name": "Geoff", "id": "12123"},
 		// Col4
-		[]interface{}{
-			map[string]interface{}{"name": "Clicky McClickHouse Jnr", "age": uint8(20)},
+		[]any{
+			map[string]any{"name": "Clicky McClickHouse Jnr", "age": uint8(20)},
 		},
 	))
 	require.NoError(t, batch.Send())

--- a/tests/issues/813_test.go
+++ b/tests/issues/813_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/813_test.go
+++ b/tests/issues/813_test.go
@@ -45,7 +45,7 @@ func Test813(t *testing.T) {
 	_, err = conn.Exec(ddl)
 	require.NoError(t, err)
 
-	valueArgs := []interface{}{
+	valueArgs := []any{
 		int64(14),
 		clickhouse.ArraySet{map[string]string{"array1_key1": "array1_value2", "array1_key2": "array1_value2"}},
 	}

--- a/tests/issues/816_test.go
+++ b/tests/issues/816_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/816_test.go
+++ b/tests/issues/816_test.go
@@ -47,9 +47,9 @@ func Test816(t *testing.T) {
 	batch, err := scope.Prepare("INSERT INTO test_816")
 	require.NoError(t, err)
 	var (
-		col1Data = map[string]interface{}{
+		col1Data = map[string]any{
 			"count": nil,
-			"products": []map[string]interface{}{
+			"products": []map[string]any{
 				{
 					"price": nil,
 					"qty":   nil,
@@ -65,7 +65,7 @@ func Test816(t *testing.T) {
 	_, err = batch.Exec(col1Data)
 	require.NoError(t, err)
 	require.NoError(t, scope.Commit())
-	var col1 interface{}
+	var col1 any
 	require.NoError(t, conn.QueryRow("SELECT Col1 FROM test_816").Scan(&col1))
 	assert.Equal(t, clickhouse_std_tests.ToJson(col1Data), clickhouse_std_tests.ToJson(col1))
 }

--- a/tests/issues/828_test.go
+++ b/tests/issues/828_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/870_test.go
+++ b/tests/issues/870_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/955_test.go
+++ b/tests/issues/955_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/issues/main_test.go
+++ b/tests/issues/main_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package issues
 
 import (

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package tests
 
 import (

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -94,7 +94,7 @@ func prepareBatch(t *testing.T, conn driver.Conn, ctx context.Context) driver.Ba
 	return batch
 }
 
-func toJson(obj interface{}) string {
+func toJson(obj any) string {
 	bytes, err := json.Marshal(obj)
 	if err != nil {
 		return "unable to marshal"
@@ -219,7 +219,7 @@ func TestJSONUUID(t *testing.T) {
 	require.NoError(t, batch.Append(row1))
 	require.NoError(t, batch.Append(row2))
 	require.NoError(t, batch.Send())
-	event := make(map[string]interface{})
+	event := make(map[string]any)
 	i := 0
 	rows, err := conn.Query(ctx, "SELECT * FROM json_test ORDER BY event.Row ASC")
 	defer rows.Close()
@@ -298,7 +298,7 @@ func TestMultipleJSONRows(t *testing.T) {
 
 func TestJSONStructWithInterface(t *testing.T) {
 	type Login struct {
-		Username interface{}
+		Username any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
@@ -314,7 +314,7 @@ func TestJSONStructWithInterface(t *testing.T) {
 
 func TestJSONStructWithStructInterface(t *testing.T) {
 	type Login struct {
-		Username interface{}
+		Username any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
@@ -330,26 +330,26 @@ func TestJSONStructWithStructInterface(t *testing.T) {
 
 func TestJSONSlicedInterfaceInconsistent(t *testing.T) {
 	type Login struct {
-		Random []interface{}
+		Random []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	event := Login{Random: []interface{}{"gingerwizard", int64(2222341)}}
+	event := Login{Random: []any{"gingerwizard", int64(2222341)}}
 	// Inconsistent slices not supported
 	require.Error(t, batch.Append(event))
 }
 
 func TestJSONSlicedInterface(t *testing.T) {
 	type Login struct {
-		Random []interface{}
+		Random []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	login := Login{Random: []interface{}{"gingerwizard", "geoff"}}
+	login := Login{Random: []any{"gingerwizard", "geoff"}}
 	require.NoError(t, batch.Append(login))
 	require.NoError(t, batch.Send())
 	var event Login
@@ -359,13 +359,13 @@ func TestJSONSlicedInterface(t *testing.T) {
 
 func TestJSONSlicedNilInterfaceStart(t *testing.T) {
 	type Login struct {
-		Random []interface{}
+		Random []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	login := Login{Random: []interface{}{nil, "gingerwizard", nil, "geoff"}}
+	login := Login{Random: []any{nil, "gingerwizard", nil, "geoff"}}
 	require.NoError(t, batch.Append(login))
 	require.NoError(t, batch.Send())
 	var event Login
@@ -375,14 +375,14 @@ func TestJSONSlicedNilInterfaceStart(t *testing.T) {
 
 func TestJSONSlicedAllNils(t *testing.T) {
 	type Login struct {
-		Random  []interface{}
+		Random  []any
 		SomeStr string
 	}
 	conn, _ := setupTest(t)
 	// defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	login := Login{Random: []interface{}{nil, nil, nil}, SomeStr: "Astring"}
+	login := Login{Random: []any{nil, nil, nil}, SomeStr: "Astring"}
 	require.NoError(t, batch.Append(login))
 	require.NoError(t, batch.Send())
 	var event Login
@@ -392,13 +392,13 @@ func TestJSONSlicedAllNils(t *testing.T) {
 
 func TestJSONSlicedInterfaceFloat(t *testing.T) {
 	type Login struct {
-		Random []interface{}
+		Random []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	login := Login{Random: []interface{}{1.1, 1.4}}
+	login := Login{Random: []any{1.1, 1.4}}
 	require.NoError(t, batch.Append(login))
 	require.NoError(t, batch.Send())
 	var event Login
@@ -408,14 +408,14 @@ func TestJSONSlicedInterfaceFloat(t *testing.T) {
 
 func TestJSONSlicedInterfaceInt(t *testing.T) {
 	type Login struct {
-		Random []interface{}
+		Random []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
 	//need int64
-	login := Login{Random: []interface{}{int64(1), int64(2)}}
+	login := Login{Random: []any{int64(1), int64(2)}}
 	require.NoError(t, batch.Append(login))
 	require.NoError(t, batch.Send())
 	var event Login
@@ -425,44 +425,44 @@ func TestJSONSlicedInterfaceInt(t *testing.T) {
 
 func TestJSONSlicedInterfaceMixed(t *testing.T) {
 	type Login struct {
-		Random []interface{}
+		Random []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	event := Login{Random: []interface{}{1, 2.3}}
+	event := Login{Random: []any{1, 2.3}}
 	// This will error - currently not permitted as float can't be converted to int - first value determines type
 	require.Error(t, batch.Append(event))
 }
 
 func TestJSONSlicedInterfaceMixedConvertable(t *testing.T) {
 	type Login struct {
-		Random []interface{}
+		Random []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
 	// this will not work - numbers currently not coerced to strings
-	event := Login{Random: []interface{}{"2.4", 2, 5.6}}
+	event := Login{Random: []any{"2.4", 2, 5.6}}
 	require.Error(t, batch.Append(event))
 }
 
 func TestJSONSlicedInterfaceMap(t *testing.T) {
 	type Login struct {
-		Values []interface{}
+		Values []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
 	event := Login{
-		Values: []interface{}{
-			map[string][]interface{}{
+		Values: []any{
+			map[string][]any{
 				"Random": {2.1, 2, 5.6},
 			},
-			map[string][]interface{}{
+			map[string][]any{
 				"Random": {2, 2},
 			},
 		},
@@ -472,15 +472,15 @@ func TestJSONSlicedInterfaceMap(t *testing.T) {
 
 func TestJSONSlicedInterfaceInconsistentMap(t *testing.T) {
 	type Login struct {
-		Values []interface{}
+		Values []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
 	event := Login{
-		Values: []interface{}{
-			map[string][]interface{}{
+		Values: []any{
+			map[string][]any{
 				"Random": {"2.4", 2, 5.6},
 			},
 			map[string][]int64{
@@ -493,20 +493,20 @@ func TestJSONSlicedInterfaceInconsistentMap(t *testing.T) {
 
 func TestJSONSlicedInterfaceConsistentMapStruct(t *testing.T) {
 	type Login struct {
-		Values []interface{}
+		Values []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
 	logins := Login{
-		Values: []interface{}{
+		Values: []any{
 			Login{
-				Values: []interface{}{
+				Values: []any{
 					"2.4", "2", "5.6",
 				},
 			},
-			map[string][]interface{}{
+			map[string][]any{
 				"Values": {"3", "1"},
 			},
 		},
@@ -514,27 +514,27 @@ func TestJSONSlicedInterfaceConsistentMapStruct(t *testing.T) {
 	// This will error - can't mix objects
 	require.NoError(t, batch.Append(logins))
 	require.NoError(t, batch.Send())
-	event := make(map[string]interface{})
+	event := make(map[string]any)
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(event), toJson(logins))
 }
 
 func TestJSONSlicedInterfaceInConsistentMapStruct(t *testing.T) {
 	type Login struct {
-		Values []interface{}
+		Values []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
 	event := Login{
-		Values: []interface{}{
+		Values: []any{
 			Login{
-				Values: []interface{}{
+				Values: []any{
 					2.4, 2, 5.6,
 				},
 			},
-			map[string][]interface{}{
+			map[string][]any{
 				"Values": {3, int8(1)},
 			},
 		},
@@ -544,20 +544,20 @@ func TestJSONSlicedInterfaceInConsistentMapStruct(t *testing.T) {
 
 func TestJSONSlicedInterfaceCompatibleObjects(t *testing.T) {
 	type Login struct {
-		Values []interface{}
+		Values []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
 	logins := Login{
-		Values: []interface{}{
+		Values: []any{
 			Login{
-				Values: []interface{}{
+				Values: []any{
 					2.4, 2.1, 5.6,
 				},
 			},
-			map[string][]interface{}{
+			map[string][]any{
 				"Random": {int64(3), int64(65)},
 			},
 		},
@@ -565,29 +565,29 @@ func TestJSONSlicedInterfaceCompatibleObjects(t *testing.T) {
 	// types dont differ in dimensions
 	require.NoError(t, batch.Append(logins))
 	require.NoError(t, batch.Send())
-	event := make(map[string]interface{})
+	event := make(map[string]any)
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, `{"Values":[{"Random":[],"Values":[2.4,2.1,5.6]},{"Random":[3,65],"Values":[]}]}`, toJson(event))
 }
 
 func TestJSONSlicedInterfaceInConsistentObjects(t *testing.T) {
 	type Login struct {
-		Values []interface{}
+		Values []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
 	logins := Login{
-		Values: []interface{}{
+		Values: []any{
 			Login{
-				Values: []interface{}{
+				Values: []any{
 					2.4, 2.1, 5.6,
 				},
 			},
-			map[string][]interface{}{
+			map[string][]any{
 				"Values": {
-					map[string]interface{}{
+					map[string]any{
 						"c": "d",
 					},
 				},
@@ -599,17 +599,17 @@ func TestJSONSlicedInterfaceInConsistentObjects(t *testing.T) {
 
 func TestJSONSlicedInterfaceInConsistentTypes(t *testing.T) {
 	type Login struct {
-		Values []interface{}
+		Values []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
 	logins := Login{
-		Values: []interface{}{
+		Values: []any{
 			Login{
-				Values: []interface{}{
-					2.4, map[string]interface{}{
+				Values: []any{
+					2.4, map[string]any{
 						"random": "will fail",
 					},
 				},
@@ -621,20 +621,20 @@ func TestJSONSlicedInterfaceInConsistentTypes(t *testing.T) {
 
 func TestJSONSlicedInterfaceStruct(t *testing.T) {
 	type Login struct {
-		Random []interface{}
+		Random []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
 	event := Login{
-		Random: []interface{}{
+		Random: []any{
 			Login{
-				Random: []interface{}{
+				Random: []any{
 					"2.4", 2, 5.6,
 				},
 			}, Login{
-				Random: []interface{}{
+				Random: []any{
 					"2.4", 1,
 				},
 			},
@@ -645,21 +645,21 @@ func TestJSONSlicedInterfaceStruct(t *testing.T) {
 
 func TestJSONSlicedInterfaceSlice(t *testing.T) {
 	type Login struct {
-		Random []interface{}
+		Random []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
 	logins := Login{
-		Random: []interface{}{
-			[]interface{}{"dale", "geoff"},
-			[]interface{}{"mike", "alexy"},
+		Random: []any{
+			[]any{"dale", "geoff"},
+			[]any{"mike", "alexy"},
 		},
 	}
 	require.NoError(t, batch.Append(logins))
 	require.NoError(t, batch.Send())
-	event := make(map[string]interface{})
+	event := make(map[string]any)
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(event), toJson(logins))
 }
@@ -749,13 +749,13 @@ func TestJSONUnTypedMapInsert(t *testing.T) {
 	type Login struct {
 		IP      net.IP `json:"ip_address"`
 		Row     uint8
-		Details map[string]interface{}
+		Details map[string]any
 	}
-	logins := make(map[string]interface{})
+	logins := make(map[string]any)
 	logins["monday"] = Login{
 		IP:  net.ParseIP("85.242.48.167"),
 		Row: 0,
-		Details: map[string]interface{}{
+		Details: map[string]any{
 			"src_port":  int64(232323),
 			"dest_port": int64(9000),
 		},
@@ -866,14 +866,14 @@ func TestJSONMapInconsistentMapWithInterface(t *testing.T) {
 	type Login struct {
 		IP      net.IP `json:"ip_address"`
 		Row     uint8
-		Details []map[string]interface{}
+		Details []map[string]any
 	}
-	logins := make(map[string]map[string]interface{})
-	logins["session"] = make(map[string]interface{})
+	logins := make(map[string]map[string]any)
+	logins["session"] = make(map[string]any)
 	logins["session"]["user"] = []Login{{
 		IP:  net.ParseIP("85.242.48.167"),
 		Row: 0,
-		Details: []map[string]interface{}{
+		Details: []map[string]any{
 			{
 				"src_port":  uint64(232323),
 				"dest_port": uint64(9000),
@@ -933,15 +933,15 @@ func TestJSONMapInconsistentComplexMap(t *testing.T) {
 	type Login struct {
 		IP      string
 		Row     uint8
-		Details []map[string]interface{}
+		Details []map[string]any
 	}
 	batch := prepareBatch(t, conn, ctx)
-	logins := map[string][]map[string]interface{}{
+	logins := map[string][]map[string]any{
 		"server": {
 			{
 				"a": "b",
 				"l": []string{"z", "x"},
-				"y": [][]map[string]interface{}{
+				"y": [][]map[string]any{
 					{
 						{
 							"a": "b",
@@ -969,12 +969,12 @@ func TestJSONMapInconsistentComplexMap(t *testing.T) {
 			},
 			{
 				"b": []string{"c", "d"},
-				"c": []map[string]interface{}{
+				"c": []map[string]any{
 					{
 						"g": Login{
 							IP:  "11.242.48.167",
 							Row: 4,
-							Details: []map[string]interface{}{
+							Details: []map[string]any{
 								{
 									"src_port":  uint64(132323),
 									"dest_port": uint64(20000),
@@ -988,7 +988,7 @@ func TestJSONMapInconsistentComplexMap(t *testing.T) {
 						},
 					},
 				},
-				"p": [][]map[string]interface{}{
+				"p": [][]map[string]any{
 					{
 						{
 							"c": "d",
@@ -1012,16 +1012,16 @@ func TestJSONMapInconsistentComplexMap(t *testing.T) {
 				},
 			},
 			{
-				"e": map[string]interface{}{
+				"e": map[string]any{
 					"f": "g",
-					"h": map[string]interface{}{
+					"h": map[string]any{
 						"i": "j",
 					},
 				},
 				"k": Login{
 					IP:  "85.242.48.167",
 					Row: 4,
-					Details: []map[string]interface{}{
+					Details: []map[string]any{
 						{
 							"src_port":  uint64(232323),
 							"dest_port": uint64(10000),
@@ -1041,7 +1041,7 @@ func TestJSONMapInconsistentComplexMap(t *testing.T) {
 				"g": Login{
 					IP:  "85.242.48.167",
 					Row: 4,
-					Details: []map[string]interface{}{
+					Details: []map[string]any{
 						{
 							"src_port":  uint64(232323),
 							"dest_port": uint64(9000),
@@ -1056,12 +1056,12 @@ func TestJSONMapInconsistentComplexMap(t *testing.T) {
 						},
 					},
 				},
-				"m": []map[string]interface{}{
+				"m": []map[string]any{
 					{
 						"g": Login{
 							IP:  "22.242.48.167",
 							Row: 4,
-							Details: []map[string]interface{}{
+							Details: []map[string]any{
 								{
 									"src_port":   uint64(132323),
 									"dest_port":  uint64(20000),
@@ -1080,7 +1080,7 @@ func TestJSONMapInconsistentComplexMap(t *testing.T) {
 	require.NoError(t, batch.Append(logins))
 	require.NoError(t, batch.Send())
 	// TODO: current issue with slices and slices at insert time
-	/*event := make(map[string]interface{})
+	/*event := make(map[string]any)
 	conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(event)
 	*/
 }
@@ -1180,7 +1180,7 @@ func TestJSONMapSimpleInconsistentRows(t *testing.T) {
 		Row uint8
 	}
 	batch := prepareBatch(t, conn, ctx)
-	row1 := map[string]map[string]interface{}{
+	row1 := map[string]map[string]any{
 		"i": {
 			"row": int64(0),
 		},
@@ -1197,7 +1197,7 @@ func TestJSONMapSimpleInconsistentRows(t *testing.T) {
 			},
 		},
 	}
-	row2 := map[string]map[string]interface{}{
+	row2 := map[string]map[string]any{
 		"i": {
 			"row": int64(1),
 		},
@@ -1231,7 +1231,7 @@ func TestJSONMapSimpleInconsistentRows(t *testing.T) {
 	require.NoError(t, batch.Append(row1))
 	require.NoError(t, batch.Append(row2))
 	require.NoError(t, batch.Send())
-	event := make(map[string]map[string]interface{})
+	event := make(map[string]map[string]any)
 	rows, err := conn.Query(ctx, "SELECT * FROM json_test ORDER BY event.i.row ASC")
 	defer rows.Close()
 	require.NoError(t, err)
@@ -1253,7 +1253,7 @@ func TestJSONMapInconsistentRowsOfSlices(t *testing.T) {
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	row1 := map[string][]map[string]interface{}{
+	row1 := map[string][]map[string]any{
 		"i": {
 			{
 				"row": int64(0),
@@ -1270,7 +1270,7 @@ func TestJSONMapInconsistentRowsOfSlices(t *testing.T) {
 			},
 		},
 	}
-	row2 := map[string][]map[string]interface{}{
+	row2 := map[string][]map[string]any{
 		"i": {
 			{
 				"row": int64(1),
@@ -1302,7 +1302,7 @@ func TestJSONMapInconsistentRowsOfSlices(t *testing.T) {
 	defer rows.Close()
 	require.NoError(t, err)
 	i := 0
-	event := make(map[string][]map[string]interface{})
+	event := make(map[string][]map[string]any)
 	for rows.Next() {
 		require.NoError(t, rows.Scan(&event))
 		if i == 0 {
@@ -1328,7 +1328,7 @@ func TestJSONInconsistentStruct(t *testing.T) {
 	type l2 struct {
 		E []l3
 		G []string
-		M interface{}
+		M any
 	}
 
 	type l1 struct {
@@ -1336,7 +1336,7 @@ func TestJSONInconsistentStruct(t *testing.T) {
 		C l2
 		A l3
 		E l3
-		F interface{}
+		F any
 	}
 
 	s1 := l1{
@@ -1390,7 +1390,7 @@ func TestJSONMapInconsistentRows(t *testing.T) {
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
 
-	row1 := map[string]map[string]interface{}{
+	row1 := map[string]map[string]any{
 		"i": {
 			"row": int8(0),
 		},
@@ -1420,7 +1420,7 @@ func TestJSONMapInconsistentRows(t *testing.T) {
 		},
 	}
 
-	row2 := map[string]map[string]interface{}{
+	row2 := map[string]map[string]any{
 		"i": {
 			"row": int8(1),
 		},
@@ -1445,7 +1445,7 @@ func TestJSONMapInconsistentRows(t *testing.T) {
 		},
 	}
 
-	row3 := map[string]map[string]interface{}{
+	row3 := map[string]map[string]any{
 		"i": {
 			"row": int8(2),
 		},
@@ -1459,7 +1459,7 @@ func TestJSONMapInconsistentRows(t *testing.T) {
 	defer rows.Close()
 	require.NoError(t, err)
 	i := 0
-	event := make(map[string]map[string]interface{})
+	event := make(map[string]map[string]any)
 	for rows.Next() {
 		require.NoError(t, rows.Scan(&event))
 		switch i {
@@ -1496,18 +1496,18 @@ func TestJSONMapSliceOfSlices(t *testing.T) {
 	assert.JSONEq(t, toJson(row1), toJson(event))
 
 	//read into a generic map
-	genEvent := make(map[string]interface{})
+	genEvent := make(map[string]any)
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&genEvent))
 	assert.JSONEq(t, toJson(row1), toJson(genEvent))
 
-	//read into a slice of interface{}
-	genSliceEvent := make(map[string][]interface{})
+	//read into a slice of any
+	genSliceEvent := make(map[string][]any)
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&genSliceEvent))
 	assert.JSONEq(t, toJson(row1), toJson(genSliceEvent))
 
 	///read into a struct
 	type UUIDSets struct {
-		Uuids [][]interface{} `json:"uuids"`
+		Uuids [][]any `json:"uuids"`
 	}
 	var sEvent UUIDSets
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&sEvent))
@@ -1515,7 +1515,7 @@ func TestJSONMapSliceOfSlices(t *testing.T) {
 
 	//read in interface struct
 	type UUIDIntSet struct {
-		Uuids interface{} `json:"uuids"`
+		Uuids any `json:"uuids"`
 	}
 	var siEvent UUIDIntSet
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&siEvent))
@@ -1523,7 +1523,7 @@ func TestJSONMapSliceOfSlices(t *testing.T) {
 	//read in interface[] struct
 
 	type UUIDArraySet struct {
-		Uuids []interface{} `json:"uuids"`
+		Uuids []any `json:"uuids"`
 	}
 	var arEvent UUIDArraySet
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&arEvent))
@@ -1562,18 +1562,18 @@ func TestJSONMapSliceOfSlicesWithStruct(t *testing.T) {
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(row1), toJson(event))
 
-	mEvent := make(map[string][][]map[string]interface{})
+	mEvent := make(map[string][][]map[string]any)
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&mEvent))
 	assert.JSONEq(t, toJson(row1), toJson(mEvent))
 
 }
 func TestJSONMapSliceOfSlicesWithMap(t *testing.T) {
-	//map[string][][]map[string]interface{}
+	//map[string][][]map[string]any
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	row1 := map[string][][]map[string]interface{}{
+	row1 := map[string][][]map[string]any{
 		"logins": {
 			{
 				{
@@ -1596,7 +1596,7 @@ func TestJSONMapSliceOfSlicesWithMap(t *testing.T) {
 	require.NoError(t, batch.Append(row1))
 	require.NoError(t, batch.Send())
 	//read into a typed map
-	event := make(map[string][][]map[string]interface{})
+	event := make(map[string][][]map[string]any)
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(row1), toJson(event))
 	type Login struct {
@@ -1609,7 +1609,7 @@ func TestJSONMapSliceOfSlicesWithMap(t *testing.T) {
 }
 
 func TestMapSliceOfInterface(t *testing.T) {
-	///query with map[string][]interface{} on map[string][]map[string][]string
+	///query with map[string][]any on map[string][]map[string][]string
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
@@ -1624,13 +1624,13 @@ func TestMapSliceOfInterface(t *testing.T) {
 	}
 	require.NoError(t, batch.Append(row1))
 	require.NoError(t, batch.Send())
-	event := make(map[string][]interface{})
-	// currently this fails cannot set []map[string][]string into []interface{} - maybe we can handle in future
+	event := make(map[string][]any)
+	// currently this fails cannot set []map[string][]string into []any - maybe we can handle in future
 	require.Panics(t, func() { conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event) })
 }
 
 func TestStructSliceOfInterface(t *testing.T) {
-	///query with map[string][]interface{} on map[string][]struct
+	///query with map[string][]any on map[string][]struct
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
@@ -1663,8 +1663,8 @@ func TestStructSliceOfInterface(t *testing.T) {
 	}
 	require.NoError(t, batch.Append(row1))
 	require.NoError(t, batch.Send())
-	event := make(map[string][]interface{})
-	// currently this fails cannot set []map[string][]string into []interface{} - maybe we can handle in future
+	event := make(map[string][]any)
+	// currently this fails cannot set []map[string][]string into []any - maybe we can handle in future
 	require.Panics(t, func() { conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event) })
 }
 
@@ -1674,13 +1674,13 @@ func TestStructSliceInInterface(t *testing.T) {
 	defer teardown(t)
 	ctx := context.Background()
 	type Junk struct {
-		Data interface{}
+		Data any
 	}
 	row1 := Junk{Data: []string{"some", "junk", "rows"}}
 	batch := prepareBatch(t, conn, ctx)
 	require.NoError(t, batch.Append(row1))
 	require.NoError(t, batch.Send())
-	event := make(map[string][]interface{})
+	event := make(map[string][]any)
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(row1), toJson(event))
 }
@@ -1692,14 +1692,14 @@ func TestInsertMarshaledJSON(t *testing.T) {
 	batch := prepareBatch(t, conn, ctx)
 	row1s := `{"a":{"d":"test"},"c":{"e":"test"},"i":{"row":0},"k":{"h":{"IP":"127.0.0.1","Row":0}}}`
 	row2s := `{"a":{"d":"test"},"d":{"e":"test"},"g":{"h":{"IP":"127.0.0.1","Row":0}},"i":{"row":1},"z":{"c":2.0}}`
-	row1 := make(map[string]interface{})
-	row2 := make(map[string]interface{})
+	row1 := make(map[string]any)
+	row2 := make(map[string]any)
 	require.NoError(t, json.Unmarshal([]byte(row1s), &row1))
 	require.NoError(t, json.Unmarshal([]byte(row2s), &row2))
 	require.NoError(t, batch.Append(row1))
 	require.NoError(t, batch.Append(row2))
 	require.NoError(t, batch.Send())
-	event := make(map[string]map[string]interface{})
+	event := make(map[string]map[string]any)
 	rows, err := conn.Query(ctx, "SELECT * FROM json_test ORDER BY event.i.row ASC")
 	require.NoError(t, err)
 	i := 0
@@ -1737,7 +1737,7 @@ func TestJSONEmbeddedStruct(t *testing.T) {
 	}
 	require.NoError(t, batch.Append(row1))
 	require.NoError(t, batch.Send())
-	event := make(map[string]interface{})
+	event := make(map[string]any)
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(row1), toJson(row1))
 
@@ -1939,28 +1939,28 @@ func TestJSONNilMapFields(t *testing.T) {
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	row1 := map[string]interface{}{
+	row1 := map[string]any{
 		"title": "Document JSON support",
 		"type":  "Issue",
-		"assignee": map[string]interface{}{
+		"assignee": map[string]any{
 			"id":            int16(1233),
 			"name":          "Dale",
 			"repositories":  nil,
 			"organizations": []string{},
 		},
 		"labels": []string{},
-		"contributors": []map[string]interface{}{
-			{"Id": int16(2244), "Name": "Dale", "orgs": []string{"Support Engineer", "Consulting", "PM", "Integrations"}, "Repositories": []map[string]interface{}{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]interface{}{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}}},
+		"contributors": []map[string]any{
+			{"Id": int16(2244), "Name": "Dale", "orgs": []string{"Support Engineer", "Consulting", "PM", "Integrations"}, "Repositories": []map[string]any{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]any{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}}},
 		},
 	}
-	row2 := map[string]interface{}{
+	row2 := map[string]any{
 		"title": "Document JSON issues",
 		"type":  "Issue",
-		"assignee": map[string]interface{}{
+		"assignee": map[string]any{
 			"id":   int16(1244),
 			"name": "Geoff",
-			"repositories": []map[string]interface{}{
-				{"url": "https://github.com/ClickHouse/clickhouse-python", "Releases": []map[string]interface{}{{"Version": "2.0.0"}, {"Version": "2.1.0"}}},
+			"repositories": []map[string]any{
+				{"url": "https://github.com/ClickHouse/clickhouse-python", "Releases": []map[string]any{{"Version": "2.0.0"}, {"Version": "2.1.0"}}},
 				{"url": "https://github.com/ClickHouse/clickhouse-go"},
 			},
 			"organizations": []string{"Support Engineer", "Integrations"},
@@ -1974,7 +1974,7 @@ func TestJSONNilMapFields(t *testing.T) {
 	require.NoError(t, batch.Send())
 	rows, err := conn.Query(ctx, "SELECT * FROM json_test ORDER BY event.assignee.id ASC")
 	require.NoError(t, err)
-	event := make(map[string]interface{})
+	event := make(map[string]any)
 	i := 0
 	for rows.Next() {
 		require.NoError(t, rows.Scan(&event))
@@ -2017,13 +2017,13 @@ func TestJSONManyColumns(t *testing.T) {
 
 func TestIPInInterfaceSlice(t *testing.T) {
 	type Login struct {
-		IPs []interface{}
+		IPs []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	login := Login{IPs: []interface{}{net.ParseIP("134.1.1.1"), net.ParseIP("127.0.0.1"), "127.0.0.2"}}
+	login := Login{IPs: []any{net.ParseIP("134.1.1.1"), net.ParseIP("127.0.0.1"), "127.0.0.2"}}
 	require.NoError(t, batch.Append(login))
 	require.NoError(t, batch.Send())
 	var event Login
@@ -2033,13 +2033,13 @@ func TestIPInInterfaceSlice(t *testing.T) {
 
 func TestNilStringInInterfaceSlice(t *testing.T) {
 	type Login struct {
-		IPs []interface{}
+		IPs []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	login := Login{IPs: []interface{}{"dale", "geoff", nil}}
+	login := Login{IPs: []any{"dale", "geoff", nil}}
 	require.NoError(t, batch.Append(login))
 	require.NoError(t, batch.Send())
 	var event Login
@@ -2049,13 +2049,13 @@ func TestNilStringInInterfaceSlice(t *testing.T) {
 
 func TestNilInNumericInterfaceSlice(t *testing.T) {
 	type Login struct {
-		IPs []interface{}
+		IPs []any
 	}
 	conn, teardown := setupTest(t)
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	login := Login{IPs: []interface{}{int64(1), int64(2), nil}}
+	login := Login{IPs: []any{int64(1), int64(2), nil}}
 	require.NoError(t, batch.Append(login))
 	require.NoError(t, batch.Send())
 	var event Login
@@ -2068,10 +2068,10 @@ func TestJSONNonStringMap(t *testing.T) {
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	row1 := map[string]interface{}{
+	row1 := map[string]any{
 		"title": "Document JSON support",
 		"type":  "Issue",
-		"assignee": map[int]interface{}{
+		"assignee": map[int]any{
 			1: "this is not permitted",
 		},
 	}
@@ -2083,24 +2083,24 @@ func TestInconsistentCompatibleTypesInBatch(t *testing.T) {
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	row1 := map[string]interface{}{
+	row1 := map[string]any{
 		"title": "Document JSON support",
 		"type":  "Issue",
-		"assignee": map[string]interface{}{
+		"assignee": map[string]any{
 			"id":            int16(0),
 			"name":          "Dale",
 			"repositories":  nil,
 			"organizations": []string{},
 		},
 		"labels": []string{},
-		"contributors": []map[string]interface{}{
-			{"Id": int16(2244), "Name": "Dale", "orgs": []string{"Support Engineer", "Consulting", "PM", "Integrations"}, "Repositories": []map[string]interface{}{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]interface{}{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}}},
+		"contributors": []map[string]any{
+			{"Id": int16(2244), "Name": "Dale", "orgs": []string{"Support Engineer", "Consulting", "PM", "Integrations"}, "Repositories": []map[string]any{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]any{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}}},
 		},
 	}
-	row2 := map[string]interface{}{
+	row2 := map[string]any{
 		"title": "Document JSON issues",
 		"type":  "Issue",
-		"assignee": map[string]interface{}{
+		"assignee": map[string]any{
 			"id":   int16(1),
 			"name": "Geoff",
 			"repositories": []Repository{
@@ -2116,7 +2116,7 @@ func TestInconsistentCompatibleTypesInBatch(t *testing.T) {
 	require.NoError(t, batch.Send())
 	rows, err := conn.Query(ctx, "SELECT * FROM json_test ORDER BY event.assignee.id ASC")
 	require.NoError(t, err)
-	event := make(map[string]interface{})
+	event := make(map[string]any)
 	i := 0
 	for rows.Next() {
 		require.NoError(t, rows.Scan(&event))
@@ -2135,10 +2135,10 @@ func TestInconsistentInCompatibleTypesInBatch(t *testing.T) {
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	row1 := map[string]interface{}{
+	row1 := map[string]any{
 		"title": "Document JSON support",
 		"type":  "Issue",
-		"assignee": map[string]interface{}{
+		"assignee": map[string]any{
 			"id":   int16(0),
 			"name": "Dale",
 			"repositories": []Repository{
@@ -2148,14 +2148,14 @@ func TestInconsistentInCompatibleTypesInBatch(t *testing.T) {
 			"organizations": []string{},
 		},
 		"labels": []string{},
-		"contributors": []map[string]interface{}{
-			{"Id": int16(2244), "Name": "Dale", "orgs": []string{"Support Engineer", "Consulting", "PM", "Integrations"}, "Repositories": []map[string]interface{}{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]interface{}{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}}},
+		"contributors": []map[string]any{
+			{"Id": int16(2244), "Name": "Dale", "orgs": []string{"Support Engineer", "Consulting", "PM", "Integrations"}, "Repositories": []map[string]any{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]any{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}}},
 		},
 	}
-	row2 := map[string]interface{}{
+	row2 := map[string]any{
 		"title": "Document JSON issues",
 		"type":  "Issue",
-		"assignee": map[string]interface{}{
+		"assignee": map[string]any{
 			"id":            int16(1),
 			"name":          "Geoff",
 			"repositories":  []string{"https://github.com/ClickHouse/clickhouse-python", "https://github.com/ClickHouse/clickhouse-go"},
@@ -2172,14 +2172,14 @@ func TestCastableTypesOnQuery(t *testing.T) {
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	row1 := map[string]interface{}{
+	row1 := map[string]any{
 		"title": "Document JSON support",
 		"type":  "Issue",
-		"assignee": map[string]interface{}{
+		"assignee": map[string]any{
 			"id":           int16(0),
 			"name":         "Dale",
 			"orgs":         []string{"clickhouse"},
-			"repositories": []map[string]interface{}{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]interface{}{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}},
+			"repositories": []map[string]any{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]any{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}},
 		},
 	}
 	require.NoError(t, batch.Append(row1))
@@ -2206,14 +2206,14 @@ func TestIncompatibleTypesOnQuery(t *testing.T) {
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	row1 := map[string]interface{}{
+	row1 := map[string]any{
 		"title": "Document JSON support",
 		"type":  "Issue",
-		"assignee": map[string]interface{}{
+		"assignee": map[string]any{
 			"id":           int16(0),
 			"name":         "Dale",
 			"orgs":         []string{"clickhouse"},
-			"repositories": []map[string]interface{}{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]interface{}{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}},
+			"repositories": []map[string]any{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]any{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}},
 		},
 	}
 	require.NoError(t, batch.Append(row1))
@@ -2239,14 +2239,14 @@ func TestInconsistentStructsOnQuery(t *testing.T) {
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	row1 := map[string]interface{}{
+	row1 := map[string]any{
 		"title": "Document JSON support",
 		"type":  "Issue",
-		"assignee": map[string]interface{}{
+		"assignee": map[string]any{
 			"id":           int16(0),
 			"name":         "Dale",
 			"orgs":         []string{"clickhouse"},
-			"repositories": []map[string]interface{}{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]interface{}{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}},
+			"repositories": []map[string]any{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]any{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}},
 		},
 	}
 	require.NoError(t, batch.Append(row1))
@@ -2271,10 +2271,10 @@ func TestColumnFormat(t *testing.T) {
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	var cols []map[string]interface{}
+	var cols []map[string]any
 
 	for i := 0; i < 1_000; i++ {
-		cols = append(cols, map[string]interface{}{
+		cols = append(cols, map[string]any{
 			"id":    int64(i),
 			"title": fmt.Sprintf("doc %v", i),
 		})
@@ -2291,7 +2291,7 @@ func TestMixedBatch(t *testing.T) {
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	require.NoError(t, batch.Append(map[string]interface{}{
+	require.NoError(t, batch.Append(map[string]any{
 		"id":    int64(0),
 		"title": "doc 0",
 	}))
@@ -2306,12 +2306,12 @@ func TestQueryMapByReference(t *testing.T) {
 	row1 := Repository{URL: "https://github.com/ClickHouse/clickhouse-python", Releases: []Releases{{Version: "1.0.0"}, {Version: "1.1.0"}}}
 	require.NoError(t, batch.Append(row1))
 	require.NoError(t, batch.Send())
-	var event map[string]interface{}
+	var event map[string]any
 	//if passing an uninitialized map, ensure it is passed by pointer
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(row1), toJson(event))
 	// an init map can be passed by ref or by value
-	event = make(map[string]interface{})
+	event = make(map[string]any)
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM json_test").Scan(&event))
 	assert.JSONEq(t, toJson(row1), toJson(event))
 }
@@ -2321,11 +2321,11 @@ func TestQueryNestedSubColumn(t *testing.T) {
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	repositories := []map[string]interface{}{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]interface{}{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}}
-	row1 := map[string]interface{}{
+	repositories := []map[string]any{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]any{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}}
+	row1 := map[string]any{
 		"title": "Document JSON support",
 		"type":  "Issue",
-		"assignee": map[string]interface{}{
+		"assignee": map[string]any{
 			"id":           int16(0),
 			"name":         "Dale",
 			"orgs":         []string{"clickhouse"},
@@ -2334,7 +2334,7 @@ func TestQueryNestedSubColumn(t *testing.T) {
 	}
 	require.NoError(t, batch.Append(row1))
 	require.NoError(t, batch.Send())
-	var event []map[string]interface{}
+	var event []map[string]any
 	require.NoError(t, conn.QueryRow(ctx, "SELECT event.assignee.repositories FROM json_test").Scan(&event))
 	assert.JSONEq(t, `[{"Releases":[{"Version":"2.0.0"},{"Version":"2.1.0"}],"url":"https://github.com/ClickHouse/clickhouse-go"},{"Releases":[],"url":"https://github.com/grafana/clickhouse"}]`, toJson(event))
 }
@@ -2344,20 +2344,20 @@ func TestQueryTupleSubColumn(t *testing.T) {
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	assignee := map[string]interface{}{
+	assignee := map[string]any{
 		"id":           int16(0),
 		"name":         "Dale",
 		"orgs":         []string{"clickhouse"},
-		"repositories": []map[string]interface{}{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]interface{}{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}},
+		"repositories": []map[string]any{{"url": "https://github.com/ClickHouse/clickhouse-go", "Releases": []map[string]any{{"Version": "2.0.0"}, {"Version": "2.1.0"}}}, {"url": "https://github.com/grafana/clickhouse"}},
 	}
-	row1 := map[string]interface{}{
+	row1 := map[string]any{
 		"title":    "Document JSON support",
 		"type":     "Issue",
 		"assignee": assignee,
 	}
 	require.NoError(t, batch.Append(row1))
 	require.NoError(t, batch.Send())
-	var event map[string]interface{}
+	var event map[string]any
 	require.NoError(t, conn.QueryRow(ctx, "SELECT event.assignee FROM json_test").Scan(&event))
 	assert.JSONEq(t, `{"id":0,"name":"Dale","orgs":["clickhouse"],"repositories":[{"Releases":[{"Version":"2.0.0"},{"Version":"2.1.0"}],"url":"https://github.com/ClickHouse/clickhouse-go"},{"Releases":[],"url":"https://github.com/grafana/clickhouse"}]}`, toJson(event))
 }
@@ -2444,9 +2444,9 @@ func TestJSONFlush(t *testing.T) {
 	defer teardown(t)
 	ctx := context.Background()
 	batch := prepareBatch(t, conn, ctx)
-	vals := [1000]map[string]interface{}{}
+	vals := [1000]map[string]any{}
 	for i := 0; i < 1000; i++ {
-		vals[i] = map[string]interface{}{
+		vals[i] = map[string]any{
 			"i": uint64(i),
 			"s": RandAsciiString(10),
 		}
@@ -2458,7 +2458,7 @@ func TestJSONFlush(t *testing.T) {
 	require.NoError(t, err)
 	i := 0
 	for rows.Next() {
-		var col1 map[string]interface{}
+		var col1 map[string]any
 		require.NoError(t, rows.Scan(&col1))
 		require.Equal(t, vals[i], col1)
 		i += 1
@@ -2468,8 +2468,8 @@ func TestJSONFlush(t *testing.T) {
 
 func TestMultipleJsonRowsWithNil(t *testing.T) {
 	// will got new map to different order
-	getMapByMapForTest := func(myMap map[string]interface{}) map[string]interface{} {
-		newMap := map[string]interface{}{}
+	getMapByMapForTest := func(myMap map[string]any) map[string]any {
+		newMap := map[string]any{}
 		for k := range myMap {
 			newMap[k] = myMap[k]
 		}
@@ -2479,10 +2479,10 @@ func TestMultipleJsonRowsWithNil(t *testing.T) {
 
 	type Login struct {
 		Username   string `json:"username"`
-		Attachment map[string]interface{}
+		Attachment map[string]any
 	}
 
-	myAttachment := map[string]interface{}{
+	myAttachment := map[string]any{
 		"col1": int64(1),
 		"col2": time.Date(2022, 11, 21, 16, 21, 0, 0, time.Local),
 		"col3": nil,

--- a/tests/map_test.go
+++ b/tests/map_test.go
@@ -210,25 +210,25 @@ func TestMapFlush(t *testing.T) {
 
 // a simple (non thread safe) ordered map
 type OrderedMap struct {
-	keys   []interface{}
-	values map[interface{}]interface{}
+	keys   []any
+	values map[any]any
 }
 
 func NewOrderedMap() *OrderedMap {
 	om := OrderedMap{}
-	om.keys = []interface{}{}
-	om.values = map[interface{}]interface{}{}
+	om.keys = []any{}
+	om.values = map[any]any{}
 	return &om
 }
 
-func (om *OrderedMap) Get(key interface{}) (interface{}, bool) {
+func (om *OrderedMap) Get(key any) (any, bool) {
 	if value, present := om.values[key]; present {
 		return value, present
 	}
 	return nil, false
 }
 
-func (om *OrderedMap) Put(key interface{}, value interface{}) {
+func (om *OrderedMap) Put(key any, value any) {
 	if _, present := om.values[key]; present {
 		om.values[key] = value
 		return
@@ -237,8 +237,8 @@ func (om *OrderedMap) Put(key interface{}, value interface{}) {
 	om.values[key] = value
 }
 
-func (om *OrderedMap) Keys() <-chan interface{} {
-	ch := make(chan interface{})
+func (om *OrderedMap) Keys() <-chan any {
+	ch := make(chan any)
 	go func() {
 		defer close(ch)
 		for _, key := range om.keys {

--- a/tests/nested_test.go
+++ b/tests/nested_test.go
@@ -101,15 +101,15 @@ func TestNestedFlattened(t *testing.T) {
 
 		col2Data = []uint8{10, 20, 30}
 		col3Data = []uint8{101, 201, 230} // Col2.Col1_N2
-		col4Data = [][][]interface{}{
-			[][]interface{}{
-				[]interface{}{uint8(1), uint8(2)},
+		col4Data = [][][]any{
+			[][]any{
+				[]any{uint8(1), uint8(2)},
 			},
-			[][]interface{}{
-				[]interface{}{uint8(1), uint8(2)},
+			[][]any{
+				[]any{uint8(1), uint8(2)},
 			},
-			[][]interface{}{
-				[]interface{}{uint8(1), uint8(2)},
+			[][]any{
+				[]any{uint8(1), uint8(2)},
 			},
 		}
 	)
@@ -119,7 +119,7 @@ func TestNestedFlattened(t *testing.T) {
 		col1 []uint8
 		col2 []uint8
 		col3 []uint8
-		col4 [][][]interface{}
+		col4 [][][]any
 	)
 	rows := conn.QueryRow(ctx, "SELECT * FROM test_nested")
 	require.NoError(t, rows.Scan(&col1, &col2, &col3, &col4))
@@ -155,7 +155,7 @@ func TestFlattenedSimpleNested(t *testing.T) {
 	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_nested")
 	require.NoError(t, err)
 	var (
-		col1Data = []map[string]interface{}{
+		col1Data = []map[string]any{
 			{
 				"Col1_N1": "1",
 			},
@@ -170,7 +170,7 @@ func TestFlattenedSimpleNested(t *testing.T) {
 	require.NoError(t, batch.Append(col1Data))
 	require.NoError(t, batch.Send())
 	var (
-		col1 []map[string]interface{}
+		col1 []map[string]any
 	)
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_nested").Scan(&col1))
 	assert.Equal(t, col1Data, col1)
@@ -211,7 +211,7 @@ func TestNestedUnFlattened(t *testing.T) {
 	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_nested")
 	require.NoError(t, err)
 	var (
-		col1Data = []map[string]interface{}{
+		col1Data = []map[string]any{
 			{
 				"Col1_N1": uint8(1),
 				"Col2_N1": uint8(20),
@@ -225,10 +225,10 @@ func TestNestedUnFlattened(t *testing.T) {
 				"Col2_N1": uint8(20),
 			},
 		}
-		col2Data = []map[string]interface{}{
+		col2Data = []map[string]any{
 			{
 				"Col1_N2": uint8(101),
-				"Col2_N2": []map[string]interface{}{
+				"Col2_N2": []map[string]any{
 					{
 						"Col1_N2_N1": uint8(1),
 						"Col2_N2_N1": uint8(2),
@@ -237,7 +237,7 @@ func TestNestedUnFlattened(t *testing.T) {
 			},
 			{
 				"Col1_N2": uint8(201),
-				"Col2_N2": []map[string]interface{}{
+				"Col2_N2": []map[string]any{
 					{
 						"Col1_N2_N1": uint8(3),
 						"Col2_N2_N1": uint8(4),
@@ -249,8 +249,8 @@ func TestNestedUnFlattened(t *testing.T) {
 	require.NoError(t, batch.Append(col1Data, col2Data))
 	require.NoError(t, batch.Send())
 	var (
-		col1 []map[string]interface{}
-		col2 []map[string]interface{}
+		col1 []map[string]any
+		col2 []map[string]any
 	)
 	rows := conn.QueryRow(ctx, "SELECT * FROM test_nested")
 	require.NoError(t, rows.Scan(&col1, &col2))
@@ -289,9 +289,9 @@ func TestNestedFlush(t *testing.T) {
 	}()
 	batch, err = conn.PrepareBatch(ctx, "INSERT INTO test_nested_flush")
 	require.NoError(t, err)
-	vals := [1000][]map[string]interface{}{}
+	vals := [1000][]map[string]any{}
 	for i := 0; i < 1000; i++ {
-		vals[i] = []map[string]interface{}{
+		vals[i] = []map[string]any{
 			{
 				"Col1_N1": uint8(i),
 				"Col2_N1": uint8(i) + 1,
@@ -313,7 +313,7 @@ func TestNestedFlush(t *testing.T) {
 	require.NoError(t, err)
 	i := 0
 	for rows.Next() {
-		var col1 []map[string]interface{}
+		var col1 []map[string]any
 		require.NoError(t, rows.Scan(&col1))
 		require.Equal(t, vals[i], col1)
 		i += 1

--- a/tests/simple_aggregate_function_test.go
+++ b/tests/simple_aggregate_function_test.go
@@ -53,7 +53,7 @@ func TestSimpleAggregateFunction(t *testing.T) {
 	var (
 		col1Data = uint64(42)
 		col2Data = float64(256.1)
-		col3Data = []interface{}{
+		col3Data = []any{
 			[]int16{1, 2, 3, 4, 5},
 			[]uint64{1, 2, 3, 4, 5},
 		}
@@ -63,7 +63,7 @@ func TestSimpleAggregateFunction(t *testing.T) {
 	var result struct {
 		Col1 uint64
 		Col2 float64
-		Col3 []interface{}
+		Col3 []any
 	}
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_simple_aggregate_function").ScanStruct(&result))
 	assert.Equal(t, col1Data, result.Col1)

--- a/tests/std/array_test.go
+++ b/tests/std/array_test.go
@@ -93,7 +93,7 @@ func TestStdArray(t *testing.T) {
 			require.NoError(t, err)
 			for rows.Next() {
 				var (
-					col1 interface{}
+					col1 any
 					col2 [][]uint32
 					col3 [][][]time.Time
 				)

--- a/tests/std/compression_test.go
+++ b/tests/std/compression_test.go
@@ -83,7 +83,7 @@ func TestCompressionStd(t *testing.T) {
 				i := int32(0)
 				for rows.Next() {
 					var (
-						col1 interface{}
+						col1 any
 						col2 int32
 					)
 					require.NoError(t, rows.Scan(&col1, &col2))
@@ -106,7 +106,7 @@ func TestCompressionStd(t *testing.T) {
 				i = 0
 				for rows.Next() {
 					var (
-						col1 interface{}
+						col1 any
 						col2 int32
 					)
 					require.NoError(t, rows.Scan(&col1, &col2))
@@ -154,7 +154,7 @@ func TestCompressionStdDSN(t *testing.T) {
 			require.NoError(t, err)
 			for rows.Next() {
 				var (
-					col1 interface{}
+					col1 any
 				)
 				require.NoError(t, rows.Scan(&col1))
 				assert.Equal(t, col1Data, col1)
@@ -213,7 +213,7 @@ func TestCompressionStdDSNWithLevel(t *testing.T) {
 			require.NoError(t, err)
 			for rows.Next() {
 				var (
-					col1 interface{}
+					col1 any
 				)
 				require.NoError(t, rows.Scan(&col1))
 				assert.Equal(t, col1Data, col1)

--- a/tests/std/fixed_string_test.go
+++ b/tests/std/fixed_string_test.go
@@ -42,7 +42,7 @@ func (bin *BinFixedString) UnmarshalBinary(b []byte) error {
 	return nil
 }
 
-func (bin *BinFixedString) Scan(src interface{}) error {
+func (bin *BinFixedString) Scan(src any) error {
 	return bin.UnmarshalBinary([]byte(src.(string)))
 }
 

--- a/tests/std/json_test.go
+++ b/tests/std/json_test.go
@@ -114,18 +114,18 @@ func TestStdJson(t *testing.T) {
 	_, err = batch.Exec(col1Data)
 	require.NoError(t, err)
 	require.NoError(t, scope.Commit())
-	// must pass interface{} - maps must be strongly typed so map[string]interface{} wont work - it wont convert
-	var event interface{}
+	// must pass any - maps must be strongly typed so map[string]any wont work - it wont convert
+	var event any
 	rows := conn.QueryRow("SELECT * FROM json_std_test")
 	require.NoError(t, rows.Scan(&event))
 	assert.JSONEq(t, ToJson(col1Data), ToJson(event))
-	// again pass interface{} for anthing other than primitives
+	// again pass any for anthing other than primitives
 	rows = conn.QueryRow("SELECT event.assignee.Achievement FROM json_std_test")
-	var achievement interface{}
+	var achievement any
 	require.NoError(t, rows.Scan(&achievement))
 	assert.JSONEq(t, ToJson(col1Data.Assignee.Achievement), ToJson(achievement))
 	rows = conn.QueryRow("SELECT event.assignee.Repositories FROM json_std_test")
-	var repositories interface{}
+	var repositories any
 	require.NoError(t, rows.Scan(&repositories))
 	assert.JSONEq(t, ToJson(col1Data.Assignee.Repositories), ToJson(repositories))
 }
@@ -164,16 +164,16 @@ func TestStdJsonWithMap(t *testing.T) {
 	require.NoError(t, err)
 	batch, err := scope.Prepare("INSERT INTO json_std_test")
 	require.NoError(t, err)
-	col1Data := map[string]interface{}{
-		"58": map[string]interface{}{
+	col1Data := map[string]any{
+		"58": map[string]any{
 			"test": []string{"2", "3"},
 		},
 	}
 	_, err = batch.Exec(col1Data)
 	require.NoError(t, err)
 	require.NoError(t, scope.Commit())
-	// must pass interface{} - maps must be strongly typed so map[string]interface{} wont work - it wont convert
-	var event interface{}
+	// must pass any - maps must be strongly typed so map[string]any wont work - it wont convert
+	var event any
 	rows := conn.QueryRow("SELECT * FROM json_std_test")
 	require.NoError(t, rows.Scan(&event))
 	assert.JSONEq(t, ToJson(col1Data), ToJson(event))

--- a/tests/std/map_test.go
+++ b/tests/std/map_test.go
@@ -81,7 +81,7 @@ func TestStdMap(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, scope.Commit())
 			var (
-				col1 interface{}
+				col1 any
 				col2 map[string]uint64
 				col3 map[string]uint64
 				col4 []map[string]string

--- a/tests/std/nested_test.go
+++ b/tests/std/nested_test.go
@@ -69,7 +69,7 @@ func TestStdNested(t *testing.T) {
 	batch, err := scope.Prepare("INSERT INTO std_nested_test")
 	require.NoError(t, err)
 	var (
-		col1Data = []map[string]interface{}{
+		col1Data = []map[string]any{
 			{
 				"Col1_N1": uint8(1),
 				"Col2_N1": uint8(20),
@@ -83,10 +83,10 @@ func TestStdNested(t *testing.T) {
 				"Col2_N1": uint8(20),
 			},
 		}
-		col2Data = []map[string]interface{}{
+		col2Data = []map[string]any{
 			{
 				"Col1_N2": uint8(101),
-				"Col2_N2": []map[string]interface{}{
+				"Col2_N2": []map[string]any{
 					{
 						"Col1_N2_N1": uint8(1),
 						"Col2_N2_N1": uint8(2),
@@ -95,7 +95,7 @@ func TestStdNested(t *testing.T) {
 			},
 			{
 				"Col1_N2": uint8(201),
-				"Col2_N2": []map[string]interface{}{
+				"Col2_N2": []map[string]any{
 					{
 						"Col1_N2_N1": uint8(3),
 						"Col2_N2_N1": uint8(4),
@@ -109,8 +109,8 @@ func TestStdNested(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, scope.Commit())
 	var (
-		col1 []map[string]interface{}
-		col2 []map[string]interface{}
+		col1 []map[string]any
+		col2 []map[string]any
 	)
 	rows := conn.QueryRow("SELECT * FROM std_nested_test")
 	require.NoError(t, rows.Scan(&col1, &col2))

--- a/tests/std/string_test.go
+++ b/tests/std/string_test.go
@@ -65,7 +65,7 @@ func TestSimpleStdString(t *testing.T) {
 			require.NoError(t, err)
 			for rows.Next() {
 				var (
-					col1 interface{}
+					col1 any
 					col2 sql.NullString
 				)
 				require.NoError(t, rows.Scan(&col1, &col2))

--- a/tests/std/tuples_test.go
+++ b/tests/std/tuples_test.go
@@ -84,43 +84,43 @@ func TestTuple(t *testing.T) {
 	batch, err := scope.Prepare("INSERT INTO test_tuple")
 	require.NoError(t, err)
 	var (
-		col1Data = []interface{}{"A", int64(42)}
-		col2Data = []interface{}{"B", int8(1), localTime.Truncate(time.Second)}
-		col3Data = map[string]interface{}{
+		col1Data = []any{"A", int64(42)}
+		col2Data = []any{"B", int8(1), localTime.Truncate(time.Second)}
+		col3Data = map[string]any{
 			"name1": localTime.Truncate(time.Second),
 			"name2": "CH",
 			"name3": map[string]string{
 				"key": "value",
 			},
 		}
-		col4Data = [][][]interface{}{
-			[][]interface{}{
-				[]interface{}{"Hi", int64(42)},
+		col4Data = [][][]any{
+			[][]any{
+				[]any{"Hi", int64(42)},
 			},
 		}
-		col5Data = []interface{}{
+		col5Data = []any{
 			"LCString",
 			[]string{"A", "B", "C"},
 		}
 		str      = "LCString"
-		col6Data = []interface{}{
+		col6Data = []any{
 			&str,
 			[]*string{&str, nil, &str},
 		}
-		col7Data = &[]interface{}{"C", int64(42)}
+		col7Data = &[]any{"C", int64(42)}
 	)
 	_, err = batch.Exec(col1Data, col2Data, col3Data, col4Data, col5Data, col6Data, col7Data)
 	require.NoError(t, err)
 	require.NoError(t, scope.Commit())
 	var (
-		col1 interface{}
-		col2 interface{}
+		col1 any
+		col2 any
 		// col3 is a named tuple - we can use map
-		col3 interface{}
-		col4 interface{}
-		col5 interface{}
-		col6 interface{}
-		col7 interface{}
+		col3 any
+		col4 any
+		col5 any
+		col6 any
+		col7 any
 	)
 	require.NoError(t, conn.QueryRow("SELECT * FROM test_tuple").Scan(&col1, &col2, &col3, &col4, &col5, &col6, &col7))
 	assert.NoError(t, err)

--- a/tests/std/tuples_test.go
+++ b/tests/std/tuples_test.go
@@ -1,3 +1,20 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 // license agreements. See the NOTICE file distributed with
 // this work for additional information regarding copyright
 // ownership. ClickHouse, Inc. licenses this file to you under

--- a/tests/std/utils.go
+++ b/tests/std/utils.go
@@ -202,7 +202,7 @@ func GetOpenDBConnection(environment string, protocol clickhouse.Protocol, setti
 	}), nil
 }
 
-func ToJson(obj interface{}) string {
+func ToJson(obj any) string {
 	bytes, err := json.Marshal(obj)
 	if err != nil {
 		return "unable to marshal"

--- a/tests/tuple_test.go
+++ b/tests/tuple_test.go
@@ -58,45 +58,45 @@ func TestTuple(t *testing.T) {
 	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_tuple")
 	require.NoError(t, err)
 	var (
-		col1Data = []interface{}{"A", int64(42)}
-		col2Data = []interface{}{"B", int8(1), localTime.Truncate(time.Second)}
-		col3Data = map[string]interface{}{
+		col1Data = []any{"A", int64(42)}
+		col2Data = []any{"B", int8(1), localTime.Truncate(time.Second)}
+		col3Data = map[string]any{
 			"name1": localTime.Truncate(time.Second),
 			"name2": "CH",
 			"name3": map[string]string{
 				"key": "value",
 			},
 		}
-		col4Data = [][][]interface{}{
-			[][]interface{}{
-				[]interface{}{"Hi", int64(42)},
+		col4Data = [][][]any{
+			[][]any{
+				[]any{"Hi", int64(42)},
 			},
 		}
-		col5Data = []interface{}{
+		col5Data = []any{
 			"LCString",
 			[]string{"A", "B", "C"},
 		}
 		str      = "LCString"
-		col6Data = []interface{}{
+		col6Data = []any{
 			&str,
 			[]*string{&str, nil, &str},
 		}
 		col8Val  = "G"
-		col7Data = &[]interface{}{"C", int64(42)}
-		col8Data = []interface{}{&col8Val, (*string)(nil)}
+		col7Data = &[]any{"C", int64(42)}
+		col8Data = []any{&col8Val, (*string)(nil)}
 	)
 	require.NoError(t, batch.Append(col1Data, col2Data, col3Data, col4Data, col5Data, col6Data, col7Data, col8Data))
 	require.NoError(t, batch.Send())
 	var (
-		col1 []interface{}
-		col2 []interface{}
+		col1 []any
+		col2 []any
 		// col3 is a named tuple - we can use map
-		col3 map[string]interface{}
-		col4 [][][]interface{}
-		col5 []interface{}
-		col6 []interface{}
-		col7 []interface{}
-		col8 []interface{}
+		col3 map[string]any
+		col4 [][][]any
+		col5 []any
+		col6 []any
+		col7 []any
+		col8 []any
 	)
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_tuple").Scan(&col1, &col2, &col3, &col4, &col5, &col6, &col7, &col8))
 	assert.NoError(t, err)
@@ -131,12 +131,12 @@ func TestNamedTupleWithSlice(t *testing.T) {
 	require.Error(t, batch.Append([]string{"A", "2"}))
 	batch, _ = conn.PrepareBatch(ctx, "INSERT INTO test_tuple")
 	var (
-		col1Data = []interface{}{"A", int64(42)}
+		col1Data = []any{"A", int64(42)}
 	)
 	require.NoError(t, batch.Append(col1Data))
 	require.NoError(t, batch.Send())
 	var (
-		col1 []interface{}
+		col1 []any
 	)
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_tuple").Scan(&col1))
 	assert.Equal(t, col1Data, col1)
@@ -196,11 +196,11 @@ func TestNamedTupleWithMap(t *testing.T) {
 	// this will fail - see TestNamedTupleWithTypedMap as tuple needs to be same type
 	require.Error(t, batch.Append(map[string]string{"name": "A", "id": "1"}))
 	batch, _ = conn.PrepareBatch(ctx, "INSERT INTO test_tuple")
-	col1Data := map[string]interface{}{"name": "A", "id": int64(1)}
+	col1Data := map[string]any{"name": "A", "id": int64(1)}
 	require.NoError(t, batch.Append(col1Data))
 	require.NoError(t, batch.Send())
 	var (
-		col1 map[string]interface{}
+		col1 map[string]any
 	)
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_tuple").Scan(&col1))
 	assert.Equal(t, col1Data, col1)
@@ -255,11 +255,11 @@ func TestNamedTupleWithEscapedColumns(t *testing.T) {
 	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_tuple")
 	require.NoError(t, err)
 	var (
-		col1Data = map[string]interface{}{"56": "A", "a22`": int64(1)}
+		col1Data = map[string]any{"56": "A", "a22`": int64(1)}
 	)
 	require.NoError(t, batch.Append(col1Data))
 	require.NoError(t, batch.Send())
-	var col1 map[string]interface{}
+	var col1 map[string]any
 	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_tuple").Scan(&col1))
 	assert.Equal(t, col1Data, col1)
 }
@@ -281,8 +281,8 @@ func TestNamedTupleIncomplete(t *testing.T) {
 	require.NoError(t, conn.Exec(ctx, ddl))
 	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_tuple")
 	require.NoError(t, err)
-	require.Error(t, batch.Append(map[string]interface{}{"name": "A"}))
-	require.Error(t, batch.Append([]interface{}{"Dale"}))
+	require.Error(t, batch.Append(map[string]any{"name": "A"}))
+	require.Error(t, batch.Append([]any{"Dale"}))
 }
 
 // unnamed tuples will not work with maps - keys cannot be attributed to fields
@@ -304,7 +304,7 @@ func TestUnNamedTupleWithMap(t *testing.T) {
 	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_tuple")
 	require.NoError(t, err)
 	var (
-		col1Data = map[string]interface{}{"name": "A", "id": int64(1)}
+		col1Data = map[string]any{"name": "A", "id": int64(1)}
 	)
 	// this will fail - maps can't be used for unnamed tuples
 	err = batch.Append(col1Data)
@@ -313,9 +313,9 @@ func TestUnNamedTupleWithMap(t *testing.T) {
 	// insert some data properly to test scan - can't reuse batch
 	batch, err = conn.PrepareBatch(ctx, "INSERT INTO test_tuple")
 	require.NoError(t, err)
-	require.NoError(t, batch.Append([]interface{}{"A", int64(42)}))
+	require.NoError(t, batch.Append([]any{"A", int64(42)}))
 	require.NoError(t, batch.Send())
-	var col1 map[string]interface{}
+	var col1 map[string]any
 	err = conn.QueryRow(ctx, "SELECT * FROM test_tuple").Scan(&col1)
 	require.Error(t, err)
 	require.Equal(t, "clickhouse [ScanRow]: (Col1) converting Tuple(String, Int64) to map[string]interface {} is unsupported. cannot use maps for unnamed tuples, use slice", err.Error())
@@ -346,26 +346,26 @@ func TestColumnarTuple(t *testing.T) {
 	require.NoError(t, err)
 	var (
 		id        []uint64
-		col1Data  = [][]interface{}{}
-		col2Data  = [][]interface{}{}
-		col3Data  = [][]interface{}{}
-		col4Data  = []*[]interface{}{}
+		col1Data  = [][]any{}
+		col2Data  = [][]any{}
+		col3Data  = [][]any{}
+		col4Data  = []*[]any{}
 		timestamp = time.Now().Truncate(time.Second)
 	)
 	for i := 0; i < 1000; i++ {
 		id = append(id, uint64(i))
-		col1Data = append(col1Data, []interface{}{
+		col1Data = append(col1Data, []any{
 			fmt.Sprintf("A_%d", i), int64(i),
 		})
-		col2Data = append(col2Data, []interface{}{
+		col2Data = append(col2Data, []any{
 			fmt.Sprintf("B_%d", i), int8(1), timestamp,
 		})
-		col3Data = append(col3Data, []interface{}{
+		col3Data = append(col3Data, []any{
 			timestamp, "CH", map[string]string{
 				"key": "value",
 			},
 		})
-		col4Data = append(col4Data, &[]interface{}{
+		col4Data = append(col4Data, &[]any{
 			fmt.Sprintf("C_%d", i), int64(i),
 		})
 	}
@@ -378,22 +378,22 @@ func TestColumnarTuple(t *testing.T) {
 	{
 		var (
 			id       uint64
-			col1     []interface{}
-			col2     []interface{}
-			col3     []interface{}
-			col4     []interface{}
-			col1Data = []interface{}{
+			col1     []any
+			col2     []any
+			col3     []any
+			col4     []any
+			col1Data = []any{
 				"A_542", int64(542),
 			}
-			col2Data = []interface{}{
+			col2Data = []any{
 				"B_542", int8(1), timestamp.In(time.UTC),
 			}
-			col3Data = []interface{}{
+			col3Data = []any{
 				timestamp.In(time.UTC), "CH", map[string]string{
 					"key": "value",
 				},
 			}
-			col4Data = &[]interface{}{
+			col4Data = &[]any{
 				"C_542", int64(542),
 			}
 		)
@@ -424,9 +424,9 @@ func TestTupleFlush(t *testing.T) {
 	require.NoError(t, conn.Exec(ctx, ddl))
 	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_tuple_flush")
 	require.NoError(t, err)
-	vals := [1000]map[string]interface{}{}
+	vals := [1000]map[string]any{}
 	for i := 0; i < 1000; i++ {
-		vals[i] = map[string]interface{}{
+		vals[i] = map[string]any{
 			"id":   int64(i),
 			"name": RandAsciiString(10),
 		}
@@ -438,7 +438,7 @@ func TestTupleFlush(t *testing.T) {
 	require.NoError(t, err)
 	i := 0
 	for rows.Next() {
-		var col1 map[string]interface{}
+		var col1 map[string]any
 		require.NoError(t, rows.Scan(&col1))
 		require.Equal(t, vals[i], col1)
 		i += 1

--- a/v1_v2_CHANGES.md
+++ b/v1_v2_CHANGES.md
@@ -4,5 +4,5 @@ Known breaking changes for v1 to v2 are collated below. These are subject to cha
 
 - v1 allowed precision loss when inserting types. For example, a sql.NullInt32 could be inserted to a UInt8 column and float64 and Decimals were interchangeable. Whilst v2 aims to be flexible, it will not transparently loose precision. Users must accept and explicitly perform this work outside the client.
 - strings cannot be inserted in Date or DateTime columns in v2. [#574](https://github.com/ClickHouse/clickhouse-go/issues/574)
-- Arrays must be strongly typed in v2 e.g. a `[]interface{}` containing strings cannot be inserted into a string column. This conversion must be down outside the client, since it incurs a cost - the array must be iterated and converted. The client will not conceal this overhead in v2.
+- Arrays must be strongly typed in v2 e.g. a `[]any` containing strings cannot be inserted into a string column. This conversion must be down outside the client, since it incurs a cost - the array must be iterated and converted. The client will not conceal this overhead in v2.
 - v1 used a connection strategy of random. v2 uses in_order by default.


### PR DESCRIPTION
## Summary

Go 1.18 (that is targeted by [go.mod](./go.mod)) introduced a handy `any` alias for `interface{}`.

This PR moves the codebase from `interface{}` to `any` for reading & dev simplicity.


## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
