### PR TITLE
Make errors channel buffered inside query() 

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -258,6 +258,11 @@ func (ch *clickhouse) acquire(ctx context.Context) (conn *connect, err error) {
 	timer := time.NewTimer(ch.opt.DialTimeout)
 	defer timer.Stop()
 	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	select {
 	case <-timer.C:
 		return nil, ErrAcquireConnTimeout
 	case <-ctx.Done():

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -258,11 +258,6 @@ func (ch *clickhouse) acquire(ctx context.Context) (conn *connect, err error) {
 	timer := time.NewTimer(ch.opt.DialTimeout)
 	defer timer.Stop()
 	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-	}
-	select {
 	case <-timer.C:
 		return nil, ErrAcquireConnTimeout
 	case <-ctx.Done():

--- a/conn_query.go
+++ b/conn_query.go
@@ -65,7 +65,7 @@ func (c *connect) query(ctx context.Context, release func(*connect, error), quer
 		bufferSize = options.blockBufferSize
 	}
 	var (
-		errors = make(chan error)
+		errors = make(chan error, 1)
 		stream = make(chan *proto.Block, bufferSize)
 	)
 


### PR DESCRIPTION
## Summary
This PR closes #1229 

While debugging this issue, I noticed the following line of code inside conn_query.go
```go
		err := c.process(ctx, onProcess)
		if err != nil {
			c.debugf("[query] process error: %v", err)
			errors <- err
```

here, err gets transferred to errors channel in case if err != nil. In my case, it happens when context gets canceled. This resulted into situation where certain goroutines couldn't pass through this errors <- err and code never got to the connection release point. So I made this errors channel a buffered one, tested it, and was satisfied with the result - connections now don't get stuck in an open pool. 