### PR TITLE
Fix: Block stream read process would be terminated by empty block with zero rows

### DIFF
--- a/clickhouse_rows.go
+++ b/clickhouse_rows.go
@@ -52,7 +52,6 @@ next:
 				r.err = err
 				return false
 			}
-			goto next
 		case block := <-r.stream:
 			if block == nil {
 				return false
@@ -63,6 +62,7 @@ next:
 			}
 			r.row, r.block = 0, block
 		}
+		goto next
 	}
 	r.row++
 	return r.row <= r.block.Rows()

--- a/clickhouse_rows_test.go
+++ b/clickhouse_rows_test.go
@@ -1,0 +1,119 @@
+package clickhouse
+
+import (
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/stretchr/testify/assert"
+	"strconv"
+	"testing"
+)
+
+func TestReadWithEmptyBlock(t *testing.T) {
+	blockInitFunc := func() *proto.Block {
+		retVal := &proto.Block{
+			Packet:   0,
+			Columns:  nil,
+			Timezone: nil,
+		}
+		retVal.AddColumn("col1", ("Int64"))
+		retVal.AddColumn("col2", ("String"))
+		return retVal
+	}
+
+	testCases := map[string]struct {
+		actual   func() rows
+		expected int
+	}{
+		"none empty": {
+			func() rows {
+				firstBlock := blockInitFunc()
+				firstBlock.Append(int64(0), strconv.Itoa(0))
+				blockChan := make(chan *proto.Block)
+				go func() {
+					for i := 1; i < 10; i++ {
+						block := blockInitFunc()
+						block.Append(int64(i), strconv.Itoa(i))
+						blockChan <- block
+					}
+					close(blockChan)
+				}()
+				return rows{
+					err:       nil,
+					row:       0,
+					block:     firstBlock,
+					totals:    nil,
+					errors:    nil,
+					stream:    blockChan,
+					columns:   nil,
+					structMap: nil,
+				}
+			},
+			// e.g. clickhouse-go/2.5.1 (lv:go/1.19.5; os:darwin)
+			10,
+		},
+		"all empty": {
+			func() rows {
+				firstBlock := blockInitFunc()
+				blockChan := make(chan *proto.Block)
+				go func() {
+					for i := 1; i < 10; i++ {
+						block := blockInitFunc()
+						blockChan <- block
+					}
+					close(blockChan)
+				}()
+				return rows{
+					err:       nil,
+					row:       0,
+					block:     firstBlock,
+					totals:    nil,
+					errors:    nil,
+					stream:    blockChan,
+					columns:   nil,
+					structMap: nil,
+				}
+			},
+			// e.g. clickhouse-go/2.5.1 (database/sql; lv:go/1.19.5; os:darwin)
+			0,
+		},
+		"some empty": {
+			func() rows {
+				firstBlock := blockInitFunc()
+				blockChan := make(chan *proto.Block)
+				go func() {
+					for i := 1; i < 10; i++ {
+						block := blockInitFunc()
+						if i%2 == 0 {
+							block.Append(int64(i), strconv.Itoa(i))
+						}
+						blockChan <- block
+					}
+					close(blockChan)
+				}()
+				return rows{
+					err:       nil,
+					row:       0,
+					block:     firstBlock,
+					totals:    nil,
+					errors:    nil,
+					stream:    blockChan,
+					columns:   nil,
+					structMap: nil,
+				}
+			},
+			// e.g. clickhouse-go/2.5.1 (database/sql; lv:go/1.19.5; os:darwin)
+			4,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual := testCase.actual()
+
+			rowCnt := 0
+			for actual.Next() {
+				rowCnt++
+			}
+			assert.Equal(t, testCase.expected, rowCnt)
+		})
+	}
+}

--- a/clickhouse_rows_test.go
+++ b/clickhouse_rows_test.go
@@ -47,7 +47,6 @@ func TestReadWithEmptyBlock(t *testing.T) {
 					structMap: nil,
 				}
 			},
-			// e.g. clickhouse-go/2.5.1 (lv:go/1.19.5; os:darwin)
 			10,
 		},
 		"all empty": {
@@ -72,7 +71,6 @@ func TestReadWithEmptyBlock(t *testing.T) {
 					structMap: nil,
 				}
 			},
-			// e.g. clickhouse-go/2.5.1 (database/sql; lv:go/1.19.5; os:darwin)
 			0,
 		},
 		"some empty": {
@@ -100,7 +98,6 @@ func TestReadWithEmptyBlock(t *testing.T) {
 					structMap: nil,
 				}
 			},
-			// e.g. clickhouse-go/2.5.1 (database/sql; lv:go/1.19.5; os:darwin)
 			4,
 		},
 	}


### PR DESCRIPTION
## Summary
Currently, empty row blocks will terminate block stream reading (i.e. `rows.Next() == false` ), this was caused by the fall through [row count increase logic](https://github.com/ClickHouse/clickhouse-go/blob/75abed29e88fa34064d97a63ae10a37c51394899/clickhouse_rows.go#L64C1-L67C9) after block reset.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
