### PR TITLE
Modify client version range supported by the go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The client is tested against the currently [supported versions](https://github.c
 | Client Version | Golang Versions |
 |----------------|-----------------|
 | => 2.0 <= 2.2  | 1.17, 1.18      |
-| >= 2.3         | 1.18.4+, 1.19   |
+| >= 2.13        | 1.18.4+, 1.19   |
 | >= 2.14        | 1.20, 1.21      |
 | >= 2.19        | 1.21, 1.22      |
 | >= 2.28        | 1.22, 1.23      |


### PR DESCRIPTION
## Summary
Fix the client version corresponding to golang, for gov1.19, the supported version should be >= 2.13.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
