### PR TITLE
Run CI on self hosted runner

### DIFF
--- a/.github/workflows/run-tests-head.yml
+++ b/.github/workflows/run-tests-head.yml
@@ -11,8 +11,7 @@ jobs:
   test-ch-head:
     runs-on: [self-hosted, style-checker]
     strategy:
-      fail-fast: true
-      max-parallel: 1
+      fail-fast: truek
       matrix:
         go:
           - "1.20"

--- a/.github/workflows/run-tests-head.yml
+++ b/.github/workflows/run-tests-head.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test-ch-head:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, style-checker]
     strategy:
       fail-fast: true
       max-parallel: 1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   single-node:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, style-checker]
     strategy:
       fail-fast: true
       max-parallel: 1
@@ -43,7 +43,7 @@ jobs:
 
   integration-tests-cloud:
     if: ${{ false }}  # disabled for now
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, style-checker]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: [self-hosted, style-checker]
     strategy:
       fail-fast: true
-      max-parallel: 1
       matrix:
         go:
           - "1.20"
@@ -48,7 +47,6 @@ jobs:
       run:
         shell: bash
     strategy:
-      max-parallel: 1
       fail-fast: true
       matrix:
         go:


### PR DESCRIPTION
## Summary

Run CI on a self hosted runner, since shared runner fails on Docker usage