### PR TITLE
Remove incorrect usage of KeepAlive in DialContext

### DIFF
--- a/conn_http.go
+++ b/conn_http.go
@@ -203,8 +203,7 @@ func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpCon
 	t := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
-			Timeout:   opt.DialTimeout,
-			KeepAlive: opt.ConnMaxLifetime,
+			Timeout: opt.DialTimeout,
 		}).DialContext,
 		MaxIdleConns:          1,
 		IdleConnTimeout:       opt.ConnMaxLifetime,


### PR DESCRIPTION
Given the `KeepAlive` implementation comment:

```
	// KeepAlive specifies the interval between keep-alive
	// probes for an active network connection.
	// If zero, keep-alive probes are sent with a default value
	// (currently 15 seconds), if supported by the protocol and operating
	// system. Network protocols or operating systems that do
	// not support keep-alives ignore this field.
	// If negative, keep-alive probes are disabled.
```	


having `KeepAlive` value set to `opt.ConnMaxLifetime` makes TCP connections broken. 