### PR TITLE
Fix Enum column definition parse logic to match ClickHouse spec

### DIFF
--- a/lib/column/enum_test.go
+++ b/lib/column/enum_test.go
@@ -1,0 +1,148 @@
+package column
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractEnumNamedValues(t *testing.T) {
+	tests := []struct {
+		name           string
+		chType         Type
+		expectedType   string
+		expectedValues map[int]string
+		isNotValid     bool
+	}{
+		{
+			name:         "Enum8",
+			chType:       "Enum8('a'=1,'b'=2)",
+			expectedType: "Enum8",
+			expectedValues: map[int]string{
+				1: "a",
+				2: "b",
+			},
+		},
+		{
+			name:         "Enum16",
+			chType:       "Enum16('a'=1,'b'=2)",
+			expectedType: "Enum16",
+			expectedValues: map[int]string{
+				1: "a",
+				2: "b",
+			},
+		},
+		{
+			name:         "Enum8 with comma in value",
+			chType:       "Enum8('a'=1,'b'=2,'c,d'=3)",
+			expectedType: "Enum8",
+			expectedValues: map[int]string{
+				1: "a",
+				2: "b",
+				3: "c,d",
+			},
+		},
+		{
+			name:         "Enum8 with spaces",
+			chType:       "Enum8('a' = 1, 'b' = 2)",
+			expectedType: "Enum8",
+			expectedValues: map[int]string{
+				1: "a",
+				2: "b",
+			},
+		},
+		{
+			name:         "Enum8 without indexes",
+			chType:       "Enum8('a','b')",
+			expectedType: "Enum8",
+			expectedValues: map[int]string{
+				1: "a",
+				2: "b",
+			},
+		},
+		{
+			name:         "Enum8 with a first index only",
+			chType:       "Enum8('a'=1,'b')",
+			expectedType: "Enum8",
+			expectedValues: map[int]string{
+				1: "a",
+				2: "b",
+			},
+		},
+		{
+			name:         "Enum8 with a last index only",
+			chType:       "Enum8('a','b'=5)",
+			expectedType: "Enum8",
+			expectedValues: map[int]string{
+				1: "a",
+				5: "b",
+			},
+		},
+		{
+			name:         "Enum8 with a first index only higher than 1",
+			chType:       "Enum8('a'=5,'b')",
+			expectedType: "Enum8",
+			expectedValues: map[int]string{
+				5: "a",
+				6: "b",
+			},
+		},
+		{
+			name:         "Enum8 with index with spaces",
+			chType:       "Enum8( 'a' , 'b' = 5 )",
+			expectedType: "Enum8",
+			expectedValues: map[int]string{
+				1: "a",
+				5: "b",
+			},
+		},
+		//{
+		//	name:         "Enum8 with escaped quotes",
+		//	chType:       "Enum8('a\\'b'=1)",
+		//	expectedType: "Enum8",
+		//	expectedValues: map[int]string{
+		//		1: "a'b",
+		//	},
+		//},
+		{
+			name:       "Enum8 with invalid index",
+			chType:     "Enum8('a'=1,'b'=256)",
+			isNotValid: true,
+		},
+		{
+			name:       "Enum8 with invalid non-integer index",
+			chType:     "Enum8('a'=1,'b'='c')",
+			isNotValid: true,
+		},
+		{
+			name:       "Empty Enum8",
+			chType:     "Enum8()",
+			isNotValid: true,
+		},
+		{
+			name:       "Empty Enum8 without brackets",
+			chType:     "Enum8",
+			isNotValid: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualType, actualValues, actualIndexes, valid := extractEnumNamedValues(tt.chType)
+
+			if tt.isNotValid {
+				assert.False(t, valid, "%s is valid enum", tt.chType)
+				return
+			}
+
+			actualValuesMap := make(map[int]string)
+			for i, v := range actualValues {
+				actualValuesMap[actualIndexes[i]] = v
+			}
+
+			assert.Equal(t, tt.expectedType, actualType)
+			assert.Equal(t, tt.expectedValues, actualValuesMap)
+
+			assert.True(t, valid, "%s is not valid enum", tt.chType)
+		})
+	}
+}

--- a/lib/column/enum_test.go
+++ b/lib/column/enum_test.go
@@ -96,14 +96,14 @@ func TestExtractEnumNamedValues(t *testing.T) {
 				5: "b",
 			},
 		},
-		//{
-		//	name:         "Enum8 with escaped quotes",
-		//	chType:       "Enum8('a\\'b'=1)",
-		//	expectedType: "Enum8",
-		//	expectedValues: map[int]string{
-		//		1: "a'b",
-		//	},
-		//},
+		{
+			name:         "Enum8 with escaped quotes",
+			chType:       `Enum8('a\'b'=1)`,
+			expectedType: "Enum8",
+			expectedValues: map[int]string{
+				1: "a'b",
+			},
+		},
 		{
 			name:       "Enum8 with invalid index",
 			chType:     "Enum8('a'=1,'b'=256)",

--- a/tests/enum_test.go
+++ b/tests/enum_test.go
@@ -21,8 +21,9 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
@@ -110,7 +111,7 @@ func TestEnum(t *testing.T) {
 	require.NoError(t, err)
 	const ddl = `
 			CREATE TABLE test_enum (
-				  Col1 Enum  ('hello'   = 1,  'world' = 2)
+				  Col1 Enum  ('hello,hello'   = 1,  'world' = 2)
 				, Col2 Enum8 ('click'   = 5,  'house' = 25)
 				, Col3 Enum16('house' = 10,   'value' = 50)
 				, Col4 Array(Enum8  ('click' = 1, 'house' = 2))
@@ -126,7 +127,7 @@ func TestEnum(t *testing.T) {
 	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_enum")
 	require.NoError(t, err)
 	var (
-		col1Data = "hello"
+		col1Data = "hello,hello"
 		col2Data = "click"
 		col3Data = "house"
 		col4Data = []string{"click", "house"}

--- a/tests/issues/1299_test.go
+++ b/tests/issues/1299_test.go
@@ -1,0 +1,38 @@
+package issues
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue1299(t *testing.T) {
+	ctx := context.Background()
+	conn, err := tests.GetConnection("issues", nil, nil, nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	expectedEnumValue := "raw:48h',1h:63d,1d:5y"
+
+	const ddl = `
+		CREATE TABLE test_1299 (
+				Col1 Enum ('raw:48h\',1h:63d,1d:5y' = 1, 'raw:8h,1m:48h,1h:63d,1d:5y' = 2)
+		) Engine MergeTree() ORDER BY tuple()
+		`
+	err = conn.Exec(ctx, ddl)
+	require.NoError(t, err)
+	defer conn.Exec(ctx, "DROP TABLE test_1299")
+
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_1299")
+	require.NoError(t, err)
+	require.NoError(t, batch.Append(expectedEnumValue))
+	require.NoError(t, batch.Send())
+
+	var actualEnumValue string
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_1299").Scan(&actualEnumValue))
+
+	assert.Equal(t, expectedEnumValue, actualEnumValue)
+}


### PR DESCRIPTION
Enum column value is allowed to contain a comma or escaped single quote: https://clickhouse.com/docs/en/sql-reference/data-types/enum

resolves https://github.com/ClickHouse/clickhouse-go/issues/1299