### PR TITLE
Fix type match condition using reflection for autogen types

### DIFF
--- a/lib/column/codegen/column.tpl
+++ b/lib/column/codegen/column.tpl
@@ -382,7 +382,7 @@ func (col *{{ .ChType }}) AppendRow(v any) error {
         col.col.Append(val)
 	{{- end }}
 	default:
-		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() || rv.CanConvert(col.ScanType()) {
 			col.col.Append(rv.Convert(col.ScanType()).Interface().({{ .GoType }}))
 		} else {
 			return &ColumnConverterError{

--- a/lib/column/column_gen.go
+++ b/lib/column/column_gen.go
@@ -348,7 +348,7 @@ func (col *Float32) AppendRow(v any) error {
 	case nil:
 		col.col.Append(0)
 	default:
-		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() || rv.CanConvert(col.ScanType()) {
 			col.col.Append(rv.Convert(col.ScanType()).Interface().(float32))
 		} else {
 			return &ColumnConverterError{
@@ -490,7 +490,7 @@ func (col *Float64) AppendRow(v any) error {
 			col.col.Append(0)
 		}
 	default:
-		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() || rv.CanConvert(col.ScanType()) {
 			col.col.Append(rv.Convert(col.ScanType()).Interface().(float64))
 		} else {
 			return &ColumnConverterError{
@@ -640,7 +640,7 @@ func (col *Int8) AppendRow(v any) error {
 		}
 		col.col.Append(val)
 	default:
-		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() || rv.CanConvert(col.ScanType()) {
 			col.col.Append(rv.Convert(col.ScanType()).Interface().(int8))
 		} else {
 			return &ColumnConverterError{
@@ -782,7 +782,7 @@ func (col *Int16) AppendRow(v any) error {
 			col.col.Append(0)
 		}
 	default:
-		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() || rv.CanConvert(col.ScanType()) {
 			col.col.Append(rv.Convert(col.ScanType()).Interface().(int16))
 		} else {
 			return &ColumnConverterError{
@@ -924,7 +924,7 @@ func (col *Int32) AppendRow(v any) error {
 			col.col.Append(0)
 		}
 	default:
-		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() || rv.CanConvert(col.ScanType()) {
 			col.col.Append(rv.Convert(col.ScanType()).Interface().(int32))
 		} else {
 			return &ColumnConverterError{
@@ -1072,7 +1072,7 @@ func (col *Int64) AppendRow(v any) error {
 	case *time.Duration:
 		col.col.Append(int64(*v))
 	default:
-		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() || rv.CanConvert(col.ScanType()) {
 			col.col.Append(rv.Convert(col.ScanType()).Interface().(int64))
 		} else {
 			return &ColumnConverterError{
@@ -1198,7 +1198,7 @@ func (col *UInt8) AppendRow(v any) error {
 		}
 		col.col.Append(t)
 	default:
-		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() || rv.CanConvert(col.ScanType()) {
 			col.col.Append(rv.Convert(col.ScanType()).Interface().(uint8))
 		} else {
 			return &ColumnConverterError{
@@ -1311,7 +1311,7 @@ func (col *UInt16) AppendRow(v any) error {
 	case nil:
 		col.col.Append(0)
 	default:
-		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() || rv.CanConvert(col.ScanType()) {
 			col.col.Append(rv.Convert(col.ScanType()).Interface().(uint16))
 		} else {
 			return &ColumnConverterError{
@@ -1424,7 +1424,7 @@ func (col *UInt32) AppendRow(v any) error {
 	case nil:
 		col.col.Append(0)
 	default:
-		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() || rv.CanConvert(col.ScanType()) {
 			col.col.Append(rv.Convert(col.ScanType()).Interface().(uint32))
 		} else {
 			return &ColumnConverterError{
@@ -1537,7 +1537,7 @@ func (col *UInt64) AppendRow(v any) error {
 	case nil:
 		col.col.Append(0)
 	default:
-		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() && rv.CanConvert(col.ScanType()) {
+		if rv := reflect.ValueOf(v); rv.Kind() == col.ScanType().Kind() || rv.CanConvert(col.ScanType()) {
 			col.col.Append(rv.Convert(col.ScanType()).Interface().(uint64))
 		} else {
 			return &ColumnConverterError{

--- a/tests/base_types_test.go
+++ b/tests/base_types_test.go
@@ -184,7 +184,8 @@ func TestSimpleInt(t *testing.T) {
 	require.NoError(t, conn.Exec(ctx, ddl))
 	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_int")
 	require.NoError(t, err)
-	require.Error(t, batch.Append(222))
+	require.NoError(t, batch.Append(222))
+	require.NoError(t, batch.Send())
 }
 
 func TestNullableInt(t *testing.T) {

--- a/tests/issues/1119_test.go
+++ b/tests/issues/1119_test.go
@@ -1,0 +1,39 @@
+package issues
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/require"
+)
+
+func Test1119(t *testing.T) {
+	var (
+		conn, err = clickhouse_tests.GetConnection("issues", clickhouse.Settings{
+			"max_execution_time":             60,
+			"allow_experimental_object_type": true,
+		}, nil, &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		})
+	)
+	ctx := context.Background()
+	require.NoError(t, err)
+	const ddl = "CREATE TABLE test_1119 (col JSON) Engine MergeTree() ORDER BY tuple()"
+	require.NoError(t, conn.Exec(ctx, ddl))
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE IF EXISTS test_1119")
+	}()
+
+	batch, err := conn.PrepareBatch(context.Background(), "INSERT INTO test_1119")
+	require.NoError(t, err)
+
+	v := map[string]any{
+		"str": "foo",
+		"int": 12,
+	}
+
+	require.NoError(t, batch.Append(v))
+	require.NoError(t, batch.Send())
+}


### PR DESCRIPTION
Resolves #1119 The type should either match or be convertible.
Fixes int cast use case as well.

Credits to [@DimaOne](https://github.com/DimaOne) for providing a solution.