### PR TITLE
Fix startAutoCloseIdleConnections cause goroutine leak

### DIFF
--- a/tests/conn_test.go
+++ b/tests/conn_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"os"
+	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -400,4 +401,25 @@ func getActiveConnections(t *testing.T, client clickhouse.Conn) (conns int64) {
 	require.NoError(t, r.Err())
 	require.NoError(t, r.Scan(&conns))
 	return conns
+}
+
+func TestConnectionCloseIdle(t *testing.T) {
+	runInDocker, _ := strconv.ParseBool(GetEnv("CLICKHOUSE_USE_DOCKER", "true"))
+	if !runInDocker {
+		t.Skip("Skip test in cloud environment. This test is not stable in cloud environment, due to race conditions.")
+	}
+	testEnv, err := GetTestEnvironment(testSet)
+	require.NoError(t, err)
+	baseGoroutine := runtime.NumGoroutine()
+	for i := 0; i < 100; i++ {
+		ctx := context.Background()
+		conn, err := TestClientWithDefaultSettings(testEnv)
+		require.NoError(t, err)
+		err = conn.Ping(ctx)
+		conn.Close()
+		require.NoError(t, err)
+	}
+	time.Sleep(100 * time.Millisecond) // wait for all connections closed
+	finalGoroutine := runtime.NumGoroutine()
+	assert.Equal(t, baseGoroutine, finalGoroutine)
 }


### PR DESCRIPTION
## Summary
In the submission of [#999](https://github.com/ClickHouse/clickhouse-go/pull/999), if a connection idle time exceeds `ConnMaxLifetime`, the connection will be closed, thus introducing the following code:

```go
func (ch *clickhouse) startAutoCloseIdleConnections() {
	ticker := time.NewTicker(ch.opt.ConnMaxLifetime)
	defer ticker.Stop()

        for {
		select {
		case <-ticker.C:
			ch.closeIdleExpired()
		}
	}
}
```

But this code is seriously bugged because `defer ticker.Stop()` will NEVER be executed, and the `for` loop will NEVER exit! Therefore, every time a new connection is created using the `Open` function, a new goroutine is created and can never be destroyed.
My test code is as follows:

```go
package main

import (
        "context"
        "fmt"
        "net"
        "runtime"
        "time"

        "github.com/ClickHouse/clickhouse-go/v2"
        "github.com/ClickHouse/clickhouse-go/v2/lib/driver"
)

func connect() (driver.Conn, error) {
        var (
                ctx       = context.Background()
                conn, err = clickhouse.Open(&clickhouse.Options{
                        Addr: []string{net.JoinHostPort("localhost", "9000")},
                        Auth: clickhouse.Auth{
                                Database: "default",
                                Username: "default",
                                Password: "123456",
                        },
                })
        )

        if err != nil {
                return nil, err
        }

        if err := conn.Ping(ctx); err != nil {
                conn.Close()
                return nil, err
        }
        return conn, nil
}

func main() {
        baseGoroutine := runtime.NumGoroutine()
        conns := make([]driver.Conn, 100)
        for i := 0; i < 100; i++ {
                conn, err := connect()
                if err == nil {
                        conns[i] = conn
                }
        }

        fmt.Printf("Running goroutine: %d\n", runtime.NumGoroutine() - baseGoroutine)
        for _, conn := range conns {
                if conn != nil {
                        conn.Close()
                } else {
                        fmt.Println("conn is null")
                }
        }
        time.Sleep(100 * time.Millisecond)
        fmt.Printf("final goroutine: %d\n", runtime.NumGoroutine() - baseGoroutine)
}
```


I create `100` connections and close them without doing anything, but there are still `100` goroutines left that cannot be destroyed.

The code execution result is as follows：

```bash
# go run main.go 
Running goroutine: 100
final goroutine: 100
```

If connections can be created successfully, more professional developers will maintain a pool of connections, which usually does not result in unlimited growth of connections, and goroutine leakage is manageable. But if the `Open` call succeeds and the `Ping` fails, then the goroutine is out of control forever. 

For example, to connect to clickhouse in a scheduled task, and then process some business logic, but the connection fails, there will be an infinite number of coroutines, which cannot be destroyed unless you restart your program.
My PR will fix [#999](https://github.com/ClickHouse/clickhouse-go/pull/999) goroutines leak problem, when the `Close` function is invoked, to signal `startAutoCloseIdleConnections` function exit.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
