### PR TITLE
Ignore materialized and alias cols infered during HTTP prepare batch

### DIFF
--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -21,13 +21,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"io"
 	"io/ioutil"
 	"regexp"
 	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
 // \x60 represents a backtick
@@ -63,14 +64,19 @@ func (h *httpConnect) prepareBatch(ctx context.Context, query string, opts drive
 	var colNames []string
 	for r.Next() {
 		var (
-			colName string
-			colType string
-			ignore  string
+			colName      string
+			colType      string
+			default_type string
+			ignore       string
 		)
 
-		if err = r.Scan(&colName, &colType, &ignore, &ignore, &ignore, &ignore, &ignore); err != nil {
+		if err = r.Scan(&colName, &colType, &default_type, &ignore, &ignore, &ignore, &ignore); err != nil {
 			return nil, err
 		}
+		// // these column types cannot be specified in INSERT queries
+		// if default_type == "MATERIALIZED" || default_type == "ALIAS" {
+		// 	continue
+		// }
 		colNames = append(colNames, colName)
 		columns[colName] = colType
 	}

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -73,8 +73,8 @@ func (h *httpConnect) prepareBatch(ctx context.Context, query string, opts drive
 			return nil, err
 		}
 		// these column types cannot be specified in INSERT queries
-                if default_type == "MATERIALIZED" || default_type == "ALIAS" {
-		 	continue
+		if default_type == "MATERIALIZED" || default_type == "ALIAS" {
+			continue
 		}
 		colNames = append(colNames, colName)
 		columns[colName] = colType

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -73,8 +73,7 @@ func (h *httpConnect) prepareBatch(ctx context.Context, query string, opts drive
 			return nil, err
 		}
 		// these column types cannot be specified in INSERT queries
-		
-    if default_type == "MATERIALIZED" || default_type == "ALIAS" {
+                if default_type == "MATERIALIZED" || default_type == "ALIAS" {
 		 	continue
 		}
 		colNames = append(colNames, colName)

--- a/tests/std/mat_cols_test.go
+++ b/tests/std/mat_cols_test.go
@@ -1,0 +1,77 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package std
+
+import (
+	"fmt"
+	"math/big"
+	"strconv"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatColInsert(t *testing.T) {
+	dsns := map[string]clickhouse.Protocol{"Native": clickhouse.Native, "Http": clickhouse.HTTP}
+	useSSL, err := strconv.ParseBool(clickhouse_tests.GetEnv("CLICKHOUSE_USE_SSL", "false"))
+	require.NoError(t, err)
+	for name, protocol := range dsns {
+		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
+			if conn, err := GetStdDSNConnection(protocol, useSSL, nil); assert.NoError(t, err) {
+				if !CheckMinServerVersion(conn, 21, 12, 0) {
+					t.Skip(fmt.Errorf("unsupported clickhouse version"))
+					return
+				}
+				const ddl = `
+		CREATE TABLE test_mat_cols (
+			  Col1 Int128
+			, Col2 MATERIALIZED Col1 * 2
+		) Engine MergeTree() ORDER BY tuple()
+		`
+				defer func() {
+					conn.Exec("DROP TABLE test_mat_cols")
+				}()
+				_, err := conn.Exec(ddl)
+				require.NoError(t, err)
+				scope, err := conn.Begin()
+				require.NoError(t, err)
+				batch, err := scope.Prepare("INSERT INTO test_mat_cols")
+				require.NoError(t, err)
+				var (
+					col1Data = big.NewInt(128)
+					col2Data = big.NewInt(128 * 2)
+				)
+				_, err = batch.Exec(col1Data)
+				require.NoError(t, err)
+				require.NoError(t, scope.Commit())
+				var (
+					col1 big.Int
+					col2 big.Int
+				)
+				require.NoError(t, conn.QueryRow("SELECT * FROM test_mat_cols").Scan(&col1))
+				assert.Equal(t, *col1Data, col1)
+				require.NoError(t, conn.QueryRow("SELECT Col1, Col2 from test_mat_cols").Scan(&col1, &col2))
+				assert.Equal(t, *col1Data, col1)
+				assert.Equal(t, *col2Data, col2)
+			}
+		})
+	}
+}

--- a/tests/std/materialized_column_test.go
+++ b/tests/std/materialized_column_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMatColInsert(t *testing.T) {
+func TestMaterializedColumnInsert(t *testing.T) {
 	dsns := map[string]clickhouse.Protocol{"Native": clickhouse.Native, "Http": clickhouse.HTTP}
 	useSSL, err := strconv.ParseBool(clickhouse_tests.GetEnv("CLICKHOUSE_USE_SSL", "false"))
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
during instantiation of the batch insert we construct all the columns, there is no need to do it for materialized and alias columns as they are non-insertable
## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [x] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
