### PR TITLE
Fix an empty JSON map append using _dummy subcolumn

### DIFF
--- a/tests/issues/1113_test.go
+++ b/tests/issues/1113_test.go
@@ -19,12 +19,7 @@ func Test1113(t *testing.T) {
 	)
 	ctx := context.Background()
 	require.NoError(t, err)
-	const ddl = `
-		CREATE TABLE test_1113 (
-			col_1 JSON,
-			col_2 JSON
-		) Engine MergeTree() ORDER BY tuple()
-		`
+	const ddl = "CREATE TABLE test_1113 (col_1 JSON, col_2 JSON) Engine MergeTree() ORDER BY tuple()"
 	require.NoError(t, conn.Exec(ctx, ddl))
 	defer func() {
 		conn.Exec(ctx, "DROP TABLE IF EXISTS test_1113")

--- a/tests/issues/1113_test.go
+++ b/tests/issues/1113_test.go
@@ -1,0 +1,43 @@
+package issues
+
+import (
+	"context"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test1113(t *testing.T) {
+	var (
+		conn, err = clickhouse_tests.GetConnection("issues", clickhouse.Settings{
+			"max_execution_time":             60,
+			"allow_experimental_object_type": true,
+		}, nil, &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		})
+	)
+	ctx := context.Background()
+	require.NoError(t, err)
+	const ddl = `
+		CREATE TABLE test_1113 (
+			col_1 JSON,
+			col_2 JSON
+		) Engine MergeTree() ORDER BY tuple()
+		`
+	require.NoError(t, conn.Exec(ctx, ddl))
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE IF EXISTS test_1113")
+	}()
+
+	batch, err := conn.PrepareBatch(context.Background(), "INSERT INTO test_1113")
+	require.NoError(t, err)
+
+	v1 := map[string]struct {
+		Str string
+	}{"a": {Str: "value"}}
+	v2 := map[string]any{}
+
+	require.NoError(t, batch.Append(v1, v2))
+	require.NoError(t, batch.Send())
+}


### PR DESCRIPTION
if map is empty, we need to create an empty Tuple to make sure subcolumns protocol is happy
_dummy is a ClickHouse internal name for empty Tuple subcolumn
 it has the same effect as `INSERT INTO single_json_type_table VALUES ('{}');`
 
 resolves #1113 