### PR TITLE
[Chore] Use defer to close rows in examples

### DIFF
--- a/examples/clickhouse_api/array.go
+++ b/examples/clickhouse_api/array.go
@@ -68,12 +68,13 @@ func ArrayInsertRead() error {
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
+
 	for rows.Next() {
 		if err := rows.Scan(&col1, &col2); err != nil {
 			return err
 		}
 		fmt.Printf("row: col1=%v, col2=%v\n", col1, col2)
 	}
-	rows.Close()
 	return rows.Err()
 }

--- a/examples/clickhouse_api/external_data.go
+++ b/examples/clickhouse_api/external_data.go
@@ -63,6 +63,8 @@ func ExternalData() error {
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
+
 	for rows.Next() {
 		var (
 			col1 uint8
@@ -72,7 +74,6 @@ func ExternalData() error {
 		rows.Scan(&col1, &col2, &col3)
 		fmt.Printf("col1=%d, col2=%s, col3=%v\n", col1, col2, col3)
 	}
-	rows.Close()
 
 	var count uint64
 	if err := conn.QueryRow(ctx, "SELECT COUNT(*) FROM external_table_1").Scan(&count); err != nil {

--- a/examples/clickhouse_api/map.go
+++ b/examples/clickhouse_api/map.go
@@ -20,8 +20,9 @@ package clickhouse_api
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column/orderedmap"
 	"strconv"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column/orderedmap"
 )
 
 func MapInsertRead() error {
@@ -72,13 +73,15 @@ func MapInsertRead() error {
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
+
 	for rows.Next() {
 		if err := rows.Scan(&col1, &col2, &col3); err != nil {
 			return err
 		}
 		fmt.Printf("row: col1=%v, col2=%v, col3=%v\n", col1, col2, col3)
 	}
-	rows.Close()
+
 	return rows.Err()
 }
 
@@ -124,6 +127,8 @@ func IterableOrderedMapInsertRead() error {
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
+
 	for rows.Next() {
 		var col1 orderedmap.Map[string, string]
 		if err := rows.Scan(&col1); err != nil {
@@ -131,6 +136,6 @@ func IterableOrderedMapInsertRead() error {
 		}
 		fmt.Printf("row: col1=%v\n", col1)
 	}
-	rows.Close()
+
 	return rows.Err()
 }

--- a/examples/clickhouse_api/nested.go
+++ b/examples/clickhouse_api/nested.go
@@ -20,8 +20,9 @@ package clickhouse_api
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"strconv"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func NestedUnFlattened() error {
@@ -109,13 +110,15 @@ func NestedUnFlattened() error {
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
+
 	for rows.Next() {
 		if err := rows.Scan(&col1, &col2); err != nil {
 			return err
 		}
 		fmt.Printf("row: col1=%v, col2=%v\n", col1, col2)
 	}
-	rows.Close()
+
 	return rows.Err()
 }
 

--- a/examples/clickhouse_api/progress.go
+++ b/examples/clickhouse_api/progress.go
@@ -20,6 +20,7 @@ package clickhouse_api
 import (
 	"context"
 	"fmt"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
@@ -45,10 +46,11 @@ func ProgressProfileLogs() error {
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
+
 	for rows.Next() {
 	}
 
 	fmt.Printf("Total Rows: %d\n", totalRows)
-	rows.Close()
 	return rows.Err()
 }

--- a/examples/std/external_data.go
+++ b/examples/std/external_data.go
@@ -63,6 +63,8 @@ func ExternalData() error {
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
+
 	for rows.Next() {
 		var (
 			col1 uint8
@@ -72,7 +74,6 @@ func ExternalData() error {
 		rows.Scan(&col1, &col2, &col3)
 		fmt.Printf("col1=%d, col2=%s, col3=%v\n", col1, col2, col3)
 	}
-	rows.Close()
 
 	var count uint64
 	if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM external_table_1").Scan(&count); err != nil {

--- a/examples/std/open_db.go
+++ b/examples/std/open_db.go
@@ -94,6 +94,8 @@ func OpenDb() error {
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
+
 	for rows.Next() {
 		var (
 			col1 uint8
@@ -105,6 +107,6 @@ func OpenDb() error {
 		}
 		fmt.Printf("row: col1=%d, col2=%s, col3=%s\n", col1, col2, col3)
 	}
-	rows.Close()
+
 	return rows.Err()
 }

--- a/examples/std/progress.go
+++ b/examples/std/progress.go
@@ -20,6 +20,7 @@ package std
 import (
 	"context"
 	"fmt"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
@@ -45,10 +46,11 @@ func ProgressProfileLogs() error {
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
+
 	for rows.Next() {
 	}
 
 	fmt.Printf("Total Rows: %d\n", totalRows)
-	rows.Close()
 	return rows.Err()
 }


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
- Updated `row.Close()` to `defer rows.Close()` 
- It ensures that row resources are consistently released, even if an error occurs during further processing in the function. Using `defer` to close resources improves code reliability and readability.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
