### PR TITLE
Support [16]byte/[]byte typed scan/append for IPv6 column

### DIFF
--- a/lib/column/ipv6.go
+++ b/lib/column/ipv6.go
@@ -70,6 +70,21 @@ func (col *IPv6) ScanRow(dest any, row int) error {
 	case **net.IP:
 		*d = new(net.IP)
 		**d = col.row(row)
+	case *[]byte:
+		*d = col.row(row)
+	case **[]byte:
+		*d = new([]byte)
+		**d = col.row(row)
+	case *proto.IPv6:
+		*d = col.col.Row(row)
+	case **proto.IPv6:
+		*d = new(proto.IPv6)
+		**d = col.col.Row(row)
+	case *[16]byte:
+		*d = col.col.Row(row)
+	case **[16]byte:
+		*d = new([16]byte)
+		**d = col.col.Row(row)
 	default:
 		return &ColumnConverterError{
 			Op:   "ScanRow",
@@ -151,7 +166,6 @@ func (col *IPv6) Append(v any) (nulls []uint8, err error) {
 	case []net.IP:
 		nulls = make([]uint8, len(v))
 		for _, v := range v {
-			nulls = make([]uint8, len(v))
 			col.col.Append(proto.ToIPv6(netip.AddrFrom16(IPv6ToBytes(v))))
 		}
 	case []*net.IP:
@@ -160,6 +174,52 @@ func (col *IPv6) Append(v any) (nulls []uint8, err error) {
 			switch {
 			case v != nil:
 				col.col.Append(proto.ToIPv6(netip.AddrFrom16(IPv6ToBytes(*v))))
+			default:
+				nulls[i] = 1
+				col.col.Append([16]byte{})
+			}
+		}
+	case [][]byte:
+		nulls = make([]uint8, len(v))
+		for _, v := range v {
+			col.col.Append(proto.ToIPv6(netip.AddrFrom16(IPv6ToBytes(v))))
+		}
+	case []*[]byte:
+		nulls = make([]uint8, len(v))
+		for i, v := range v {
+			switch {
+			case v != nil:
+				col.col.Append(proto.ToIPv6(netip.AddrFrom16(IPv6ToBytes(*v))))
+			default:
+				nulls[i] = 1
+				col.col.Append([16]byte{})
+			}
+		}
+	case [][16]byte:
+		for _, v := range v {
+			col.col.Append(v)
+		}
+	case []*[16]byte:
+		nulls = make([]uint8, len(v))
+		for i, v := range v {
+			switch {
+			case v != nil:
+				col.col.Append(*v)
+			default:
+				nulls[i] = 1
+				col.col.Append([16]byte{})
+			}
+		}
+	case []proto.IPv6:
+		for _, v := range v {
+			col.col.Append(v)
+		}
+	case []*proto.IPv6:
+		nulls = make([]uint8, len(v))
+		for i, v := range v {
+			switch {
+			case v != nil:
+				col.col.Append(*v)
 			default:
 				nulls[i] = 1
 				col.col.Append([16]byte{})
@@ -217,6 +277,33 @@ func (col *IPv6) AppendRow(v any) (err error) {
 		switch {
 		case v != nil:
 			col.col.Append(proto.ToIPv6(netip.AddrFrom16(IPv6ToBytes(*v))))
+		default:
+			col.col.Append([16]byte{})
+		}
+	case []byte:
+		col.col.Append(proto.ToIPv6(netip.AddrFrom16(IPv6ToBytes(v))))
+	case *[]byte:
+		switch {
+		case v != nil:
+			col.col.Append(proto.ToIPv6(netip.AddrFrom16(IPv6ToBytes(*v))))
+		default:
+			col.col.Append([16]byte{})
+		}
+	case [16]byte:
+		col.col.Append(v)
+	case *[16]byte:
+		switch {
+		case v != nil:
+			col.col.Append(*v)
+		default:
+			col.col.Append([16]byte{})
+		}
+	case proto.IPv6:
+		col.col.Append(v)
+	case *proto.IPv6:
+		switch {
+		case v != nil:
+			col.col.Append(*v)
 		default:
 			col.col.Append([16]byte{})
 		}

--- a/tests/ipv6_test.go
+++ b/tests/ipv6_test.go
@@ -306,24 +306,23 @@ func assertRowColumnEqualToIP(t *testing.T, value any, ip net.IP) {
 func TestIPv6AppendRow(t *testing.T) {
 	ip := getTestIPv6()[0]
 	strIp := ip.String()
-
+	ipBytes := netip.MustParseAddr(strIp).As16()
 	col := column.IPv6{}
 
 	rows := []any{
-		strIp,                                   // appending string
-		&ip,                                     // appending IP pointer
-		ip,                                      // appending IP
-		&strIp,                                  // appending string pointer
-		netip.MustParseAddr(ip.String()).As16(), // appending [16]byte
-		proto.IPv6(netip.MustParseAddr(ip.String()).As16()),                   // appending proto.IPv6
-		&[][16]byte{netip.MustParseAddr(ip.String()).As16()}[0],               // appending [16]byte pointer
-		&[]proto.IPv6{proto.IPv6(netip.MustParseAddr(ip.String()).As16())}[0], // appending proto.IPv6 pointer
+		strIp,                     // appending string
+		&ip,                       // appending IP pointer
+		ip,                        // appending IP
+		&strIp,                    // appending string pointer
+		ipBytes,                   // appending [16]byte
+		proto.IPv6(ipBytes),       // appending proto.IPv6
+		&[][16]byte{ipBytes}[0],   // appending [16]byte pointer
+		&[]proto.IPv6{ipBytes}[0], // appending proto.IPv6 pointer
 	}
 	for i, row := range rows {
 		err := col.AppendRow(row)
-
-		require.NoError(t, err)
-		require.Equal(t, i+1, col.Rows(), "AppendRow didn't add IP")
+		assert.Nil(t, err)
+		assert.Truef(t, i+1 == col.Rows(), "AppendRow didn't add IP")
 		assertRowColumnEqualToIP(t, col.Row(i, false), ip)
 	}
 }

--- a/tests/ipv6_test.go
+++ b/tests/ipv6_test.go
@@ -19,9 +19,11 @@ package tests
 
 import (
 	"context"
+	"github.com/ClickHouse/ch-go/proto"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"github.com/stretchr/testify/require"
 	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -41,6 +43,10 @@ func TestIPv6(t *testing.T) {
 				, Col3 Nullable(IPv6)
 				, Col4 Array(IPv6)
 				, Col5 Array(Nullable(IPv6))
+			    , Col6 Array(IPv6)
+				, Col7 Array(Nullable(IPv6))
+			    , Col8 IPv6
+				, Col9 Nullable(IPv6)
 			) Engine MergeTree() ORDER BY tuple()
 		`
 	defer func() {
@@ -55,8 +61,12 @@ func TestIPv6(t *testing.T) {
 		col3Data = col1Data
 		col4Data = []net.IP{col1Data, col2Data}
 		col5Data = []*net.IP{&col1Data, nil, &col2Data}
+		col6Data = []*net.IP{&col1Data, &col2Data}
+		col7Data = []*net.IP{&col1Data, nil, &col2Data}
+		col8Data = &col1Data
+		col9Data = col2Data
 	)
-	require.NoError(t, batch.Append(col1Data, col2Data, col3Data, col4Data, col5Data))
+	require.NoError(t, batch.Append(col1Data, col2Data, col3Data, col4Data, col5Data, col6Data, col7Data, col8Data, col9Data))
 	require.NoError(t, batch.Send())
 	var (
 		col1 net.IP
@@ -64,8 +74,12 @@ func TestIPv6(t *testing.T) {
 		col3 *net.IP
 		col4 []net.IP
 		col5 []*net.IP
+		col6 []net.IP
+		col7 []*net.IP
+		col8 [16]byte
+		col9 *[16]byte
 	)
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_ipv6").Scan(&col1, &col2, &col3, &col4, &col5))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_ipv6").Scan(&col1, &col2, &col3, &col4, &col5, &col6, &col7, &col8, &col9))
 	assert.Equal(t, col1Data, col1)
 	assert.Equal(t, col2Data, col2)
 	assert.Equal(t, col3Data, *col3)
@@ -76,6 +90,18 @@ func TestIPv6(t *testing.T) {
 	require.Nil(t, col5[1])
 	assert.Equal(t, col1Data, *col5[0])
 	assert.Equal(t, col2Data, *col5[2])
+
+	require.Len(t, col6, 2)
+	assert.Equal(t, col1Data, col4[0])
+	assert.Equal(t, col2Data, col4[1])
+	require.Len(t, col7, 3)
+	require.Nil(t, col7[1])
+	assert.Equal(t, col1Data, *col7[0])
+	assert.Equal(t, col2Data, *col7[2])
+
+	assert.Equal(t, col1Data, net.ParseIP(netip.AddrFrom16(col8).String()))
+	assert.Equal(t, col2Data, net.ParseIP(netip.AddrFrom16(*col9).String()))
+
 }
 
 func TestIPv4InIPv6(t *testing.T) {
@@ -88,6 +114,7 @@ func TestIPv4InIPv6(t *testing.T) {
 			CREATE TABLE test_ipv6 (
 				  Col1 IPv6
 				, Col2 IPv6
+				, Col3 IPv6
 			) Engine MergeTree() ORDER BY tuple()
 		`
 	defer func() {
@@ -99,16 +126,19 @@ func TestIPv4InIPv6(t *testing.T) {
 	var (
 		col1Data = net.ParseIP("127.0.0.1").To4()
 		col2Data = net.ParseIP("85.242.48.167").To4()
+		col3Data = net.ParseIP("85.242.48.167").To4()
 	)
-	require.NoError(t, batch.Append(col1Data, col2Data))
+	require.NoError(t, batch.Append(col1Data, col2Data, col3Data))
 	require.NoError(t, batch.Send())
 	var (
 		col1 net.IP
 		col2 net.IP
+		col3 [16]byte
 	)
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_ipv6").Scan(&col1, &col2))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_ipv6").Scan(&col1, &col2, &col3))
 	assert.Equal(t, col1Data.To16(), col1)
 	assert.Equal(t, col2Data.To16(), col2)
+	assert.Equal(t, col3Data.To16(), net.ParseIP(netip.AddrFrom16(col3).String()))
 }
 
 func TestNullableIPv6(t *testing.T) {
@@ -121,6 +151,7 @@ func TestNullableIPv6(t *testing.T) {
 			CREATE TABLE test_ipv6 (
 				  Col1 Nullable(IPv6)
 				, Col2 Nullable(IPv6)
+				, Col3 Nullable(IPv6)
 			) Engine MergeTree() ORDER BY tuple()
 		`
 	defer func() {
@@ -132,29 +163,34 @@ func TestNullableIPv6(t *testing.T) {
 	var (
 		col1Data = net.ParseIP("2a02:aa08:e000:3100::2")
 		col2Data = net.ParseIP("2001:44c8:129:2632:33:0:252:2")
+		col3Data = net.ParseIP("2001:44c8:129:2632:33:0:252:2")
 	)
-	require.NoError(t, batch.Append(col1Data, col2Data))
+	require.NoError(t, batch.Append(col1Data, col2Data, col3Data))
 	require.NoError(t, batch.Send())
 	var (
 		col1 *net.IP
 		col2 *net.IP
+		col3 *[16]byte
 	)
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_ipv6").Scan(&col1, &col2))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_ipv6").Scan(&col1, &col2, &col3))
 	assert.Equal(t, col1Data, *col1)
 	assert.Equal(t, col2Data, *col2)
+	assert.Equal(t, col3Data, net.ParseIP(netip.AddrFrom16(*col3).String()))
 	require.NoError(t, conn.Exec(ctx, "TRUNCATE TABLE test_ipv6"))
 	batch, err = conn.PrepareBatch(ctx, "INSERT INTO test_ipv6")
 	require.NoError(t, err)
 	col1Data = net.ParseIP("2001:44c8:129:2632:33:0:252:2")
-	require.NoError(t, batch.Append(col1Data, nil))
+	require.NoError(t, batch.Append(col1Data, nil, nil))
 	require.NoError(t, batch.Send())
 	{
 		var (
 			col1 *net.IP
 			col2 *net.IP
+			col3 *[16]byte
 		)
-		require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_ipv6").Scan(&col1, &col2))
+		require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_ipv6").Scan(&col1, &col2, &col3))
 		require.Nil(t, col2)
+		require.Nil(t, col3)
 		assert.Equal(t, col1Data, *col1)
 	}
 }
@@ -170,6 +206,8 @@ func TestColumnarIPv6(t *testing.T) {
 				  Col1 IPv6
 				, Col2 IPv6
 				, Col3 Nullable(IPv6)
+				, Col4 IPv6
+				, Col5 Nullable(IPv6)
 			) Engine MergeTree() ORDER BY tuple()
 		`
 	defer func() {
@@ -183,26 +221,36 @@ func TestColumnarIPv6(t *testing.T) {
 		col1Data []*net.IP
 		col2Data []*net.IP
 		col3Data []*net.IP
+		col4Data []*[16]byte
+		col5Data []*[16]byte
 		v1, v2   = net.ParseIP("2001:44c8:129:2632:33:0:252:2"), net.ParseIP("192.168.1.1").To4()
 	)
 	col1Data = append(col1Data, &v1)
 	col2Data = append(col2Data, &v2)
 	col3Data = append(col3Data, nil)
+	col4Data = append(col4Data, &[][16]byte{netip.MustParseAddr(v1.String()).As16()}[0])
+	col5Data = append(col5Data, nil)
 	{
 		batch.Column(0).Append(col1Data)
 		batch.Column(1).Append(col2Data)
 		batch.Column(2).Append(col3Data)
+		batch.Column(3).Append(col4Data)
+		batch.Column(4).Append(col5Data)
 	}
 	require.NoError(t, batch.Send())
 	var (
 		col1 *net.IP
 		col2 *net.IP
 		col3 *net.IP
+		col4 *[16]byte
+		col5 *[16]byte
 	)
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_ipv6").Scan(&col1, &col2, &col3))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_ipv6").Scan(&col1, &col2, &col3, &col4, &col5))
 	require.Nil(t, col3)
+	require.Nil(t, col5)
 	require.Equal(t, v1, *col1)
 	require.Equal(t, v2.To16(), *col2)
+	require.Equal(t, v1.To16(), net.ParseIP(netip.AddrFrom16(*col4).String()).To16())
 }
 
 const invalidIPv6Str = "0:0:0:piyiy:0:0:0:1"
@@ -291,15 +339,42 @@ func TestIPv6_AppendRow(t *testing.T) {
 	if !col.Row(3, false).(net.IP).Equal(ip) {
 		require.Failf(t, "Invalid result of AppendRow", "Added %q instead of %q", col.Row(3, false), ip)
 	}
+
+	// appending [16]byte
+	require.NoError(t, col.AppendRow(netip.MustParseAddr(ip.String()).As16()))
+	require.Equal(t, 5, col.Rows(), "AppendRow didn't add IP")
+	if !col.Row(4, false).(net.IP).Equal(ip) {
+		require.Failf(t, "Invalid result of AppendRow", "Added %q instead of %q", col.Row(4, false), ip)
+	}
+
+	// appending proto.IPv6
+	require.NoError(t, col.AppendRow(proto.IPv6(netip.MustParseAddr(ip.String()).As16())))
+	require.Equal(t, 6, col.Rows(), "AppendRow didn't add IP")
+	if !col.Row(5, false).(net.IP).Equal(ip) {
+		require.Failf(t, "Invalid result of AppendRow", "Added %q instead of %q", col.Row(5, false), ip)
+	}
+
+	// appending [16]byte pointer
+	require.NoError(t, col.AppendRow(&[][16]byte{netip.MustParseAddr(ip.String()).As16()}[0]))
+	require.Equal(t, 7, col.Rows(), "AppendRow didn't add IP")
+	if !col.Row(6, false).(net.IP).Equal(ip) {
+		require.Failf(t, "Invalid result of AppendRow", "Added %q instead of %q", col.Row(6, false), ip)
+	}
+
+	// appending proto.IPv6 pointer
+	require.NoError(t, col.AppendRow(&[]proto.IPv6{proto.IPv6(netip.MustParseAddr(ip.String()).As16())}[0]))
+	require.Equal(t, 8, col.Rows(), "AppendRow didn't add IP")
+	if !col.Row(7, false).(net.IP).Equal(ip) {
+		require.Failf(t, "Invalid result of AppendRow", "Added %q instead of %q", col.Row(7, false), ip)
+	}
+
 }
 
-func TestIPv6_Append(t *testing.T) {
-	ips := getTestIPv6()
-
-	var strIps []string
+func testAppend[T any](t *testing.T, ips []net.IP, convertor func(ip net.IP) T) {
+	var strIps []T
 
 	for _, ip := range ips {
-		strIps = append(strIps, ip.String())
+		strIps = append(strIps, convertor(ip))
 	}
 
 	// appending strings
@@ -313,25 +388,43 @@ func TestIPv6_Append(t *testing.T) {
 			require.Failf(t, "Invalid result of Append", "Added %q instead of %q", col.Row(i, false), ip)
 		}
 	}
+}
 
-	// appending string pointers
-	var strPtrIps []*string
+func TestIPv6_Append(t *testing.T) {
+	ips := getTestIPv6()
 
-	for _, ip := range ips {
+	testAppend(t, ips, func(ip net.IP) string {
+		return ip.String()
+	})
+	testAppend(t, ips, func(ip net.IP) *string {
 		str := ip.String()
-		strPtrIps = append(strPtrIps, &str)
-	}
+		return &str
+	})
+	testAppend(t, ips, func(ip net.IP) [16]byte {
+		return netip.MustParseAddr(ip.String()).As16()
+	})
+	testAppend(t, ips, func(ip net.IP) *[16]byte {
+		return &[][16]byte{netip.MustParseAddr(ip.String()).As16()}[0]
+	})
+	testAppend(t, ips, func(ip net.IP) proto.IPv6 {
+		return netip.MustParseAddr(ip.String()).As16()
+	})
+	testAppend(t, ips, func(ip net.IP) *proto.IPv6 {
+		return &[]proto.IPv6{netip.MustParseAddr(ip.String()).As16()}[0]
+	})
 
-	col = column.IPv6{}
-	_, err = col.Append(strPtrIps)
+}
 
-	require.NoError(t, err)
-	require.Equalf(t, col.Rows(), len(strPtrIps), "Added %d rows instead of %d", col.Rows(), len(strPtrIps))
-	for i, ip := range ips {
-		if !col.Row(i, false).(net.IP).Equal(ip) {
-			require.Failf(t, "Invalid result of Append", "Added %q instead of %q", col.Row(i, false), ip)
+func testScanRow[T any](t *testing.T, col *column.IPv6, ips []net.IP, convertor func(result T, src net.IP) bool) {
+	for i := range ips {
+		var u T
+		err := col.ScanRow(&u, i)
+		require.NoError(t, err)
+		if !convertor(u, ips[i]) {
+			require.Failf(t, "Invalid result of ScanRow", "ScanRow resulted in %q instead of %q", u, ips[i])
 		}
 	}
+
 }
 
 func TestIPv6_ScanRow(t *testing.T) {
@@ -344,31 +437,41 @@ func TestIPv6_ScanRow(t *testing.T) {
 	}
 
 	// scanning ips
-	for i := range ips {
-		var u net.IP
-		err := col.ScanRow(&u, i)
-		require.NoError(t, err)
-		if !u.Equal(ips[i]) {
-			require.Failf(t, "Invalid result of ScanRow", "ScanRow resulted in %q instead of %q", u, ips[i])
-		}
-	}
+	testScanRow(t, &col, ips, func(result net.IP, src net.IP) bool {
+		return result.Equal(src)
+	})
 
 	// scanning strings
-	for i := range ips {
-		var u string
-		err := col.ScanRow(&u, i)
-		require.NoError(t, err)
-		require.Equal(t, ips[i].String(), u)
-	}
+	testScanRow(t, &col, ips, func(result string, src net.IP) bool {
+		return src.String() == result
+	})
 
 	// scanning string pointers
-	for i := range ips {
-		var u *string
-		err := col.ScanRow(&u, i)
-		require.NoError(t, err)
-		require.NotNilf(t, u, "ScanRow resulted nil")
-		require.Equal(t, *u, ips[i].String(), "ScanRow resulted in %q instead of %q", *u, ips[i])
-	}
+	testScanRow(t, &col, ips, func(result *string, src net.IP) bool {
+		return src.String() == *result
+	})
+
+	// scanning [16]byte
+	testScanRow(t, &col, ips, func(result [16]byte, src net.IP) bool {
+		expected := netip.MustParseAddr(src.String()).As16()
+		for i := range expected {
+			if expected[i] != result[i] {
+				return false
+			}
+		}
+		return true
+	})
+
+	// scanning [16]byte pointer
+	testScanRow(t, &col, ips, func(result *[16]byte, src net.IP) bool {
+		expected := netip.MustParseAddr(src.String()).As16()
+		for i := range expected {
+			if expected[i] != (*result)[i] {
+				return false
+			}
+		}
+		return true
+	})
 }
 
 func TestIPv6Flush(t *testing.T) {


### PR DESCRIPTION
## Summary
add support for [16]byte/[]byte IPv6 columns #976 
## Checklist
- [x] Unit and integration tests covering the common scenarios were added
