### PR TITLE
Force disable reaper for testcontainers

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -162,6 +162,7 @@ func CreateClickHouseTestEnvironment(testSet string) (ClickHouseTestEnvironment,
 		Resources: container.Resources{
 			Ulimits: expected,
 		},
+		SkipReaper: true,
 	}
 	clickhouseContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -601,6 +601,7 @@ func CreateTinyProxyTestEnvironment(t *testing.T) (TinyProxyTestEnvironment, err
 		ExposedPorts: []string{"8888/tcp"},
 		WaitingFor:   wait.ForListeningPort("8888/tcp").WithStartupTimeout(time.Second * time.Duration(120)),
 		Cmd:          []string{"--enable-debug", "ANY"},
+		SkipReaper:   true,
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -540,6 +540,7 @@ func CreateNginxReverseProxyTestEnvironment(clickhouseEnv ClickHouseTestEnvironm
 		ExposedPorts: []string{"80/tcp"},
 		WaitingFor:   wait.ForListeningPort("80/tcp").WithStartupTimeout(time.Second * time.Duration(120)),
 		Cmd:          []string{},
+		SkipReaper:   true,
 	}
 	nginxContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: nginxReq,


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
