### PR TITLE
Optimize Date/Date32 scan

### DIFF
--- a/lib/column/date.go
+++ b/lib/column/date.go
@@ -250,9 +250,7 @@ func parseDate(value string, minDate time.Time, maxDate time.Time, location *tim
 		return tv, nil
 	}
 	if tv, err = time.Parse(defaultDateFormatNoZone, value); err == nil {
-		return time.Date(
-			tv.Year(), tv.Month(), tv.Day(), tv.Hour(), tv.Minute(), tv.Second(), tv.Nanosecond(), location,
-		), nil
+		return getTimeWithDifferentLocation(tv, location), nil
 	}
 	return time.Time{}, err
 }
@@ -272,10 +270,10 @@ func (col *Date) Encode(buffer *proto.Buffer) {
 func (col *Date) row(i int) time.Time {
 	t := col.col.Row(i)
 
-	if col.location != nil {
+	if col.location != nil && col.location != time.UTC {
 		// proto.Date is normalized as time.Time with UTC timezone.
 		// We make sure Date return from ClickHouse matches server timezone or user defined location.
-		t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), col.location)
+		t = getTimeWithDifferentLocation(t, col.location)
 	}
 	return t
 }

--- a/lib/column/date32.go
+++ b/lib/column/date32.go
@@ -247,10 +247,10 @@ func (col *Date32) Encode(buffer *proto.Buffer) {
 func (col *Date32) row(i int) time.Time {
 	t := col.col.Row(i)
 
-	if col.location != nil {
+	if col.location != nil && col.location != time.UTC {
 		// proto.Date is normalized as time.Time with UTC timezone.
 		// We make sure Date return from ClickHouse matches server timezone or user defined location.
-		t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), col.location)
+		t = getTimeWithDifferentLocation(t, col.location)
 	}
 	return t
 }

--- a/lib/column/datetime.go
+++ b/lib/column/datetime.go
@@ -302,9 +302,7 @@ func (col *DateTime) parseDateTime(value string) (tv time.Time, err error) {
 		return tv, nil
 	}
 	if tv, err = time.Parse(defaultDateTimeFormatNoZone, value); err == nil {
-		return time.Date(
-			tv.Year(), tv.Month(), tv.Day(), tv.Hour(), tv.Minute(), tv.Second(), tv.Nanosecond(), time.Local,
-		), nil
+		return getTimeWithDifferentLocation(tv, time.Local), nil
 	}
 	return time.Time{}, err
 }

--- a/lib/column/datetime64.go
+++ b/lib/column/datetime64.go
@@ -307,9 +307,7 @@ func (col *DateTime64) parseDateTime(value string) (tv time.Time, err error) {
 		return tv, nil
 	}
 	if tv, err = time.Parse(defaultDateTime64FormatNoZone, value); err == nil {
-		return time.Date(
-			tv.Year(), tv.Month(), tv.Day(), tv.Hour(), tv.Minute(), tv.Second(), tv.Nanosecond(), time.Local,
-		), nil
+		return getTimeWithDifferentLocation(tv, time.Local), nil
 	}
 	return time.Time{}, err
 }

--- a/lib/column/time_helper.go
+++ b/lib/column/time_helper.go
@@ -1,0 +1,29 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package column
+
+import "time"
+
+// getTimeWithDifferentLocation returns the same time but with different location, e.g.
+// "2024-08-15 13:22:34 -03:00" will become "2024-08-15 13:22:34 +04:00".
+func getTimeWithDifferentLocation(t time.Time, loc *time.Location) time.Time {
+	year, month, day := t.Date()
+	hour, minute, sec := t.Clock()
+
+	return time.Date(year, month, day, hour, minute, sec, t.Nanosecond(), loc)
+}

--- a/lib/column/time_helper_test.go
+++ b/lib/column/time_helper_test.go
@@ -1,0 +1,76 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package column
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTimeWithDifferentLocation(t *testing.T) {
+	tests := []struct {
+		in   string
+		loc  *time.Location
+		want string
+	}{
+		{
+			in:   "2023-02-15 14:02:12.321 +00:00",
+			loc:  time.FixedZone("", 60*60),
+			want: "2023-02-15 14:02:12.321 +01:00",
+		},
+		{
+			in:   "2023-02-15 14:02:12.321 +03:00",
+			loc:  time.FixedZone("", -4*60*60),
+			want: "2023-02-15 14:02:12.321 -04:00",
+		},
+		{
+			in:   "2024-02-29 02:01:12 -06:00",
+			loc:  time.FixedZone("", -4*60*60),
+			want: "2024-02-29 02:01:12 -04:00",
+		},
+		{
+			in:   "2023-02-15 04:02:12.321 +02:00",
+			loc:  time.UTC,
+			want: "2023-02-15 04:02:12.321 +00:00",
+		},
+		{
+			in:   "2023-02-15 04:02:12.321 +00:00",
+			loc:  time.UTC,
+			want: "2023-02-15 04:02:12.321 +00:00",
+		},
+	}
+	for _, tt := range tests {
+		in, _ := time.Parse(defaultDateTime64FormatWithZone, tt.in)
+		got := getTimeWithDifferentLocation(in, tt.loc)
+		assert.Equal(t, tt.want, got.Format(defaultDateTime64FormatWithZone))
+	}
+}
+
+var benchmarkResultTime time.Time
+
+func BenchmarkGetTimeWithDifferentLocation(b *testing.B) {
+	t := time.Date(2023, time.April, 12, 1, 12, 33, 0, time.UTC)
+	loc := time.FixedZone("", 4*60*60)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchmarkResultTime = getTimeWithDifferentLocation(t, loc)
+	}
+}


### PR DESCRIPTION
## Summary

- Get year, month, day via a single call to `time.Time.Date` and hour, minute, seconds via `time.Time.Clock`. This change eliminates multiple calls to `time.Time.date` and `time.Time.abs`.
- Don't allocate new `time.Time` if desired location is `UTC`.

**Benchmark results of `getTimeWithDifferentLocation`:**

```
name                             old time/op    new time/op    delta
GetTimeWithDifferentLocation-32    32.8ns ± 3%    17.4ns ± 3%  -46.83%  (p=0.000 n=10+10)

name                             old alloc/op   new alloc/op   delta
GetTimeWithDifferentLocation-32     0.00B          0.00B          ~     (all equal)

name                             old allocs/op  new allocs/op  delta
GetTimeWithDifferentLocation-32      0.00           0.00          ~     (all equal)
```

<details>
  <summary>Raw benchmark results</summary>

  **Old version**

  ```go
  // "old" version
  func getTimeWithDifferentLocation(t time.Time, loc *time.Location) time.Time {
  	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), loc)
  }
  ```

  ```
  goos: linux
  goarch: amd64
  pkg: github.com/ClickHouse/clickhouse-go/v2/lib/column
  cpu: 13th Gen Intel(R) Core(TM) i9-13900HX
  BenchmarkGetTimeWithDifferentLocation
  BenchmarkGetTimeWithDifferentLocation-32    	36481345	        33.37 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	33599790	        32.63 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	38609709	        33.81 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	37585620	        32.85 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	38654622	        32.43 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	37217412	        33.23 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	34944349	        32.15 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	37236122	        32.88 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	38284749	        32.53 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	36064225	        32.32 ns/op	       0 B/op	       0 allocs/op
  PASS
  ok  	github.com/ClickHouse/clickhouse-go/v2/lib/column	12.454s
  ```

  **Optimized version**

  ```
  goos: linux
  goarch: amd64
  pkg: github.com/ClickHouse/clickhouse-go/v2/lib/column
  cpu: 13th Gen Intel(R) Core(TM) i9-13900HX
  BenchmarkGetTimeWithDifferentLocation
  BenchmarkGetTimeWithDifferentLocation-32    	73176572	        17.92 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	63622671	        17.43 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	73126280	        17.48 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	69986809	        17.41 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	69220406	        17.56 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	70910238	        17.39 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	71086362	        17.63 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	72798584	        17.16 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	68707909	        17.33 ns/op	       0 B/op	       0 allocs/op
  BenchmarkGetTimeWithDifferentLocation-32    	65608513	        17.19 ns/op	       0 B/op	       0 allocs/op
  PASS
  ok  	github.com/ClickHouse/clickhouse-go/v2/lib/column	12.387s
  ```
</details>


## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG

