### PR TITLE
Fix column list parsing for multiline INSERT statements

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -26,9 +26,9 @@ import (
 )
 
 var normalizeInsertQueryMatch = regexp.MustCompile(`(?i)(INSERT\s+INTO\s+([^(]+)(?:\s*\([^()]*(?:\([^()]*\)[^()]*)*\))?)(?:\s*VALUES)?`)
-var truncateFormat = regexp.MustCompile(`\sFORMAT\s+[^\s]+`)
+var truncateFormat = regexp.MustCompile(`(?i)\sFORMAT\s+[^\s]+`)
 var truncateValues = regexp.MustCompile(`\sVALUES\s.*$`)
-var extractInsertColumnsMatch = regexp.MustCompile(`(?s)INSERT INTO .+\s\((?P<Columns>.+)\)$`)
+var extractInsertColumnsMatch = regexp.MustCompile(`(?si)INSERT INTO .+\s\((?P<Columns>.+)\)$`)
 
 func extractNormalizedInsertQueryAndColumns(query string) (normalizedQuery string, tableName string, columns []string, err error) {
 	query = truncateFormat.ReplaceAllString(query, "")

--- a/batch.go
+++ b/batch.go
@@ -28,7 +28,7 @@ import (
 var normalizeInsertQueryMatch = regexp.MustCompile(`(?i)(INSERT\s+INTO\s+([^(]+)(?:\s*\([^()]*(?:\([^()]*\)[^()]*)*\))?)(?:\s*VALUES)?`)
 var truncateFormat = regexp.MustCompile(`\sFORMAT\s+[^\s]+`)
 var truncateValues = regexp.MustCompile(`\sVALUES\s.*$`)
-var extractInsertColumnsMatch = regexp.MustCompile(`INSERT INTO .+\s\((?P<Columns>.+)\)$`)
+var extractInsertColumnsMatch = regexp.MustCompile(`(?s)INSERT INTO .+\s\((?P<Columns>.+)\)$`)
 
 func extractNormalizedInsertQueryAndColumns(query string) (normalizedQuery string, tableName string, columns []string, err error) {
 	query = truncateFormat.ReplaceAllString(query, "")

--- a/batch_test.go
+++ b/batch_test.go
@@ -25,6 +25,7 @@ import (
 
 func TestExtractNormalizedInsertQueryAndColumns(t *testing.T) {
 	var testCases = []struct {
+		name                    string
 		query                   string
 		expectedNormalizedQuery string
 		expectedTableName       string
@@ -32,6 +33,7 @@ func TestExtractNormalizedInsertQueryAndColumns(t *testing.T) {
 		expectedError           bool
 	}{
 		{
+			name:                    "Regular insert",
 			query:                   "INSERT INTO table_name (col1, col2) VALUES (1, 2)",
 			expectedNormalizedQuery: "INSERT INTO table_name (col1, col2) FORMAT Native",
 			expectedTableName:       "table_name",
@@ -39,6 +41,33 @@ func TestExtractNormalizedInsertQueryAndColumns(t *testing.T) {
 			expectedError:           false,
 		},
 		{
+			name:                    "Lowercase insert",
+			query:                   "insert into table_name (col1, col2) values (1, 2)",
+			expectedNormalizedQuery: "insert into table_name (col1, col2) FORMAT Native",
+			expectedTableName:       "table_name",
+			expectedColumns:         []string{"col1", "col2"},
+			expectedError:           false,
+		},
+		{
+			name: "Insert with mixed case, multiline and format specified",
+			query: `INSERT INTO "db"."table_name" (
+						col1,
+						col2
+					) Values (
+						1,
+						2
+					)
+					format JSONEachRow`,
+			expectedNormalizedQuery: `INSERT INTO "db"."table_name" (
+						col1,
+						col2
+					) FORMAT Native`,
+			expectedTableName: "\"db\".\"table_name\"",
+			expectedColumns:   []string{"col1", "col2"},
+			expectedError:     false,
+		},
+		{
+			name: "Multiline insert",
 			query: `INSERT INTO table_name (
 						col1,
 						col2
@@ -55,6 +84,32 @@ func TestExtractNormalizedInsertQueryAndColumns(t *testing.T) {
 			expectedError:     false,
 		},
 		{
+			name: "Multiline insert, with columns inline",
+			query: `INSERT INTO table_name (col1, col2) VALUES (
+						1,
+						2
+					)`,
+			expectedNormalizedQuery: `INSERT INTO table_name (col1, col2) FORMAT Native`,
+			expectedTableName:       "table_name",
+			expectedColumns:         []string{"col1", "col2"},
+			expectedError:           false,
+		},
+		{
+			name: "Multiline insert, with values inline",
+			query: `INSERT INTO table_name (
+						col1,
+						col2
+					) VALUES (1, 2)`,
+			expectedNormalizedQuery: `INSERT INTO table_name (
+						col1,
+						col2
+					) FORMAT Native`,
+			expectedTableName: "table_name",
+			expectedColumns:   []string{"col1", "col2"},
+			expectedError:     false,
+		},
+		{
+			name:                    "Insert with backtick quoted database and table names",
 			query:                   "INSERT INTO `db`.`table_name` (col1, col2) VALUES (1, 2)",
 			expectedNormalizedQuery: "INSERT INTO `db`.`table_name` (col1, col2) FORMAT Native",
 			expectedTableName:       "`db`.`table_name`",
@@ -62,6 +117,15 @@ func TestExtractNormalizedInsertQueryAndColumns(t *testing.T) {
 			expectedError:           false,
 		},
 		{
+			name:                    "Insert with double quoted database and table names",
+			query:                   "INSERT INTO \"db\".\"table_name\" (col1, col2) VALUES (1, 2)",
+			expectedNormalizedQuery: "INSERT INTO \"db\".\"table_name\" (col1, col2) FORMAT Native",
+			expectedTableName:       "\"db\".\"table_name\"",
+			expectedColumns:         []string{"col1", "col2"},
+			expectedError:           false,
+		},
+		{
+			name:                    "Insert with special characters in database and table names",
 			query:                   "INSERT INTO `_test_1345# $.ДБ`.`2. Таблица №2`",
 			expectedNormalizedQuery: "INSERT INTO `_test_1345# $.ДБ`.`2. Таблица №2` FORMAT Native",
 			expectedTableName:       "`_test_1345# $.ДБ`.`2. Таблица №2`",
@@ -69,6 +133,7 @@ func TestExtractNormalizedInsertQueryAndColumns(t *testing.T) {
 			expectedError:           false,
 		},
 		{
+			name:                    "Insert with special characters in database and table names, with columns",
 			query:                   "INSERT INTO `_test_1345# $.ДБ`.`2. Таблица №2` (col1, col2)",
 			expectedNormalizedQuery: "INSERT INTO `_test_1345# $.ДБ`.`2. Таблица №2` (col1, col2) FORMAT Native",
 			expectedTableName:       "`_test_1345# $.ДБ`.`2. Таблица №2`",
@@ -76,6 +141,7 @@ func TestExtractNormalizedInsertQueryAndColumns(t *testing.T) {
 			expectedError:           false,
 		},
 		{
+			name:                    "Insert with special characters in database and table names, with columns and values",
 			query:                   "INSERT INTO `_test_1345# $.ДБ`.`2. Таблица №2` (col1, col2) VALUES (1, 2)",
 			expectedNormalizedQuery: "INSERT INTO `_test_1345# $.ДБ`.`2. Таблица №2` (col1, col2) FORMAT Native",
 			expectedTableName:       "`_test_1345# $.ДБ`.`2. Таблица №2`",
@@ -83,6 +149,7 @@ func TestExtractNormalizedInsertQueryAndColumns(t *testing.T) {
 			expectedError:           false,
 		},
 		{
+			name:                    "Insert without database name",
 			query:                   "INSERT INTO table_name (col1, col2) VALUES (1, 2) FORMAT Native",
 			expectedNormalizedQuery: "INSERT INTO table_name (col1, col2) FORMAT Native",
 			expectedTableName:       "table_name",
@@ -90,6 +157,7 @@ func TestExtractNormalizedInsertQueryAndColumns(t *testing.T) {
 			expectedError:           false,
 		},
 		{
+			name:                    "Insert without columns and values",
 			query:                   "INSERT INTO table_name",
 			expectedNormalizedQuery: "INSERT INTO table_name FORMAT Native",
 			expectedTableName:       "table_name",
@@ -97,6 +165,7 @@ func TestExtractNormalizedInsertQueryAndColumns(t *testing.T) {
 			expectedError:           false,
 		},
 		{
+			name:                    "Insert with format",
 			query:                   "INSERT INTO table_name FORMAT Native",
 			expectedNormalizedQuery: "INSERT INTO table_name FORMAT Native",
 			expectedTableName:       "table_name",
@@ -104,6 +173,15 @@ func TestExtractNormalizedInsertQueryAndColumns(t *testing.T) {
 			expectedError:           false,
 		},
 		{
+			name:                    "Insert with lowercase format",
+			query:                   "INSERT INTO table_name format Native",
+			expectedNormalizedQuery: "INSERT INTO table_name FORMAT Native",
+			expectedTableName:       "table_name",
+			expectedColumns:         []string{},
+			expectedError:           false,
+		},
+		{
+			name:                    "Insert with JSONEachRow format",
 			query:                   "INSERT INTO table_name FORMAT JSONEachRow",
 			expectedNormalizedQuery: "INSERT INTO table_name FORMAT Native",
 			expectedTableName:       "table_name",
@@ -111,6 +189,7 @@ func TestExtractNormalizedInsertQueryAndColumns(t *testing.T) {
 			expectedError:           false,
 		},
 		{
+			name:                    "Insert with quoted table name only",
 			query:                   "INSERT INTO `table_name` VALUES (1, 2)",
 			expectedNormalizedQuery: "INSERT INTO `table_name` FORMAT Native",
 			expectedTableName:       "`table_name`",
@@ -118,6 +197,7 @@ func TestExtractNormalizedInsertQueryAndColumns(t *testing.T) {
 			expectedError:           false,
 		},
 		{
+			name:          "Select, should produce error",
 			query:         "SELECT * FROM table_name",
 			expectedError: true,
 		},

--- a/batch_test.go
+++ b/batch_test.go
@@ -39,6 +39,22 @@ func TestExtractNormalizedInsertQueryAndColumns(t *testing.T) {
 			expectedError:           false,
 		},
 		{
+			query: `INSERT INTO table_name (
+						col1,
+						col2
+					) VALUES (
+						1,
+						2
+					)`,
+			expectedNormalizedQuery: `INSERT INTO table_name (
+						col1,
+						col2
+					) FORMAT Native`,
+			expectedTableName: "table_name",
+			expectedColumns:   []string{"col1", "col2"},
+			expectedError:     false,
+		},
+		{
 			query:                   "INSERT INTO `db`.`table_name` (col1, col2) VALUES (1, 2)",
 			expectedNormalizedQuery: "INSERT INTO `db`.`table_name` (col1, col2) FORMAT Native",
 			expectedTableName:       "`db`.`table_name`",


### PR DESCRIPTION
## Summary
This PR is fixing an issue when multiline INSERT statement is used and driver is using list of columns from ClickHouse table instead of provided in statement list of columns
As a result of this bug error "clickhouse: expected N arguments, got M" produced when columns count mismatch in ClickHouse table and INSERT statement

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
