### PR TITLE
Binding arguments for AsyncInsert interface

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -20,6 +20,7 @@ package clickhouse
 import (
 	std_driver "database/sql/driver"
 	"fmt"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"reflect"
 	"regexp"
 	"strings"
@@ -279,6 +280,22 @@ func format(tz *time.Location, scale TimeUnit, v any) (string, error) {
 		return fmt.Sprintf("[%s]", val), nil
 	case fmt.Stringer:
 		return quote(v.String()), nil
+	case column.OrderedMap:
+		values := make([]string, 0)
+		for key := range v.Keys() {
+			name, err := format(tz, scale, key)
+			if err != nil {
+				return "", err
+			}
+			value, _ := v.Get(key)
+			val, err := format(tz, scale, value)
+			if err != nil {
+				return "", err
+			}
+			values = append(values, fmt.Sprintf("%s, %s", name, val))
+		}
+
+		return "map(" + strings.Join(values, ", ") + ")", nil
 	}
 	switch v := reflect.ValueOf(v); v.Kind() {
 	case reflect.String:

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -165,12 +165,12 @@ func (ch *clickhouse) PrepareBatch(ctx context.Context, query string) (driver.Ba
 	return batch, nil
 }
 
-func (ch *clickhouse) AsyncInsert(ctx context.Context, query string, wait bool) error {
+func (ch *clickhouse) AsyncInsert(ctx context.Context, query string, wait bool, args ...any) error {
 	conn, err := ch.acquire(ctx)
 	if err != nil {
 		return err
 	}
-	if err := conn.asyncInsert(ctx, query, wait); err != nil {
+	if err := conn.asyncInsert(ctx, query, wait, args...); err != nil {
 		ch.release(conn, err)
 		return err
 	}

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -171,7 +171,7 @@ type stdConnect interface {
 	exec(ctx context.Context, query string, args ...any) error
 	ping(ctx context.Context) (err error)
 	prepareBatch(ctx context.Context, query string, release func(*connect, error), acquire func(context.Context) (*connect, error)) (ldriver.Batch, error)
-	asyncInsert(ctx context.Context, query string, wait bool) error
+	asyncInsert(ctx context.Context, query string, wait bool, args ...any) error
 }
 
 type stdDriver struct {
@@ -236,10 +236,7 @@ func (std *stdDriver) CheckNamedValue(nv *driver.NamedValue) error { return nil 
 
 func (std *stdDriver) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 	if options := queryOptions(ctx); options.async.ok {
-		if len(args) != 0 {
-			return nil, errors.New("clickhouse: you can't use parameters in an asynchronous insert")
-		}
-		return driver.RowsAffected(0), std.conn.asyncInsert(ctx, query, options.async.wait)
+		return driver.RowsAffected(0), std.conn.asyncInsert(ctx, query, options.async.wait, rebind(args)...)
 	}
 	if err := std.conn.exec(ctx, query, rebind(args)...); err != nil {
 		if isConnBrokenError(err) {

--- a/conn_async_insert.go
+++ b/conn_async_insert.go
@@ -19,9 +19,10 @@ package clickhouse
 
 import (
 	"context"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
-func (c *connect) asyncInsert(ctx context.Context, query string, wait bool) error {
+func (c *connect) asyncInsert(ctx context.Context, query string, wait bool, args ...any) error {
 	options := queryOptions(ctx)
 	{
 		options.settings["async_insert"] = 1
@@ -30,6 +31,16 @@ func (c *connect) asyncInsert(ctx context.Context, query string, wait bool) erro
 			options.settings["wait_for_async_insert"] = 1
 		}
 	}
+
+	if len(args) > 0 {
+		queryParamsProtocolSupport := c.revision >= proto.DBMS_MIN_PROTOCOL_VERSION_WITH_PARAMETERS
+		var err error
+		query, err = bindQueryOrAppendParameters(queryParamsProtocolSupport, &options, query, c.server.Timezone, args...)
+		if err != nil {
+			return err
+		}
+	}
+
 	if err := c.sendQuery(query, &options); err != nil {
 		return err
 	}

--- a/conn_http_async_insert.go
+++ b/conn_http_async_insert.go
@@ -23,7 +23,7 @@ import (
 	"io/ioutil"
 )
 
-func (h *httpConnect) asyncInsert(ctx context.Context, query string, wait bool) error {
+func (h *httpConnect) asyncInsert(ctx context.Context, query string, wait bool, args ...any) error {
 
 	options := queryOptions(ctx)
 	options.settings["async_insert"] = 1
@@ -31,6 +31,14 @@ func (h *httpConnect) asyncInsert(ctx context.Context, query string, wait bool) 
 	if wait {
 		options.settings["wait_for_async_insert"] = 1
 	}
+	if len(args) > 0 {
+		var err error
+		query, err = bindQueryOrAppendParameters(true, &options, query, h.location, args...)
+		if err != nil {
+			return err
+		}
+	}
+
 	res, err := h.sendQuery(ctx, query, &options, h.headers)
 	if res != nil {
 		defer res.Body.Close()

--- a/examples/clickhouse_api/async.go
+++ b/examples/clickhouse_api/async.go
@@ -19,7 +19,6 @@ package clickhouse_api
 
 import (
 	"context"
-	"fmt"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
@@ -49,9 +48,9 @@ func AsyncInsert() error {
 		return err
 	}
 	for i := 0; i < 100; i++ {
-		if err := conn.AsyncInsert(ctx, fmt.Sprintf(`INSERT INTO example VALUES (
-			%d, '%s', [1, 2, 3, 4, 5, 6, 7, 8, 9], now()
-		)`, i, "Golang SQL database driver"), false); err != nil {
+		if err := conn.AsyncInsert(ctx, `INSERT INTO example VALUES (
+			?, ?, ?, now()
+		)`, false, i, "Golang SQL database driver", []uint8{1, 2, 3, 4, 5, 6, 7, 8, 9}); err != nil {
 			return err
 		}
 	}

--- a/examples/std/async.go
+++ b/examples/std/async.go
@@ -19,7 +19,6 @@ package std
 
 import (
 	"context"
-	"fmt"
 	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
@@ -45,9 +44,9 @@ func AsyncInsert() error {
 	ctx := clickhouse.Context(context.Background(), clickhouse.WithStdAsync(false))
 	{
 		for i := 0; i < 100; i++ {
-			_, err := conn.ExecContext(ctx, fmt.Sprintf(`INSERT INTO example VALUES (
-				%d, '%s', [1, 2, 3, 4, 5, 6, 7, 8, 9], now()
-			)`, i, "Golang SQL database driver"))
+			_, err := conn.ExecContext(ctx, `INSERT INTO example VALUES (
+				?, ?, ?, now()
+			)`, i, "Golang SQL database driver", []uint8{1, 2, 3, 4, 5, 6, 7, 8, 9})
 			if err != nil {
 				return err
 			}

--- a/lib/driver/driver.go
+++ b/lib/driver/driver.go
@@ -56,7 +56,7 @@ type (
 		QueryRow(ctx context.Context, query string, args ...any) Row
 		PrepareBatch(ctx context.Context, query string) (Batch, error)
 		Exec(ctx context.Context, query string, args ...any) error
-		AsyncInsert(ctx context.Context, query string, wait bool) error
+		AsyncInsert(ctx context.Context, query string, wait bool, args ...any) error
 		Ping(context.Context) error
 		Stats() Stats
 		Close() error


### PR DESCRIPTION
## Summary
Proposal for https://github.com/ClickHouse/clickhouse-go/issues/896, allowing argument replacement in INSERT query strings. To help constructing these for AsyncInserts.

Also adds parsing `OrderedMap` for binding as was done for other arguments here: https://github.com/ClickHouse/clickhouse-go/pull/763

Includes tests, but not yet a changelog. First looking for feedback and will then cleanup where needed.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
