### PR TITLE
Replace deprecated `io/ioutil` functions with equivalents

### DIFF
--- a/conn_http.go
+++ b/conn_http.go
@@ -26,7 +26,6 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net"
@@ -86,7 +85,7 @@ func (rw HTTPReaderWriter) read(res *http.Response) ([]byte, error) {
 			if err := reader.Reset(res.Body); err != nil {
 				return nil, err
 			}
-			body, err := ioutil.ReadAll(reader)
+			body, err := io.ReadAll(reader)
 			if err != nil {
 				return nil, err
 			}
@@ -97,7 +96,7 @@ func (rw HTTPReaderWriter) read(res *http.Response) ([]byte, error) {
 			if err := rw.reader.(flate.Resetter).Reset(res.Body, nil); err != nil {
 				return nil, err
 			}
-			body, err := ioutil.ReadAll(reader)
+			body, err := io.ReadAll(reader)
 			if err != nil {
 				return nil, err
 			}
@@ -107,14 +106,14 @@ func (rw HTTPReaderWriter) read(res *http.Response) ([]byte, error) {
 			if err := reader.Reset(res.Body); err != nil {
 				return nil, err
 			}
-			body, err := ioutil.ReadAll(reader)
+			body, err := io.ReadAll(reader)
 			if err != nil {
 				return nil, err
 			}
 			return body, nil
 		}
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/conn_http_async_insert.go
+++ b/conn_http_async_insert.go
@@ -20,7 +20,6 @@ package clickhouse
 import (
 	"context"
 	"io"
-	"io/ioutil"
 )
 
 func (h *httpConnect) asyncInsert(ctx context.Context, query string, wait bool, args ...any) error {
@@ -43,7 +42,7 @@ func (h *httpConnect) asyncInsert(ctx context.Context, query string, wait bool, 
 	if res != nil {
 		defer res.Body.Close()
 		// we don't care about result, so just discard it to reuse connection
-		_, _ = io.Copy(ioutil.Discard, res.Body)
+		_, _ = io.Copy(io.Discard, res.Body)
 	}
 
 	return err

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -21,13 +21,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"regexp"
+	"strings"
+
 	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
-	"io"
-	"io/ioutil"
-	"regexp"
-	"strings"
 )
 
 // \x60 represents a backtick
@@ -224,7 +224,7 @@ func (b *httpBatch) Send() (err error) {
 	if res != nil {
 		defer res.Body.Close()
 		// we don't care about result, so just discard it to reuse connection
-		_, _ = io.Copy(ioutil.Discard, res.Body)
+		_, _ = io.Copy(io.Discard, res.Body)
 	}
 
 	return err

--- a/conn_http_exec.go
+++ b/conn_http_exec.go
@@ -20,7 +20,6 @@ package clickhouse
 import (
 	"context"
 	"io"
-	"io/ioutil"
 )
 
 func (h *httpConnect) exec(ctx context.Context, query string, args ...any) error {
@@ -34,7 +33,7 @@ func (h *httpConnect) exec(ctx context.Context, query string, args ...any) error
 	if res != nil {
 		defer res.Body.Close()
 		// we don't care about result, so just discard it to reuse connection
-		_, _ = io.Copy(ioutil.Discard, res.Body)
+		_, _ = io.Copy(io.Discard, res.Body)
 	}
 
 	return err

--- a/examples/clickhouse_api/ssl.go
+++ b/examples/clickhouse_api/ssl.go
@@ -21,10 +21,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"io/ioutil"
 	"os"
 	"path"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func SSLVersion() error {
@@ -37,7 +37,7 @@ func SSLVersion() error {
 		return err
 	}
 	t := &tls.Config{}
-	caCert, err := ioutil.ReadFile(path.Join(cwd, "../../tests/resources/CAroot.crt"))
+	caCert, err := os.ReadFile(path.Join(cwd, "../../tests/resources/CAroot.crt"))
 	if err != nil {
 		return err
 	}

--- a/examples/std/ssl.go
+++ b/examples/std/ssl.go
@@ -22,10 +22,10 @@ import (
 	"crypto/x509"
 	"database/sql"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"io/ioutil"
 	"os"
 	"path"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func ConnectSSL() error {
@@ -38,7 +38,7 @@ func ConnectSSL() error {
 		return err
 	}
 	t := &tls.Config{}
-	caCert, err := ioutil.ReadFile(path.Join(cwd, "../../tests/resources/CAroot.crt"))
+	caCert, err := os.ReadFile(path.Join(cwd, "../../tests/resources/CAroot.crt"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
`io/ioutil` is deprecated.
https://pkg.go.dev/io/ioutil
