### PR TITLE
Update ClickHouse versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,12 +25,11 @@ jobs:
           - "1.19.10"
           - "1.20.5"
         clickhouse: # https://github.com/ClickHouse/ClickHouse/blob/master/SECURITY.md#scope-and-supported-versions
-          - "22.3"
           - "22.8"
-          - "22.12"
-          - "23.1"
-          - "23.2"
-          - "latest"
+          - "23.3"
+          - "23.5"
+          - "23.6"
+#          - "23.7" - disabled due to backward-compatibility issues with sparse serialization for native protocol
     steps:
       - uses: actions/checkout@main
 


### PR DESCRIPTION
Updates ClickHouse supported versions: https://github.com/ClickHouse/ClickHouse/blob/master/SECURITY.md#scope-and-supported-versions
Also, it's a work-around for #1048