### PR TITLE
Add FreeBufOnConnRelease to clickhouse.Options

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -26,6 +26,7 @@ import (
 
 	_ "time/tzdata"
 
+	chproto "github.com/ClickHouse/ch-go/proto"
 	"github.com/ClickHouse/clickhouse-go/v2/contributors"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -345,6 +346,9 @@ func (ch *clickhouse) release(conn *connect, err error) {
 	if err != nil || time.Since(conn.connectedAt) >= ch.opt.ConnMaxLifetime {
 		conn.close()
 		return
+	}
+	if ch.opt.FreeBufOnConnRelease {
+		conn.buffer = new(chproto.Buffer)
 	}
 	select {
 	case ch.idle <- conn:

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -138,6 +138,7 @@ type Options struct {
 	MaxIdleConns         int           // default 5
 	ConnMaxLifetime      time.Duration // default 1 hour
 	ConnOpenStrategy     ConnOpenStrategy
+	FreeBufOnConnRelease bool              // drop preserved memory buffer after each query
 	HttpHeaders          map[string]string // set additional headers on HTTP requests
 	HttpUrlPath          string            // set additional URL path for HTTP requests
 	BlockBufferSize      uint8             // default 2 - can be overwritten on query


### PR DESCRIPTION
## Summary
Add a flag to `clickhouse.Options` which will trigger connection's buffer being dropped on query execution finish
Resolves issue #1086

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
