### PR TITLE
Fix insertion of empty map into JSON column by using _dummy subcolumn

### DIFF
--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -501,6 +501,13 @@ func appendStructOrMap(jCol *JSONObject, data any) error {
 				Err:        fmt.Errorf("map keys must be string for column %s", jCol.Name()),
 			}
 		}
+		if jCol.columns == nil && vData.Len() == 0 {
+			// if map is empty, we need to create an empty Tuple to make sure subcolumns protocol is happy
+			// _dummy is a ClickHouse internal name for empty Tuple subcolumn
+			// it has the same effect as `INSERT INTO single_json_type_table VALUES ('{}');`
+			jCol.upsertValue("_dummy", "Int8")
+			return jCol.insertEmptyColumn("_dummy")
+		}
 		return iterateMap(vData, jCol, 0)
 	}
 	return &UnsupportedColumnTypeError{

--- a/tests/issues/1113_test.go
+++ b/tests/issues/1113_test.go
@@ -1,0 +1,39 @@
+package issues
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/require"
+)
+
+func Test1113(t *testing.T) {
+	var (
+		conn, err = clickhouse_tests.GetConnection("issues", clickhouse.Settings{
+			"max_execution_time":             60,
+			"allow_experimental_object_type": true,
+		}, nil, &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		})
+	)
+	ctx := context.Background()
+	require.NoError(t, err)
+	const ddl = "CREATE TABLE test_1113 (col_1 JSON, col_2 JSON) Engine MergeTree() ORDER BY tuple()"
+	require.NoError(t, conn.Exec(ctx, ddl))
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE IF EXISTS test_1113")
+	}()
+
+	batch, err := conn.PrepareBatch(context.Background(), "INSERT INTO test_1113")
+	require.NoError(t, err)
+
+	v1 := map[string]struct {
+		Str string
+	}{"a": {Str: "value"}}
+	v2 := map[string]any{}
+
+	require.NoError(t, batch.Append(v1, v2))
+	require.NoError(t, batch.Send())
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/ClickHouse/clickhouse-go/issues/1113 (in the issue the code to reproduce it)

This PR correctly handles the inputting of an empty map,
by creating an empty tuple to ensure the subcolumns protocol is happy.

The `_dummy` key is a ClickHouse internal name for an empty tuple subcolumn. In fact, it is the same key it gets used when inputting `{}`.

With this PR,
inputting `map[string]any{}` from Go has the same effect as `INSERT INTO single_json_type_table VALUES ('{}');`.

In @jkaflik's PR https://github.com/ClickHouse/clickhouse-go/pull/1115 there are other evaluated fixes/solutions.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG

