### PR TITLE
Batch: impl `Columns() []column.Interface` method

### DIFF
--- a/conn_batch.go
+++ b/conn_batch.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -309,8 +310,8 @@ func (b *batch) Rows() int {
 	return b.block.Rows()
 }
 
-func (b *batch) Block() proto.Block {
-	return *b.block
+func (b *batch) Columns() []column.Interface {
+	return slices.Clone(b.block.Columns)
 }
 
 func (b *batch) closeQuery() error {

--- a/conn_batch.go
+++ b/conn_batch.go
@@ -309,6 +309,10 @@ func (b *batch) Rows() int {
 	return b.block.Rows()
 }
 
+func (b *batch) Block() proto.Block {
+	return *b.block
+}
+
 func (b *batch) closeQuery() error {
 	if err := b.conn.sendData(&proto.Block{}, ""); err != nil {
 		return err

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
@@ -239,8 +240,8 @@ func (b *httpBatch) Rows() int {
 	return b.block.Rows()
 }
 
-func (b *httpBatch) Block() proto.Block {
-	return *b.block
+func (b *httpBatch) Columns() []column.Interface {
+	return slices.Clone(b.block.Columns)
 }
 
 var _ driver.Batch = (*httpBatch)(nil)

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -239,4 +239,8 @@ func (b *httpBatch) Rows() int {
 	return b.block.Rows()
 }
 
+func (b *httpBatch) Block() proto.Block {
+	return *b.block
+}
+
 var _ driver.Batch = (*httpBatch)(nil)

--- a/lib/driver/driver.go
+++ b/lib/driver/driver.go
@@ -85,6 +85,7 @@ type (
 		Send() error
 		IsSent() bool
 		Rows() int
+		Block() proto.Block
 	}
 	BatchColumn interface {
 		Append(any) error

--- a/lib/driver/driver.go
+++ b/lib/driver/driver.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
@@ -85,7 +86,7 @@ type (
 		Send() error
 		IsSent() bool
 		Rows() int
-		Block() proto.Block
+		Columns() []column.Interface
 	}
 	BatchColumn interface {
 		Append(any) error


### PR DESCRIPTION
Hello, my proposal is to provide additional method `Columns() []column.Interface` for `Batch` interface. This might be useful when additional information about the table metadata is needed.

Example:
```go
batch, err := chConn.PrepareBatch(ctx, fmt.Sprintf(`INSERT INTO %q`, table))
if err != nil {
        return errors.Wrap(err, "ClickHouse: Prepare batch")
}

structType, err := tableSchema(batch.Columns())
if err != nil {
        return err
}

func tableSchema(columns []column.Interface) (reflect.Type, error) {
	fields := make([]reflect.StructField, len(columns ))
	for i, col := range columns  {
		fieldType := col.ScanType()
		name := col.Name()
		fields[i] = reflect.StructField{
			Name: cases.Title(language.Und).String(name),
			Type: fieldType,
			Tag:  reflect.StructTag(fmt.Sprintf("json:%q ch:%q", name, name)),
		}
	}
	return reflect.StructOf(fields), nil
}
```