### PR TITLE
Unpack value of indirect types in array column to support nested structures in interfaced slices/arrays

### DIFF
--- a/lib/column/array.go
+++ b/lib/column/array.go
@@ -197,7 +197,17 @@ func (col *Array) append(elem reflect.Value, level int) error {
 		case reflect.Slice, reflect.Array, reflect.String:
 			col.appendOffset(level, uint64(elem.Len()))
 			for i := 0; i < elem.Len(); i++ {
-				if err := col.append(elem.Index(i), level+1); err != nil {
+				el := elem.Index(i)
+
+				if el.Kind() == reflect.Interface && !el.IsNil() {
+					el = el.Elem()
+				}
+
+				if el.Kind() == reflect.Ptr && !el.IsNil() {
+					el = el.Elem()
+				}
+
+				if err := col.append(el, level+1); err != nil {
 					return err
 				}
 			}

--- a/tests/issues/1349_test.go
+++ b/tests/issues/1349_test.go
@@ -1,0 +1,61 @@
+package issues
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue1349(t *testing.T) {
+	ctx := context.Background()
+
+	conn, err := tests.GetConnection("issues", nil, nil, nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	const ddl = `
+		CREATE TABLE test_array (
+				Col1 Array(Array(String)),
+				Col2 Array(Array(Nullable(String)))
+		) Engine MergeTree() ORDER BY tuple()
+		`
+	err = conn.Exec(ctx, ddl)
+	require.NoError(t, err)
+	defer conn.Exec(ctx, "DROP TABLE test_array")
+
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_array")
+	require.NoError(t, err)
+
+	var (
+		a        = "a"
+		b        = "b"
+		col1Data = []interface{}{[]string{}, []string{"a", "b"}, &[]string{"c"}, []interface{}{&a, &b}}
+		col2Data = []interface{}{[]*string{&a, nil}, &[]*string{&b, nil}, &[]interface{}{nil, &a}}
+	)
+
+	err = batch.Append(col1Data, col2Data)
+	require.NoError(t, err)
+
+	err = batch.Send()
+	require.NoError(t, err)
+
+	rows, err := conn.Query(ctx, "SELECT * FROM test_array")
+	require.NoError(t, err)
+
+	require.True(t, rows.Next())
+
+	var (
+		col1 any
+		col2 any
+	)
+	err = rows.Scan(&col1, &col2)
+	require.NoError(t, err)
+
+	require.Equal(t, [][]string{{}, {"a", "b"}, {"c"}, {"a", "b"}}, col1)
+	require.Equal(t, [][]*string{{&a, nil}, {&b, nil}, {nil, &a}}, col2)
+
+	require.NoError(t, rows.Close())
+	require.NoError(t, rows.Err())
+}


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

Unpack value of indirect types in array column to support nested structures in interfaced slices/arrays

Fixes #1349

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [x] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
