### PR TITLE
Custom settings support in native protocol

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -131,18 +131,27 @@ type connect struct {
 }
 
 func (c *connect) settings(querySettings Settings) []proto.Setting {
+	settingToProtoSetting := func(k string, v any) proto.Setting {
+		isCustom := false
+		if cv, ok := v.(CustomSetting); ok {
+			v = cv.Value
+			isCustom = true
+		}
+
+		return proto.Setting{
+			Key:       k,
+			Value:     v,
+			Important: !isCustom,
+			Custom:    isCustom,
+		}
+	}
+
 	settings := make([]proto.Setting, 0, len(c.opt.Settings)+len(querySettings))
 	for k, v := range c.opt.Settings {
-		settings = append(settings, proto.Setting{
-			Key:   k,
-			Value: v,
-		})
+		settings = append(settings, settingToProtoSetting(k, v))
 	}
 	for k, v := range querySettings {
-		settings = append(settings, proto.Setting{
-			Key:   k,
-			Value: v,
-		})
+		settings = append(settings, settingToProtoSetting(k, v))
 	}
 	return settings
 }

--- a/conn_http.go
+++ b/conn_http.go
@@ -189,6 +189,10 @@ func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpCon
 	}
 
 	for k, v := range opt.Settings {
+		if cv, ok := v.(CustomSetting); ok {
+			v = cv.Value
+		}
+
 		query.Set(k, fmt.Sprint(v))
 	}
 
@@ -462,6 +466,9 @@ func (h *httpConnect) createRequest(ctx context.Context, reader io.Reader, optio
 			// check that query doesn't change format
 			if key == "default_format" {
 				continue
+			}
+			if cv, ok := value.(CustomSetting); ok {
+				value = cv.Value
 			}
 			query.Set(key, fmt.Sprint(value))
 		}

--- a/context.go
+++ b/context.go
@@ -32,6 +32,14 @@ var _contextOptionKey = &QueryOptions{
 }
 
 type Settings map[string]any
+
+// CustomSetting is a helper struct to distinguish custom settings from important ones.
+// For native protocol, is_important flag is set to value 0x02 (see https://github.com/ClickHouse/ClickHouse/blob/c873560fe7185f45eed56520ec7d033a7beb1551/src/Core/BaseSettings.h#L516-L521)
+// Only string value is supported until formatting logic that exists in ClickHouse is implemented in clickhouse-go. (https://github.com/ClickHouse/ClickHouse/blob/master/src/Core/Field.cpp#L312 and https://github.com/ClickHouse/clickhouse-go/issues/992)
+type CustomSetting struct {
+	Value string
+}
+
 type Parameters map[string]string
 type (
 	QueryOption  func(*QueryOptions) error

--- a/tests/conn_test.go
+++ b/tests/conn_test.go
@@ -305,3 +305,44 @@ func TestEmptyDatabaseConfig(t *testing.T) {
 	err = anotherConn.Ping(context.Background())
 	require.NoError(t, err)
 }
+
+func TestCustomSettings(t *testing.T) {
+	runInDocker, _ := strconv.ParseBool(GetEnv("CLICKHOUSE_USE_DOCKER", "true"))
+	if !runInDocker {
+		t.Skip("Skip test in cloud environment.") // todo configure cloud instance with custom settings
+	}
+
+	conn, err := GetNativeConnection(clickhouse.Settings{
+		"custom_setting": clickhouse.CustomSetting{"custom_value"},
+	}, nil, &clickhouse.Compression{
+		Method: clickhouse.CompressionLZ4,
+	})
+	require.NoError(t, err)
+
+	t.Run("get existing custom setting value", func(t *testing.T) {
+		row := conn.QueryRow(context.Background(), "SELECT getSetting('custom_setting')")
+		require.NoError(t, row.Err())
+
+		var setting string
+		require.NoError(t, row.Scan(&setting))
+		require.Equal(t, "custom_value", setting)
+	})
+
+	t.Run("get non-existing custom setting value", func(t *testing.T) {
+		row := conn.QueryRow(context.Background(), "SELECT getSetting('custom_non_existing_setting')")
+		require.ErrorContains(t, row.Err(), "Unknown setting custom_non_existing_setting")
+	})
+
+	t.Run("get custom setting value from query context", func(t *testing.T) {
+		ctx := clickhouse.Context(context.Background(), clickhouse.WithSettings(clickhouse.Settings{
+			"custom_query_setting": clickhouse.CustomSetting{"custom_query_value"},
+		}))
+
+		row := conn.QueryRow(ctx, "SELECT getSetting('custom_query_setting')")
+		require.NoError(t, row.Err())
+
+		var setting string
+		require.NoError(t, row.Scan(&setting))
+		require.Equal(t, "custom_query_value", setting)
+	})
+}

--- a/tests/resources/custom.xml
+++ b/tests/resources/custom.xml
@@ -32,4 +32,5 @@
         </client>
     </openSSL>
     <display_name>clickhouse</display_name>
+    <custom_settings_prefixes>custom_</custom_settings_prefixes>
 </clickhouse>


### PR DESCRIPTION
## Summary

This PR adds support for the custom settings in the native protocol.
It introduces an additional `clickhouse.CustomSetting` type, a value wrapper for the `clickhouse.Setting` type.
It can be passed to the `clickhouse.Settings` type as a value. If the value is provided with `clickhouse.CustomSetting` type, it will be passed to the server as a custom setting with an appropriate flag.
Only string type value is currently supported until [this change](https://github.com/ClickHouse/clickhouse-go/issues/992) is implemented.

Resolves #983 

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
