### PR TITLE
Fix send query on batch retry

### DIFF
--- a/conn_batch.go
+++ b/conn_batch.go
@@ -76,6 +76,7 @@ func (c *connect) prepareBatch(ctx context.Context, query string, release func(*
 	}
 	return &batch{
 		ctx:         ctx,
+		query:       query,
 		conn:        c,
 		block:       block,
 		released:    false,
@@ -88,6 +89,7 @@ func (c *connect) prepareBatch(ctx context.Context, query string, release func(*
 type batch struct {
 	err         error
 	ctx         context.Context
+	query       string
 	conn        *connect
 	sent        bool
 	released    bool
@@ -196,13 +198,38 @@ func (b *batch) retry() (err error) {
 		return ErrBatchNotSent
 	}
 
+	if err = b.resetConnection(); err != nil {
+		return err
+	}
+
+	b.sent = false
+	b.released = false
+	return b.Send()
+}
+
+func (b *batch) resetConnection() (err error) {
 	// acquire a new conn
 	if b.conn, err = b.connAcquire(b.ctx); err != nil {
 		return err
 	}
-	b.sent = false
-	b.released = false
-	return b.Send()
+
+	options := queryOptions(b.ctx)
+	if deadline, ok := b.ctx.Deadline(); ok {
+		b.conn.conn.SetDeadline(deadline)
+		defer b.conn.conn.SetDeadline(time.Time{})
+	}
+
+	if err = b.conn.sendQuery(b.query, &options); err != nil {
+		b.release(err)
+		return err
+	}
+
+	if _, err = b.conn.firstBlock(b.ctx, b.onProcess); err != nil {
+		b.release(err)
+		return err
+	}
+
+	return nil
 }
 
 func (b *batch) Flush() error {


### PR DESCRIPTION
Hi, now `retry()` create empty connection, without `INSERT INTO` statement, because of this, it cannot be used.
