### PR TITLE
Fixed panic on concurrent context key map write

### DIFF
--- a/conn_http.go
+++ b/conn_http.go
@@ -372,11 +372,10 @@ func (h *httpConnect) writeData(block *proto.Block) error {
 	return nil
 }
 
-func (h *httpConnect) readData(ctx context.Context, reader *chproto.Reader) (*proto.Block, error) {
-	opts := queryOptions(ctx)
+func (h *httpConnect) readData(reader *chproto.Reader, timezone *time.Location) (*proto.Block, error) {
 	location := h.location
-	if opts.userLocation != nil {
-		location = opts.userLocation
+	if timezone != nil {
+		location = timezone
 	}
 
 	block := proto.Block{Timezone: location}

--- a/conn_http_query.go
+++ b/conn_http_query.go
@@ -73,7 +73,7 @@ func (h *httpConnect) query(ctx context.Context, release func(*connect, error), 
 		return nil, err
 	}
 	chReader := chproto.NewReader(reader)
-	block, err := h.readData(ctx, chReader)
+	block, err := h.readData(chReader, options.userLocation)
 	if err != nil && !errors.Is(err, io.EOF) {
 		res.Body.Close()
 		h.compressionPool.Put(rw)
@@ -91,7 +91,7 @@ func (h *httpConnect) query(ctx context.Context, release func(*connect, error), 
 	)
 	go func() {
 		for {
-			block, err := h.readData(ctx, chReader)
+			block, err := h.readData(chReader, options.userLocation)
 			if err != nil {
 				// ch-go wraps EOF errors
 				if !errors.Is(err, io.EOF) {


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

When open a ClickHouse DB connection through the HTTP protocol and using the WithDeadline context during transaction execution, there is a small probability of concurrent writes to a map, which can lead to a panic. The reason is that when the PrepareContext function is called, it creates a goroutine to read data through the readData function. The readData function updates the key of “max_execution_time” in the map by calling the queryOptions function. Finally, when the transaction executes the Commit, it also calls the Send function, which in turn calls the queryOptions function to update the key of ”max_execution_time“ in the map.

```
fatal error: concurrent map writes
goroutine 4257644 [running]:
[github.com/ClickHouse/clickhouse-go/v2.queryOptions](http://github.com/ClickHouse/clickhouse-go/v2.queryOptions)({0x2219688, 0xc0238c33e0})
        /home/test/go1.19/global/pkg/mod/[github.com/!click!house/clickhouse-go/v2@v2.7.0/context.go:163](http://github.com/!click!house/clickhouse-go/v2@v2.7.0/context.go:163) +0x196
[github.com/ClickHouse/clickhouse-go/v2.(*httpConnect).readData](http://github.com/ClickHouse/clickhouse-go/v2.(*httpConnect).readData)(0xc01322e9b0, {0x2219688?, 0xc0238c33e0?}, 0xc031b80f00)
        /home/test/go1.19/global/pkg/mod/[github.com/!click!house/clickhouse-go/v2@v2.7.0/conn_http.go:367](http://github.com/!click!house/clickhouse-go/v2@v2.7.0/conn_http.go:367) +0x85
[github.com/ClickHouse/clickhouse-go/v2.(*httpConnect).query.func2()](http://github.com/ClickHouse/clickhouse-go/v2.(*httpConnect).query.func2())
        /home/test/go1.19/global/pkg/mod/[github.com/!click!house/clickhouse-go/v2@v2.7.0/conn_http_query.go:100](http://github.com/!click!house/clickhouse-go/v2@v2.7.0/conn_http_query.go:100) +0x8c
created by [github.com/ClickHouse/clickhouse-go/v2.(*httpConnect).query](http://github.com/ClickHouse/clickhouse-go/v2.(*httpConnect).query)
        /home/test/go1.19/global/pkg/mod/[github.com/!click!house/clickhouse-go/v2@v2.7.0/conn_http_query.go:98](http://github.com/!click!house/clickhouse-go/v2@v2.7.0/conn_http_query.go:98) +0x7ec
```

