### PR TITLE
always call rows.Close

### DIFF
--- a/examples/clickhouse_api/query_rows.go
+++ b/examples/clickhouse_api/query_rows.go
@@ -62,6 +62,7 @@ func QueryRows() error {
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var (
 			col1 uint8
@@ -73,6 +74,5 @@ func QueryRows() error {
 		}
 		fmt.Printf("row: col1=%d, col2=%s, col3=%s\n", col1, col2, col3)
 	}
-	rows.Close()
 	return rows.Err()
 }


### PR DESCRIPTION
## Summary
follow go convention to always close rows, irrespective of success scans or early error returns

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
