### PR TITLE
Fix truncate ` for HTTP adapter

### DIFF
--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -46,7 +46,7 @@ func (h *httpConnect) prepareBatch(ctx context.Context, query string, opts drive
 		colMatch := strings.TrimSuffix(strings.TrimPrefix(matches[2], "("), ")")
 		rColumns = strings.Split(colMatch, ",")
 		for i := range rColumns {
-			rColumns[i] = strings.TrimSpace(rColumns[i])
+			rColumns[i] = strings.Trim(strings.TrimSpace(rColumns[i]), "`")
 		}
 	}
 	query = "INSERT INTO " + tableName + " FORMAT Native"


### PR DESCRIPTION
allow for escaped columns

## Summary
[<!-- A short description of the changes with a link to an open issue. -->](https://github.com/ClickHouse/clickhouse-go/issues/848)

https://github.com/ClickHouse/clickhouse-go/pull/829/commits/c2f151b96f25ac83a723fd8f2d7a8a5a78d54b20

As the matter of fact, the commit 829 only fixed conn_batch.go, but not fixed conn_http_batch.go, this pr will fix it
https://github.com/ClickHouse/clickhouse-go/issues/848
the 848 issue also reported this problem


