### PR TITLE
support http connection reuse after external table query execution

### DIFF
--- a/lib/column/ipv6.go
+++ b/lib/column/ipv6.go
@@ -70,27 +70,6 @@ func (col *IPv6) ScanRow(dest any, row int) error {
 	case **net.IP:
 		*d = new(net.IP)
 		**d = col.row(row)
-	case *[16]uint8:
-		v := col.row(row)
-		if len(v) < 16 {
-			return &ColumnConverterError{
-				Op:   "ScanRow",
-				To:   fmt.Sprintf("%T", dest),
-				From: "IPv6",
-			}
-		}
-		*d = IPv6ToBytes(v)
-	case **[16]uint8:
-		v := col.row(row)
-		if len(v) < 16 {
-			return &ColumnConverterError{
-				Op:   "ScanRow",
-				To:   fmt.Sprintf("%T", dest),
-				From: "IPv6",
-			}
-		}
-		*d = new([16]uint8)
-		**d = IPv6ToBytes(v)
 	default:
 		return &ColumnConverterError{
 			Op:   "ScanRow",

--- a/lib/column/ipv6.go
+++ b/lib/column/ipv6.go
@@ -70,6 +70,27 @@ func (col *IPv6) ScanRow(dest any, row int) error {
 	case **net.IP:
 		*d = new(net.IP)
 		**d = col.row(row)
+	case *[16]uint8:
+		v := col.row(row)
+		if len(v) < 16 {
+			return &ColumnConverterError{
+				Op:   "ScanRow",
+				To:   fmt.Sprintf("%T", dest),
+				From: "IPv6",
+			}
+		}
+		*d = IPv6ToBytes(v)
+	case **[16]uint8:
+		v := col.row(row)
+		if len(v) < 16 {
+			return &ColumnConverterError{
+				Op:   "ScanRow",
+				To:   fmt.Sprintf("%T", dest),
+				From: "IPv6",
+			}
+		}
+		*d = new([16]uint8)
+		**d = IPv6ToBytes(v)
 	default:
 		return &ColumnConverterError{
 			Op:   "ScanRow",

--- a/tests/issues/990_test.go
+++ b/tests/issues/990_test.go
@@ -1,0 +1,71 @@
+package issues
+
+import (
+	"context"
+	"fmt"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/ext"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func Test990(t *testing.T) {
+	useSSL, err := strconv.ParseBool(clickhouse_tests.GetEnv("CLICKHOUSE_USE_SSL", "false"))
+	require.NoError(t, err)
+	conn, err := clickhouse_std_tests.GetDSNConnection("issues", clickhouse.HTTP, useSSL, nil)
+
+	for i := 0; i < 10; i++ {
+		externalTableNameA, externalTableNameB := fmt.Sprintf("external_table_%v_a", i), fmt.Sprintf("external_table_%v_b", i)
+		table1, err := ext.NewTable(externalTableNameA,
+			ext.Column("col1", "UInt8"),
+			ext.Column("col2", "String"),
+			ext.Column("col3", "DateTime"),
+		)
+		require.NoError(t, err)
+		for i := 0; i < 10; i++ {
+			assert.NoError(t, table1.Append(uint8(i), fmt.Sprintf("value_%d", i), time.Now()))
+		}
+		table2, err := ext.NewTable(externalTableNameB,
+			ext.Column("col1", "UInt8"),
+			ext.Column("col2", "String"),
+			ext.Column("col3", "DateTime"),
+		)
+		require.NoError(t, err)
+		for i := 0; i < 10; i++ {
+			assert.NoError(t, table2.Append(uint8(i), fmt.Sprintf("value_%d", i), time.Now()))
+		}
+		require.NoError(t, err)
+
+		ctx := clickhouse.Context(context.Background(),
+			clickhouse.WithExternalTable(table1, table2),
+		)
+
+		rows, err := conn.QueryContext(ctx, fmt.Sprintf("SELECT * FROM %v", externalTableNameA))
+		require.NoError(t, err)
+		for rows.Next() {
+			var (
+				col1 uint8
+				col2 string
+				col3 time.Time
+			)
+			require.NoError(t, rows.Scan(&col1, &col2, &col3))
+			t.Logf("row: col1=%d, col2=%s, col3=%s\n", col1, col2, col3)
+		}
+		rows.Close()
+
+		var count uint64
+		require.NoError(t, conn.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %v", externalTableNameA)).Scan(&count))
+		assert.Equal(t, uint64(10), count)
+		require.NoError(t, conn.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %v", externalTableNameB)).Scan(&count))
+		assert.Equal(t, uint64(10), count)
+		require.NoError(t, conn.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM (SELECT * FROM %v UNION ALL SELECT * FROM %v)", externalTableNameA, externalTableNameB)).Scan(&count))
+		assert.Equal(t, uint64(20), count)
+		require.NoError(t, conn.Ping())
+	}
+
+}


### PR DESCRIPTION
## Summary
Support http connection reuse after external table query execution and  fix #990 

## Checklist
- [x] Unit and integration tests covering the common scenarios were added

