### PR TITLE
Restore test against CH 23.7

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,7 @@ jobs:
           - "23.3"
           - "23.5"
           - "23.6"
-#          - "23.7" - disabled due to backward-compatibility issues with sparse serialization for native protocol
+          - "23.7"
     steps:
       - uses: actions/checkout@main
 


### PR DESCRIPTION
ClickHouse 23.7 has been patched to restore backward compatibility.

resolves #1048 