### PR TITLE
Reintroduce the random connection strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,9 @@ conn.SetConnMaxLifetime(time.Hour)
 * username/password - auth credentials
 * database - select the current default database
 * dial_timeout -  a duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix such as "300ms", "1s". Valid time units are "ms", "s", "m". (default 30s)
-* connection_open_strategy - round_robin/in_order (default in_order).
-    * round_robin      - choose a round-robin server from the set
+* connection_open_strategy - random/round_robin/in_order (default in_order).
+    * random      - choose random server from the set
+    * round_robin - choose a round-robin server from the set
     * in_order    - first live server is chosen in specified order
 * debug - enable debug output (boolean value)
 * compress - compress - specify the compression algorithm - “none” (default), `zstd`, `lz4`, `gzip`, `deflate`, `br`. If set to `true`, `lz4` will be used.

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"sync/atomic"
 	"time"
 
@@ -233,6 +234,7 @@ func (ch *clickhouse) dial(ctx context.Context) (conn *connect, err error) {
 }
 
 func DefaultDialStrategy(ctx context.Context, connID int, opt *Options, dial Dial) (r DialResult, err error) {
+	random := rand.Int()
 	for i := range opt.Addr {
 		var num int
 		switch opt.ConnOpenStrategy {
@@ -240,6 +242,8 @@ func DefaultDialStrategy(ctx context.Context, connID int, opt *Options, dial Dia
 			num = i
 		case ConnOpenRoundRobin:
 			num = (int(connID) + i) % len(opt.Addr)
+		case ConnOpenRandom:
+			num = (random + i) % len(opt.Addr)
 		}
 
 		if r, err = dial(ctx, opt.Addr[num], opt); err == nil {

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -87,6 +87,7 @@ type ConnOpenStrategy uint8
 const (
 	ConnOpenInOrder ConnOpenStrategy = iota
 	ConnOpenRoundRobin
+	ConnOpenRandom
 )
 
 type Protocol int
@@ -265,6 +266,8 @@ func (o *Options) fromDSN(in string) error {
 				o.ConnOpenStrategy = ConnOpenInOrder
 			case "round_robin":
 				o.ConnOpenStrategy = ConnOpenRoundRobin
+			case "random":
+				o.ConnOpenStrategy = ConnOpenRandom
 			}
 		case "max_open_conns":
 			maxOpenConns, err := strconv.Atoi(params.Get(v))

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/rand"
 	"os"
 	"reflect"
 	"strings"
@@ -81,6 +82,7 @@ func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) 
 		return nil, ErrAcquireConnNoAddress
 	}
 
+	random := rand.Int()
 	for i := range o.opt.Addr {
 		var num int
 		switch o.opt.ConnOpenStrategy {
@@ -88,6 +90,8 @@ func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) 
 			num = i
 		case ConnOpenRoundRobin:
 			num = (int(connID) + i) % len(o.opt.Addr)
+		case ConnOpenRandom:
+			num = (random + i) % len(o.opt.Addr)
 		}
 		if conn, err = dialFunc(ctx, o.opt.Addr[num], connID, o.opt); err == nil {
 			var debugf = func(format string, v ...any) {}

--- a/examples/clickhouse_api/main_test.go
+++ b/examples/clickhouse_api/main_test.go
@@ -163,6 +163,7 @@ func TestIterableOrderedMapInsertRead(t *testing.T) {
 func TestMultiHostConnect(t *testing.T) {
 	require.NoError(t, MultiHostVersion())
 	require.NoError(t, MultiHostRoundRobinVersion())
+	require.NoError(t, MultiHostRandomVersion())
 }
 
 func TestNested(t *testing.T) {

--- a/examples/clickhouse_api/multi_host.go
+++ b/examples/clickhouse_api/multi_host.go
@@ -23,40 +23,36 @@ import (
 )
 
 func MultiHostVersion() error {
+	return multiHostVersion(nil)
+}
+
+func MultiHostRoundRobinVersion() error {
+	connOpenStrategy := clickhouse.ConnOpenRoundRobin
+	return multiHostVersion(&connOpenStrategy)
+}
+
+func MultiHostRandomVersion() error {
+	connOpenStrategy := clickhouse.ConnOpenRandom
+	return multiHostVersion(&connOpenStrategy)
+}
+
+func multiHostVersion(connOpenStrategy *clickhouse.ConnOpenStrategy) error {
 	env, err := GetNativeTestEnvironment()
 	if err != nil {
 		return err
 	}
-	conn, err := clickhouse.Open(&clickhouse.Options{
+	options := clickhouse.Options{
 		Addr: []string{"127.0.0.1:9001", "127.0.0.1:9002", fmt.Sprintf("%s:%d", env.Host, env.Port)},
 		Auth: clickhouse.Auth{
 			Database: env.Database,
 			Username: env.Username,
 			Password: env.Password,
 		},
-	})
-	if err != nil {
-		return err
 	}
-	v, err := conn.ServerVersion()
-	if err != nil {
-		return err
+	if connOpenStrategy != nil {
+		options.ConnOpenStrategy = *connOpenStrategy
 	}
-	fmt.Println(v.String())
-	return nil
-}
-
-func MultiHostRoundRobinVersion() error {
-	env, err := GetNativeTestEnvironment()
-	conn, err := clickhouse.Open(&clickhouse.Options{
-		Addr:             []string{"127.0.0.1:9001", "127.0.0.1:9002", fmt.Sprintf("%s:%d", env.Host, env.Port)},
-		ConnOpenStrategy: clickhouse.ConnOpenRoundRobin,
-		Auth: clickhouse.Auth{
-			Database: env.Database,
-			Username: env.Username,
-			Password: env.Password,
-		},
-	})
+	conn, err := clickhouse.Open(&options)
 	if err != nil {
 		return err
 	}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -715,6 +715,8 @@ func optionsToDSN(o *clickhouse.Options) string {
 			strategy = "in_order"
 		case clickhouse.ConnOpenRoundRobin:
 			strategy = "round_robin"
+		case clickhouse.ConnOpenRandom:
+			strategy = "random"
 		}
 
 		params.Set("connection_open_strategy", strategy)


### PR DESCRIPTION
Referring to https://github.com/ClickHouse/clickhouse-go/discussions/1302

I chose the name 'random' for the connection strategy like it was called in v1 but maybe 'randomised' would be more accurate? 

Grouped test code of the three connection strategies (in-order, round-robin and random) in order to avoid three copies of the same

Tested with CLICKHOUSE_USE_DOCKER=false