### PR TITLE
Fix an obscure error in HTTP protocol with LZ4 compression

### DIFF
--- a/conn_http.go
+++ b/conn_http.go
@@ -425,6 +425,9 @@ func (h *httpConnect) readRawResponse(response *http.Response) (body []byte, err
 	if err != nil {
 		return nil, err
 	}
+	if response.StatusCode == http.StatusForbidden {
+		return nil, errors.New(string(body))
+	}
 	if h.compression == CompressionLZ4 || h.compression == CompressionZSTD {
 		chReader := chproto.NewReader(reader)
 		chReader.EnableCompression()


### PR DESCRIPTION
## Summary
Resolves #1150 

Now return error like:
```
clickhouse [execute]:: 403 code: failed to read the response: Code: 516. DB::Exception: default: Authentication failed: password is incorrect, or there is no user with such name.

If you have installed ClickHouse and forgot password you can reset it in the configuration file.
The password for default user is typically located at /etc/clickhouse-server/users.d/default-password.xml
and deleting this file will reset the password.
See also /etc/clickhouse-server/users.xml on the server where ClickHouse is installed.

. (AUTHENTICATION_FAILED) (version 23.8.9.54 (official build))
```

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
