### PR TITLE
Improving object allocation for (positional) parameter binding

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -244,9 +244,11 @@ func formatTime(tz *time.Location, scale TimeUnit, value time.Time) (string, err
 	return fmt.Sprintf("toDateTime64('%s', %d, '%s')", value.Format(fmt.Sprintf("2006-01-02 15:04:05.%0*d", int(scale*3), 0)), int(scale*3), value.Location().String()), nil
 }
 
+var stringQuoteReplacer = strings.NewReplacer(`\`, `\\`, `'`, `\'`)
+
 func format(tz *time.Location, scale TimeUnit, v any) (string, error) {
 	quote := func(v string) string {
-		return "'" + strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(v) + "'"
+		return "'" + stringQuoteReplacer.Replace(v) + "'"
 	}
 	switch v := v.(type) {
 	case nil:

--- a/bind.go
+++ b/bind.go
@@ -155,6 +155,11 @@ func bindPositional(tz *time.Location, query string, args ...any) (_ string, err
 		}
 	}
 
+	// If there were no replacements, quick return without copying the string
+	if lastMatchIndex < 0 {
+		return query, nil
+	}
+
 	// Append the remainder
 	buf = append(buf, query[lastMatchIndex+1:]...)
 

--- a/bind.go
+++ b/bind.go
@@ -110,41 +110,59 @@ func checkAllNamedArguments(args ...any) (bool, error) {
 	return haveNamed, nil
 }
 
-var bindPositionCharRe = regexp.MustCompile(`[?]`)
-
 func bindPositional(tz *time.Location, query string, args ...any) (_ string, err error) {
 	var (
-		unbind = make(map[int]struct{})
-		params = make([]string, len(args))
+		lastMatchIndex = -1 // Position of previous match for copying
+		argIndex       = 0  // Index for the argument at current position
+		buf            = make([]byte, 0, len(query))
+		unbindCount    = 0 // Number of positional arguments that couldn't be matched
 	)
-	for i, v := range args {
-		if fn, ok := v.(std_driver.Valuer); ok {
-			if v, err = fn.Value(); err != nil {
-				return "", nil
+
+	for i := 0; i < len(query); i++ {
+		// It's fine looping through the query string as bytes, because the (fixed) characters we're looking for
+		// are in the ASCII range to won't take up more than one byte.
+		if query[i] == '?' {
+			if i > 0 && query[i-1] == '\\' {
+				// Copy all previous index to here characters
+				buf = append(buf, query[lastMatchIndex+1:i-1]...)
+				buf = append(buf, '?')
+			} else {
+				// Copy all previous index to here characters
+				buf = append(buf, query[lastMatchIndex+1:i]...)
+
+				// Append the argument value
+				if argIndex < len(args) {
+					v := args[argIndex]
+					if fn, ok := v.(std_driver.Valuer); ok {
+						if v, err = fn.Value(); err != nil {
+							return "", nil
+						}
+					}
+
+					value, err := format(tz, Seconds, v)
+					if err != nil {
+						return "", err
+					}
+
+					buf = append(buf, value...)
+					argIndex++
+				} else {
+					unbindCount++
+				}
 			}
-		}
-		params[i], err = format(tz, Seconds, v)
-		if err != nil {
-			return "", err
+
+			lastMatchIndex = i
 		}
 	}
-	i := 0
-	query = bindPositionalRe.ReplaceAllStringFunc(query, func(n string) string {
-		if i >= len(params) {
-			unbind[i] = struct{}{}
-			return ""
-		}
-		val := params[i]
-		i++
-		return bindPositionCharRe.ReplaceAllStringFunc(n, func(m string) string {
-			return val
-		})
-	})
-	for param := range unbind {
-		return "", fmt.Errorf("have no arg for param ? at position %d", param)
+
+	// Append the remainder
+	buf = append(buf, query[lastMatchIndex+1:]...)
+
+	if unbindCount > 0 {
+		return "", fmt.Errorf("have no arg for param ? at last %d positions", unbindCount)
 	}
-	// replace \? escape sequence
-	return strings.ReplaceAll(query, "\\?", "?"), nil
+
+	return string(buf), nil
 }
 
 func bindNumeric(tz *time.Location, query string, args ...any) (_ string, err error) {


### PR DESCRIPTION
## Summary

I noticed _very_ high object allocation count with the ClickHouse Go client in our code. While with binding the parameters to a `String` this is logical to some extend, I found some easy improvements:

1) Mis-use of the `strings.NewReplacer`, as this instance is meant to be re-used but a new instance was created all the time
2) Replacement of positional arguments in the query string, for which not really a regex is needed. Specifically to find `\?` cases, two regex replacements were nested, creating a temporary string instance that shouldn't be needed. So I changed to code to a 'simple' loop that copies byte sequences.

Original object allocation:
![2023-09-11-10-21-14_1899x227](https://github.com/ClickHouse/clickhouse-go/assets/954721/1196b672-71cf-4d77-83c9-8a1e0b14b932)


Allocations after just changing `strings.NewReplacer` to be called once:
![2023-09-11-10-21-56_1906x257](https://github.com/ClickHouse/clickhouse-go/assets/954721/4e4664df-1dbc-4400-8ae2-d606a20640a0)


Final result:
![2023-09-11-17-13-17_1901x169](https://github.com/ClickHouse/clickhouse-go/assets/954721/562fddaf-fda6-4bac-8983-e74776556b41)

(of course above numbers are case specific, but for our instance this meant going from being responsible for 70% of object allocations to around 30%)


## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
