### PR TITLE
Fix README example for Debugf

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Support for the ClickHouse protocol advanced features using `Context`:
 		},
 		Debug: true,
 		Debugf: func(format string, v ...any) {
-			fmt.Printf(format, v)
+			fmt.Printf(format+"\n", v...)
 		},
 		Settings: clickhouse.Settings{
 			"max_execution_time": 60,


### PR DESCRIPTION
## Summary
Fixes an example in the README where `Debugf` is configured to route to `fmt.Printf`, by using the splat operator to properly unpack format arguments.

### Before

- Format arguments not passed properly
- No trailing new-line, hard to read

```
[send query] compression=["lz4" "((stripped))"] %!s(MISSING)[send data] compression=["lz4"][read data] compression=["lz4" '\x01' '\x00']. block: columns=%!d(MISSING), rows=%!d(MISSING)[read data] compression=["lz4" '\x01' '\x01']. block: columns=%!d(MISSING), rows=%!d(MISSING)[profile info] [rows=1, bytes=256, blocks=1, rows before limit=0, applied limit=false, calculated rows before limit=true][progress] [rows=83256135, bytes=83250374, total rows=83256135, wrote rows=0 wrote bytes=0 elapsed=10.628191ms][progress] [rows=83256135, bytes=83250374, total rows=83256135, wrote rows=0 wrote bytes=0 elapsed=10.628191ms][read data] compression=["lz4" '\x06' '0']. block: columns=%!d(MISSING), rows=%!d(MISSING)[profile events] rows=[48][read data] compression=["lz4" '\x00' '\x00']. block: columns=%!d(MISSING), rows=%!d(MISSING)[progress] [rows=0, bytes=0, total rows=0, wrote rows=0 wrote bytes=0 elapsed=137.047µs][progress] [rows=0, bytes=0, total rows=0, wrote rows=0 wrote bytes=0 elapsed=137.047µs][end of stream]%!(EXTRA []interface {}=[])
```

### After

- Format arguments passed properly
- Trailing new-line, readable

```
[send query] compression="lz4" ((stripped))
[send data] compression="lz4"
[read data] compression="lz4". block: columns=1, rows=0
[read data] compression="lz4". block: columns=1, rows=1
[profile info] rows=1, bytes=256, blocks=1, rows before limit=0, applied limit=false, calculated rows before limit=true
[progress] rows=83256135, bytes=83250374, total rows=83256135, wrote rows=0 wrote bytes=0 elapsed=10.734099ms
[progress] rows=83256135, bytes=83250374, total rows=83256135, wrote rows=0 wrote bytes=0 elapsed=10.734099ms
[read data] compression="lz4". block: columns=6, rows=48
[profile events] rows=48
[read data] compression="lz4". block: columns=0, rows=0
[progress] rows=0, bytes=0, total rows=0, wrote rows=0 wrote bytes=0 elapsed=154.309µs
[progress] rows=0, bytes=0, total rows=0, wrote rows=0 wrote bytes=0 elapsed=154.309µs
[end of stream]
```

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [x] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
