### PR TITLE
Don't recreate keys from LC columns from direct stream

### DIFF
--- a/lib/column/lowcardinality.go
+++ b/lib/column/lowcardinality.go
@@ -220,6 +220,9 @@ func (col *LowCardinality) Encode(buffer *proto.Buffer) {
 	}()
 	ixLen := uint64(len(col.append.index))
 	switch {
+	case col.keys().Rows() > 0:
+		// We already have keys, so this column is probably in a block directly decoded from the server, and we should
+		// not reset them
 	case ixLen < math.MaxUint8:
 		col.key = keyUInt8
 		for _, v := range col.append.keys {

--- a/tests/batch_block_test.go
+++ b/tests/batch_block_test.go
@@ -41,11 +41,11 @@ func TestBatchAppendRows(t *testing.T) {
 	// given we have two tables and a million rows in the source table
 	var tables = []string{"source", "target"}
 	for _, table := range tables {
-		require.NoError(t, conn.Exec(context.Background(), "create table if not exists "+table+" (number1 Int, number2 String, number3 Tuple(String, Int), number4 DateTime) engine = Memory()"))
+		require.NoError(t, conn.Exec(context.Background(), "create table if not exists "+table+" (number1 Int, number2 LowCardinality(String), number3 Tuple(String, Int), number4 DateTime) engine = Memory()"))
 		defer conn.Exec(context.Background(), "drop table if exists "+table)
 	}
 
-	require.NoError(t, conn.Exec(ctx, "INSERT INTO source SELECT number, 'string', tuple('foo', number), now() FROM system.numbers LIMIT 1000000"))
+	require.NoError(t, conn.Exec(ctx, "INSERT INTO source SELECT number, toString(number), tuple('foo', number), now() FROM system.numbers LIMIT 1000000"))
 
 	// when we create a batch with direct data block access 10 times
 	sourceRows, err := conn.Query(ctx, "SELECT * FROM source")


### PR DESCRIPTION
## Summary
Fixes an issue with low cardinality columns with a large number of distinct values when using experimental SELECT streaming

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added

