### PR TITLE
Setting `X-Clickhouse-SSL-Certificate-Auth` header correctly given `X-ClickHouse-Key`

### DIFF
--- a/conn_http.go
+++ b/conn_http.go
@@ -161,6 +161,9 @@ func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpCon
 		headers["X-ClickHouse-User"] = opt.Auth.Username
 		if len(opt.Auth.Password) > 0 {
 			headers["X-ClickHouse-Key"] = opt.Auth.Password
+			headers["X-ClickHouse-SSL-Certificate-Auth"] = "off"
+		} else {
+			headers["X-ClickHouse-SSL-Certificate-Auth"] = "on"
 		}
 	}
 


### PR DESCRIPTION
## Summary

Set `X-Clickhouse-SSL-Certificate-Auth` correctly given `X-ClickHouse-Key`

Issue - https://github.com/ClickHouse/clickhouse-go/issues/1273

## Checklist
Delete items not relevant to your PR:
- [ x] A human-readable description of the changes was provided to include in CHANGELOG
