### PR TITLE
Always compress responses when the client compression is on

### DIFF
--- a/conn_http.go
+++ b/conn_http.go
@@ -424,14 +424,14 @@ func (h *httpConnect) readRawResponse(response *http.Response) (body []byte, err
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode == http.StatusOK && (h.compression == CompressionLZ4 || h.compression == CompressionZSTD) {
+	if h.compression == CompressionLZ4 || h.compression == CompressionZSTD {
 		chReader := chproto.NewReader(reader)
 		chReader.EnableCompression()
 		reader = chReader
 	}
 
 	body, err = io.ReadAll(reader)
-	if err != nil {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 	return body, nil

--- a/conn_http.go
+++ b/conn_http.go
@@ -424,10 +424,7 @@ func (h *httpConnect) readRawResponse(response *http.Response) (body []byte, err
 	if err != nil {
 		return nil, err
 	}
-	if response.StatusCode == http.StatusForbidden {
-		return nil, errors.New(string(body))
-	}
-	if h.compression == CompressionLZ4 || h.compression == CompressionZSTD {
+	if response.StatusCode == http.StatusOK && (h.compression == CompressionLZ4 || h.compression == CompressionZSTD) {
 		chReader := chproto.NewReader(reader)
 		chReader.EnableCompression()
 		reader = chReader

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -199,6 +199,7 @@ func (b *httpBatch) Send() (err error) {
 		headers["Content-Encoding"] = b.conn.compression.String()
 	case CompressionZSTD, CompressionLZ4:
 		options.settings["decompress"] = "1"
+		options.settings["compress"] = "1"
 	}
 
 	go func() {


### PR DESCRIPTION
## Summary
* It resolves https://github.com/ClickHouse/clickhouse-go/issues/1150 again, since [the fix](https://github.com/ClickHouse/clickhouse-go/pull/1230) was broken at some time (`body` after `return` [is empty](https://github.com/ClickHouse/clickhouse-go/blob/main/conn_http.go#L428) since it hasn't been read yet)
* The previous fix covered only the 403 code, but this one covers all non-200
* As a bonus, with this fix the error doesn't state that it `failed to read the response` (which is technically not true since a response is successfully read)
Now it looks like:
```
clickhouse [execute]:: 403 code: Code: 516. DB::Exception: default: Authentication failed: password is incorrect, or there is no user with such name.
<and the rest>
```