### PR TITLE
Implement `ConnBeginTx` as replacement for deprecated `Begin`

### DIFF
--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -364,6 +364,7 @@ func (s *stdBatch) ExecContext(ctx context.Context, args []driver.NamedValue) (d
 var _ driver.StmtExecContext = (*stdBatch)(nil)
 
 func (s *stdBatch) Query(args []driver.Value) (driver.Rows, error) {
+	// Note: not implementing driver.StmtQueryContext accordingly
 	return nil, errors.New("only Exec method supported in batch mode")
 }
 

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -222,6 +222,9 @@ func (std *stdDriver) ResetSession(ctx context.Context) error {
 func (std *stdDriver) Ping(ctx context.Context) error { return std.conn.ping(ctx) }
 
 func (std *stdDriver) Begin() (driver.Tx, error) { return std, nil }
+func (std *stdDriver) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	return std, nil
+}
 
 func (std *stdDriver) Commit() error {
 	if std.commit == nil {


### PR DESCRIPTION
## Summary
Implement missing method for dabase/sql/driver per `drivers.ConnBeginTx` interface. This interface is a replacement for `Begin()`, which is deprecated

## Checklist
Delete items not relevant to your PR:
- [x] A human-readable description of the changes was provided to include in CHANGELOG
  - use description under Summary above

fixes https://github.com/pressly/goose/issues/730 & #733 