### PR TITLE
Fix support custom serialization in Nested type

### DIFF
--- a/lib/column/nested.go
+++ b/lib/column/nested.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type Nested struct {
@@ -84,6 +86,24 @@ func nestedColumns(raw string) (columns []namedCol) {
 		}
 	}
 	return
+}
+
+func (col *Nested) ReadStatePrefix(reader *proto.Reader) error {
+	if serialize, ok := col.Interface.(CustomSerialization); ok {
+		if err := serialize.ReadStatePrefix(reader); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (col *Nested) WriteStatePrefix(buffer *proto.Buffer) error {
+	if serialize, ok := col.Interface.(CustomSerialization); ok {
+		if err := serialize.WriteStatePrefix(buffer); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 var _ Interface = (*Nested)(nil)

--- a/tests/issues/1297_test.go
+++ b/tests/issues/1297_test.go
@@ -1,0 +1,41 @@
+package issues
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/require"
+)
+
+func Test1297(t *testing.T) {
+	testEnv, err := clickhouse_tests.GetTestEnvironment("issues")
+	require.NoError(t, err)
+	conn, err := clickhouse_tests.TestClientWithDefaultOptions(testEnv, clickhouse.Settings{
+		"flatten_nested": "0",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, conn.Exec(context.Background(), `CREATE TABLE test_1297
+(
+    Id UInt8,
+    Device LowCardinality(String),
+    Nestme Nested(
+    	Id UInt32,
+		TestLC LowCardinality(String),
+		Test String
+	)
+)
+ENGINE = MergeTree
+ORDER BY Id;`), "Create table failed")
+	t.Cleanup(func() {
+		conn.Exec(context.Background(), "DROP TABLE IF EXISTS test_1297")
+	})
+
+	batch, err := conn.PrepareBatch(context.Background(), "INSERT INTO test_1297")
+	require.NoError(t, err, "PrepareBatch failed")
+
+	require.NoError(t, batch.Append(uint8(1), "pc", []any{[]any{1, "test LC 1", "test"}, []any{2, "test LC 2", "test"}}), "Append failed")
+	require.NoError(t, batch.Send())
+}

--- a/tests/read_only_user_test.go
+++ b/tests/read_only_user_test.go
@@ -19,10 +19,11 @@ package tests
 
 import (
 	"context"
+	"testing"
+
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestReadOnlyUser(t *testing.T) {
@@ -95,7 +96,7 @@ func TestReadOnlyUser(t *testing.T) {
 	roEnv.Username = username
 	roEnv.Password = password
 
-	roClient, err := testClientWithDefaultOptions(roEnv, nil)
+	roClient, err := TestClientWithDefaultOptions(roEnv, nil)
 	require.NoError(t, err)
 	defer roClient.Close()
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -324,7 +324,7 @@ func ClientOptionsFromEnv(env ClickHouseTestEnvironment, settings clickhouse.Set
 	}
 }
 
-func testClientWithDefaultOptions(env ClickHouseTestEnvironment, settings clickhouse.Settings) (driver.Conn, error) {
+func TestClientWithDefaultOptions(env ClickHouseTestEnvironment, settings clickhouse.Settings) (driver.Conn, error) {
 	opts := ClientOptionsFromEnv(env, settings, false)
 	return clickhouse.Open(&opts)
 }
@@ -347,7 +347,7 @@ func TestClientDefaultSettings(env ClickHouseTestEnvironment) clickhouse.Setting
 }
 
 func TestClientWithDefaultSettings(env ClickHouseTestEnvironment) (driver.Conn, error) {
-	return testClientWithDefaultOptions(env, TestClientDefaultSettings(env))
+	return TestClientWithDefaultOptions(env, TestClientDefaultSettings(env))
 }
 
 func TestDatabaseSQLClientWithDefaultOptions(env ClickHouseTestEnvironment, settings clickhouse.Settings) (*sql.DB, error) {


### PR DESCRIPTION
A state prefix is required in the LowCardinality column. Nested type didn't propagate state for underlying types.

resolves https://github.com/ClickHouse/clickhouse-go/issues/1297