### PR TITLE
Implement release connection in batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The client is tested against the currently [supported versions](https://github.c
 * Connection pool
 * Failover and load balancing
 * [Bulk write support](examples/clickhouse_api/batch.go) (for `database/sql` [use](examples/std/batch.go) `begin->prepare->(in loop exec)->commit`)
+* [PrepareBatch options](#preparebatch-options)
 * [AsyncInsert](benchmark/v2/write-async/main.go) (more details in [Async insert](#async-insert) section)
 * Named and numeric placeholders support
 * LZ4/ZSTD compression support
@@ -281,6 +282,11 @@ HTTP protocol supports batching. It can be enabled by setting `async_insert` whe
 
 For more details please see [asynchronous inserts](https://clickhouse.com/docs/en/optimize/asynchronous-inserts#enabling-asynchronous-inserts) documentation.
 
+## PrepareBatch options
+
+Available options:
+- [WithReleaseConnection](examples/clickhouse_api/batch_release_connection.go) - after PrepareBatch connection will be returned to the pool. It can help you make a long-lived batch.
+
 ## Benchmark
 
 | [V1 (READ)](benchmark/v1/read/main.go) | [V2 (READ) std](benchmark/v2/read/main.go) | [V2 (READ) clickhouse API](benchmark/v2/read-native/main.go) |
@@ -305,6 +311,7 @@ go get -u github.com/ClickHouse/clickhouse-go/v2
 ### native interface
 
 * [batch](examples/clickhouse_api/batch.go)
+* [batch with release connection](examples/clickhouse_api/batch_release_connection.go)
 * [async insert](examples/clickhouse_api/async.go)
 * [batch struct](examples/clickhouse_api/append_struct.go)
 * [columnar](examples/clickhouse_api/columnar_insert.go)

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -44,12 +44,11 @@ type (
 var (
 	ErrBatchInvalid              = errors.New("clickhouse: batch is invalid. check appended data is correct")
 	ErrBatchAlreadySent          = errors.New("clickhouse: batch has already been sent")
-	ErrBatchNotSent              = errors.New("clickhouse: invalid retry, batch not sent yet")
+	ErrBatchUnexpectedRelease    = errors.New("clickhouse: unexpected connection release")
 	ErrAcquireConnTimeout        = errors.New("clickhouse: acquire conn timeout. you can increase the number of max open conn or the dial timeout")
 	ErrUnsupportedServerRevision = errors.New("clickhouse: unsupported server revision")
 	ErrBindMixedParamsFormats    = errors.New("clickhouse [bind]: mixed named, numeric or positional parameters")
 	ErrAcquireConnNoAddress      = errors.New("clickhouse: no valid address supplied")
-	ErrServerUnexpectedData      = errors.New("code: 101, message: Unexpected packet Data received from client")
 )
 
 type OpError struct {

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -170,7 +170,7 @@ type stdConnect interface {
 	query(ctx context.Context, release func(*connect, error), query string, args ...any) (*rows, error)
 	exec(ctx context.Context, query string, args ...any) error
 	ping(ctx context.Context) (err error)
-	prepareBatch(ctx context.Context, query string, release func(*connect, error), acquire func(context.Context) (*connect, error)) (ldriver.Batch, error)
+	prepareBatch(ctx context.Context, query string, options ldriver.PrepareBatchOptions, release func(*connect, error), acquire func(context.Context) (*connect, error)) (ldriver.Batch, error)
 	asyncInsert(ctx context.Context, query string, wait bool) error
 }
 
@@ -273,7 +273,7 @@ func (std *stdDriver) Prepare(query string) (driver.Stmt, error) {
 }
 
 func (std *stdDriver) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
-	batch, err := std.conn.prepareBatch(ctx, query, func(*connect, error) {}, func(context.Context) (*connect, error) { return nil, nil })
+	batch, err := std.conn.prepareBatch(ctx, query, ldriver.PrepareBatchOptions{}, func(*connect, error) {}, func(context.Context) (*connect, error) { return nil, nil })
 	if err != nil {
 		if isConnBrokenError(err) {
 			std.debugf("PrepareContext got a fatal error, resetting connection: %v\n", err)

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -118,6 +118,11 @@ func (b *httpBatch) Flush() error {
 	return nil
 }
 
+// ReleaseConnection doesn't support by HTTP batch.
+func (b *httpBatch) ReleaseConnection() error {
+	return nil
+}
+
 func (b *httpBatch) Abort() error {
 	defer func() {
 		b.sent = true

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -33,8 +33,9 @@ import (
 // \x60 represents a backtick
 var httpInsertRe = regexp.MustCompile(`(?i)^INSERT INTO\s+\x60?([\w.^\(]+)\x60?\s*(\([^\)]*\))?`)
 
-// release is ignored, because http used by std with empty release function
-func (h *httpConnect) prepareBatch(ctx context.Context, query string, release func(*connect, error), acquire func(context.Context) (*connect, error)) (driver.Batch, error) {
+// release is ignored, because http used by std with empty release function.
+// Also opts ignored because all options unused in http batch.
+func (h *httpConnect) prepareBatch(ctx context.Context, query string, opts driver.PrepareBatchOptions, release func(*connect, error), acquire func(context.Context) (*connect, error)) (driver.Batch, error) {
 	matches := httpInsertRe.FindStringSubmatch(query)
 	if len(matches) < 3 {
 		return nil, errors.New("cannot get table name from query")
@@ -115,11 +116,6 @@ type httpBatch struct {
 
 // Flush TODO: noop on http currently - requires streaming to be implemented
 func (b *httpBatch) Flush() error {
-	return nil
-}
-
-// ReleaseConnection doesn't support by HTTP batch.
-func (b *httpBatch) ReleaseConnection() error {
 	return nil
 }
 

--- a/examples/clickhouse_api/batch_release_connection.go
+++ b/examples/clickhouse_api/batch_release_connection.go
@@ -1,0 +1,133 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package clickhouse_api
+
+import (
+	"context"
+	"errors"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+)
+
+func BatchWithReleaseConnection() error {
+	conn, err := GetNativeConnection(nil, nil, nil)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE example")
+	}()
+	if err := conn.Exec(ctx, `DROP TABLE IF EXISTS example`); err != nil {
+		return err
+	}
+	err = conn.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS example (
+			Col1 UInt64,
+			Col2 String
+		) engine=Memory
+	`)
+
+	batch, err := New(ctx, conn, "INSERT INTO example")
+	if err != nil {
+		return err
+	}
+
+	if err = batch.Append(1, "test-1"); err != nil {
+		return err
+	}
+
+	if err = batch.Send(); err != nil {
+		return err
+	}
+
+	if err = batch.Append(2, "test-2"); err != nil {
+		return err
+	}
+
+	if err = batch.Send(); err != nil {
+		return err
+	}
+
+	var count uint64
+	if err = conn.QueryRow(context.Background(), `SELECT COUNT(*) FROM example`).Scan(&count); err != nil {
+		return err
+	}
+
+	if count != uint64(2) {
+		return errors.New("count must be 2")
+	}
+
+	return nil
+}
+
+type YourBatch struct {
+	ctx context.Context
+
+	insertStatement string
+
+	conn  driver.Conn
+	batch driver.Batch
+}
+
+func New(ctx context.Context, conn driver.Conn, insertStatement string) (*YourBatch, error) {
+	batch, err := conn.PrepareBatch(ctx, insertStatement)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = batch.ReleaseConnection(); err != nil {
+		return nil, err
+	}
+
+	return &YourBatch{
+		ctx:             ctx,
+		insertStatement: insertStatement,
+		conn:            conn,
+		batch:           batch,
+	}, nil
+}
+
+func (b *YourBatch) Append(col1 uint64, col2 string) error {
+	return b.batch.Append(
+		col1,
+		col2,
+	)
+}
+
+func (b *YourBatch) Send() error {
+	if err := b.batch.Send(); err != nil {
+		return err
+	}
+
+	return b.reset()
+}
+
+func (b *YourBatch) reset() error {
+	batch, err := b.conn.PrepareBatch(b.ctx, b.insertStatement)
+	if err != nil {
+		return err
+	}
+
+	if err = batch.ReleaseConnection(); err != nil {
+		return err
+	}
+
+	b.batch = batch
+
+	return nil
+}

--- a/examples/clickhouse_api/batch_release_connection.go
+++ b/examples/clickhouse_api/batch_release_connection.go
@@ -85,12 +85,8 @@ type YourBatch struct {
 }
 
 func New(ctx context.Context, conn driver.Conn, insertStatement string) (*YourBatch, error) {
-	batch, err := conn.PrepareBatch(ctx, insertStatement)
+	batch, err := conn.PrepareBatch(ctx, insertStatement, driver.WithReleaseConnection())
 	if err != nil {
-		return nil, err
-	}
-
-	if err = batch.ReleaseConnection(); err != nil {
 		return nil, err
 	}
 
@@ -118,12 +114,8 @@ func (b *YourBatch) Send() error {
 }
 
 func (b *YourBatch) reset() error {
-	batch, err := b.conn.PrepareBatch(b.ctx, b.insertStatement)
+	batch, err := b.conn.PrepareBatch(b.ctx, b.insertStatement, driver.WithReleaseConnection())
 	if err != nil {
-		return err
-	}
-
-	if err = batch.ReleaseConnection(); err != nil {
 		return err
 	}
 

--- a/examples/clickhouse_api/main_test.go
+++ b/examples/clickhouse_api/main_test.go
@@ -87,6 +87,10 @@ func TestBatchInsert(t *testing.T) {
 	require.NoError(t, BatchInsert())
 }
 
+func TestBatchWithReleaseConnection(t *testing.T) {
+	require.NoError(t, BatchWithReleaseConnection())
+}
+
 func TestAuthConnect(t *testing.T) {
 	require.NoError(t, Auth())
 }

--- a/lib/driver/driver.go
+++ b/lib/driver/driver.go
@@ -84,6 +84,7 @@ type (
 		Flush() error
 		Send() error
 		IsSent() bool
+		ReleaseConnection() error
 	}
 	BatchColumn interface {
 		Append(any) error

--- a/lib/driver/driver.go
+++ b/lib/driver/driver.go
@@ -54,7 +54,7 @@ type (
 		Select(ctx context.Context, dest any, query string, args ...any) error
 		Query(ctx context.Context, query string, args ...any) (Rows, error)
 		QueryRow(ctx context.Context, query string, args ...any) Row
-		PrepareBatch(ctx context.Context, query string) (Batch, error)
+		PrepareBatch(ctx context.Context, query string, opts ...PrepareBatchOption) (Batch, error)
 		Exec(ctx context.Context, query string, args ...any) error
 		AsyncInsert(ctx context.Context, query string, wait bool) error
 		Ping(context.Context) error
@@ -84,7 +84,6 @@ type (
 		Flush() error
 		Send() error
 		IsSent() bool
-		ReleaseConnection() error
 	}
 	BatchColumn interface {
 		Append(any) error

--- a/lib/driver/options.go
+++ b/lib/driver/options.go
@@ -1,0 +1,13 @@
+package driver
+
+type PrepareBatchOptions struct {
+	ReleaseConnection bool
+}
+
+type PrepareBatchOption func(options *PrepareBatchOptions)
+
+func WithReleaseConnection() PrepareBatchOption {
+	return func(options *PrepareBatchOptions) {
+		options.ReleaseConnection = true
+	}
+}

--- a/tests/batch_release_connection_test.go
+++ b/tests/batch_release_connection_test.go
@@ -1,0 +1,76 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestBatchReleaseConnection(t *testing.T) {
+	conn, err := GetNativeConnection(nil, nil, &clickhouse.Compression{
+		Method: clickhouse.CompressionLZ4,
+	})
+	ctx := context.Background()
+	require.NoError(t, err)
+
+	const tableName = "test_release_connection"
+
+	var ddl = fmt.Sprintf(`
+		CREATE TABLE %s (
+			  Col1 UInt64
+			, Col2 String
+		) Engine MergeTree() ORDER BY tuple()
+		`, tableName)
+	defer func() {
+		dropTable(conn, tableName)
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s", tableName))
+	require.NoError(t, err)
+	require.NoError(t, batch.Append(uint64(1), "test"))
+
+	require.NoError(t, batch.ReleaseConnection())
+	require.Error(t, batch.ReleaseConnection())
+
+	require.NoError(t, batch.Send())
+	require.Equal(t, uint64(1), getRowsCount(t, conn, tableName))
+
+	require.NoError(t, batch.Send())
+	require.Equal(t, uint64(2), getRowsCount(t, conn, tableName))
+
+	deduplicateTable(t, conn, tableName)
+	require.Equal(t, uint64(1), getRowsCount(t, conn, tableName))
+}
+
+func TestBatchReleaseConnectionFlush(t *testing.T) {
+	conn, err := GetNativeConnection(nil, nil, &clickhouse.Compression{
+		Method: clickhouse.CompressionLZ4,
+	})
+	ctx := context.Background()
+	require.NoError(t, err)
+
+	const tableName = "test_release_connection_flush"
+
+	var ddl = fmt.Sprintf(`
+		CREATE TABLE %s (
+			  Col1 UInt64
+			, Col2 String
+		) Engine MergeTree() ORDER BY tuple()
+		`, tableName)
+	defer func() {
+		dropTable(conn, tableName)
+	}()
+	require.NoError(t, conn.Exec(ctx, ddl))
+	batch, err := conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s", tableName))
+	require.NoError(t, err)
+	require.NoError(t, batch.Append(uint64(1), "test"))
+
+	require.NoError(t, batch.ReleaseConnection())
+	require.NoError(t, batch.Flush())
+	require.Error(t, batch.ReleaseConnection())
+	require.NoError(t, batch.Send())
+
+	require.Equal(t, uint64(1), getRowsCount(t, conn, tableName))
+}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -446,6 +446,17 @@ func getDatabaseName(testSet string) string {
 	return fmt.Sprintf("clickhouse-go-%s-%s-%d", testSet, testUUID, testTimestamp)
 }
 
+func getRowsCount(t *testing.T, conn driver.Conn, table string) uint64 {
+	var count uint64
+	err := conn.QueryRow(context.Background(), fmt.Sprintf(`SELECT COUNT(*) FROM %s`, table)).Scan(&count)
+	require.NoError(t, err)
+	return count
+}
+
+func deduplicateTable(t *testing.T, conn driver.Conn, table string) {
+	require.NoError(t, conn.Exec(context.Background(), fmt.Sprintf(`OPTIMIZE TABLE %s DEDUPLICATE`, table)))
+}
+
 func GetEnv(key, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value


### PR DESCRIPTION
With this change, you can append to the batch directly without using helper structures (slice). Earlier this led to an empty pool, although it is not necessary to keep the connection in the batcher for the append operation.

In our implementation we saved about 2GB of memory per pod.

<img width="1361" alt="screen" src="https://github.com/ClickHouse/clickhouse-go/assets/36516357/d383b378-d8f3-4029-ac80-2dfdf2667531">

Close #1047 