### PR TITLE
Add custom dialer option to http based conn

### DIFF
--- a/conn_http.go
+++ b/conn_http.go
@@ -25,7 +25,6 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2/resources"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -35,6 +34,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/resources"
 
 	"github.com/ClickHouse/ch-go/compress"
 	chproto "github.com/ClickHouse/ch-go/proto"
@@ -209,6 +210,12 @@ func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpCon
 		IdleConnTimeout:       opt.ConnMaxLifetime,
 		ResponseHeaderTimeout: opt.ReadTimeout,
 		TLSClientConfig:       opt.TLS,
+	}
+
+	if opt.DialContext != nil {
+		t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return opt.DialContext(ctx, addr)
+		}
 	}
 
 	conn := &httpConnect{

--- a/tests/custom_dial_test.go
+++ b/tests/custom_dial_test.go
@@ -20,12 +20,14 @@ package tests
 import (
 	"context"
 	"crypto/tls"
+	"database/sql"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"net"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
@@ -77,4 +79,45 @@ func TestCustomDialContext(t *testing.T) {
 		assert.Equal(t, 1, dialCount)
 	}
 	assert.True(t, time.Since(start) < time.Second)
+}
+
+func TestCustomHTTPDialContext(t *testing.T) {
+	env, err := GetNativeTestEnvironment()
+	require.NoError(t, err)
+	var (
+		dialCount int
+	)
+	useSSL, err := strconv.ParseBool(GetEnv("CLICKHOUSE_USE_SSL", "false"))
+	require.NoError(t, err)
+	port := env.HttpPort
+	var tlsConfig *tls.Config
+	if useSSL {
+		port = env.SslPort
+		tlsConfig = &tls.Config{}
+	}
+	connector := clickhouse.Connector(&clickhouse.Options{
+		Addr:     []string{fmt.Sprintf("%s:%d", env.Host, port)},
+		Protocol: clickhouse.HTTP,
+		Auth: clickhouse.Auth{
+			Database: "default",
+			Username: env.Username,
+			Password: env.Password,
+		},
+		DialContext: func(ctx context.Context, addr string) (net.Conn, error) {
+			dialCount++
+			var d net.Dialer
+			if tlsConfig != nil {
+				return tls.DialWithDialer(&net.Dialer{Timeout: time.Duration(5) * time.Second}, "tcp", addr, tlsConfig)
+			}
+			return d.DialContext(ctx, "tcp", addr)
+		},
+		TLS: tlsConfig,
+	})
+	conn, err := connector.Connect(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	db := sql.OpenDB(connector)
+	require.Equal(t, 1, dialCount)
+	err = db.Ping()
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary
This PR adds the ability to use the custom dialer on the http based connection. Previously, even when you set the custom dialer, it was overwritten if http was used [here](https://github.com/ClickHouse/clickhouse-go/blob/958b91787564e79ab54a01ab8285fd7a917176e4/conn_http.go#L204). This ensures the new custom dialer is used, if set.