### PR TITLE
Revert the minimum required Go version to 1.21

### DIFF
--- a/.github/workflows/run-tests-cloud.yml
+++ b/.github/workflows/run-tests-cloud.yml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         go:
           - "1.23"
-          - "1.22"
     steps:
       - name: Check Out Code
         uses: actions/checkout@v3

--- a/.github/workflows/run-tests-head.yml
+++ b/.github/workflows/run-tests-head.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         go:
           - "1.23"
-          - "1.22"
     steps:
       - uses: actions/checkout@main
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,6 +20,7 @@ jobs:
         go:
           - "1.23"
           - "1.22"
+          - "1.21"
         clickhouse: # https://github.com/ClickHouse/ClickHouse/blob/master/SECURITY.md#scope-and-supported-versions
           - "24.8"
           - "24.7"

--- a/README.md
+++ b/README.md
@@ -40,13 +40,14 @@ The client is tested against the currently [supported versions](https://github.c
 
 ## Supported Golang Versions
 
-| Client Version | Golang Versions |
-|----------------|-----------------|
-| => 2.0 <= 2.2  | 1.17, 1.18      |
-| >= 2.3         | 1.18.4+, 1.19   |
-| >= 2.14        | 1.20, 1.21      |
-| >= 2.19        | 1.21, 1.22      |
-| >= 2.28        | 1.22, 1.23      |
+| Client Version | Golang Versions  |
+|----------------|------------------|
+| => 2.0 <= 2.2  | 1.17, 1.18       |
+| >= 2.3         | 1.18.4+, 1.19    |
+| >= 2.14        | 1.20, 1.21       |
+| >= 2.19        | 1.21, 1.22       |
+| >= 2.28        | 1.22, 1.23       |
+| >= 2.29        | 1.21, 1.22, 1.23 |
 
 ## Documentation
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ClickHouse/clickhouse-go/v2
 
-go 1.22
+go 1.21
 
 require (
 	github.com/ClickHouse/ch-go v0.61.5


### PR DESCRIPTION
This PR reverts Go minimum version to 1.21 as suggested in https://github.com/ClickHouse/clickhouse-go/discussions/1397.

Also, we will save on cloud/head test to run only a single Go version.