### PR TITLE
Force use Go 1.19.10, 1.20.5 in GH Actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,7 @@ jobs:
       max-parallel: 1
       matrix:
         go:
-          - "1.19"
+          - "1.19.10"
           - "1.20.5"
         clickhouse: # https://github.com/ClickHouse/ClickHouse/blob/master/SECURITY.md#scope-and-supported-versions
           - "22.3"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         go:
           - "1.19"
-          - "1.20"
+          - "1.20.5"
         clickhouse: # https://github.com/ClickHouse/ClickHouse/blob/master/SECURITY.md#scope-and-supported-versions
           - "22.3"
           - "22.8"


### PR DESCRIPTION
There is an issue with recent changes introduced in Go 1.20.6 stdlib. More details in https://github.com/testcontainers/testcontainers-go/issues/1359

This should be revert once either testcontainers is fixed or Go has stdlib fixed.