### PR TITLE
Fix ClickHouse Terraform provider version

### DIFF
--- a/.github/cloud/service.tf
+++ b/.github/cloud/service.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     clickhouse = {
       source  = "ClickHouse/clickhouse"
-      version = "~> 0.0.5"
+      version = "0.0.6"
     }
   }
 }


### PR DESCRIPTION
The latest Terraform provider version has regression.