### PR TITLE
Add Variant Type

### DIFF
--- a/lib/chcol/variant.go
+++ b/lib/chcol/variant.go
@@ -1,0 +1,141 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package chcol
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+// Variant represents a ClickHouse Variant type that can hold multiple possible types
+type Variant struct {
+	value any
+}
+
+// NewVariant creates a new Variant with the given value
+func NewVariant(v any) Variant {
+	return Variant{value: v}
+}
+
+// Any returns the underlying value as any. Same as Interface.
+func (v Variant) Any() any {
+	return v.value
+}
+
+// Interface returns the underlying value as interface{}. Same as Any.
+func (v Variant) Interface() interface{} {
+	return v.value
+}
+
+// Int64 returns the value as an int64 if possible
+func (v Variant) Int64() (int64, bool) {
+	if i, ok := v.value.(int64); ok {
+		return i, true
+	}
+
+	return 0, false
+}
+
+// String returns the value as a string if possible
+func (v Variant) String() (string, bool) {
+	if s, ok := v.value.(string); ok {
+		return s, true
+	}
+
+	return "", false
+}
+
+// Bool returns the value as an bool if possible
+func (v Variant) Bool() (bool, bool) {
+	if b, ok := v.value.(bool); ok {
+		return b, true
+	}
+
+	return false, false
+}
+
+// MustInt64 returns the bool value or panics if not possible
+func (v Variant) MustInt64() int64 {
+	i, ok := v.Int64()
+	if !ok {
+		panic(fmt.Sprintf("variant value %v is not an int64", v.value))
+	}
+
+	return i
+}
+
+// MustString returns the string value or panics if not possible
+func (v Variant) MustString() string {
+	s, ok := v.String()
+	if !ok {
+		panic(fmt.Sprintf("variant value %v is not a string", v.value))
+	}
+
+	return s
+}
+
+// MustBool returns the bool value or panics if not possible
+func (v Variant) MustBool() bool {
+	b, ok := v.Bool()
+	if !ok {
+		panic(fmt.Sprintf("variant value %v is not a bool", v.value))
+	}
+
+	return b
+}
+
+// Scan implements the sql.Scanner interface
+func (v *Variant) Scan(value interface{}) error {
+	if value == nil {
+		v.value = nil
+		return nil
+	}
+
+	v.value = value
+	return nil
+}
+
+// Value implements the driver.Valuer interface
+func (v Variant) Value() (driver.Value, error) {
+	return v.value, nil
+}
+
+func (v Variant) WithType(chType string) VariantWithType {
+	return VariantWithType{
+		Variant: v,
+		chType:  chType,
+	}
+}
+
+type VariantWithType struct {
+	Variant
+	chType string
+}
+
+// NewVariantWithType creates a new Variant with the given value and encoding type
+func NewVariantWithType(v any, chType string) VariantWithType {
+	return VariantWithType{
+		Variant: Variant{value: v},
+		chType:  chType,
+	}
+}
+
+// Type returns the ClickHouse type as a string.
+func (v VariantWithType) Type() string {
+	return v.chType
+}

--- a/lib/chcol/variant_test.go
+++ b/lib/chcol/variant_test.go
@@ -1,0 +1,60 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package chcol
+
+import (
+	"testing"
+)
+
+func TestVariant_Int64(t *testing.T) {
+	var in int64 = 42
+
+	v := NewVariant(in)
+
+	out, ok := v.Int64()
+	if !ok {
+		t.Fatalf("failed to get int64 from variant")
+	} else if out != in {
+		t.Fatalf("incorrect value from variant. expected: %d got: %d", in, out)
+	}
+}
+
+func TestVariant_String(t *testing.T) {
+	in := "test"
+
+	v := NewVariant(in)
+
+	out, ok := v.String()
+	if !ok {
+		t.Fatalf("failed to get string from variant")
+	} else if out != in {
+		t.Fatalf("incorrect value from variant. expected: %s got: %s", in, out)
+	}
+}
+
+func TestVariant_TypeSwitch(t *testing.T) {
+	in := struct{}{}
+
+	v := NewVariant(in)
+
+	if i, ok := v.Int64(); ok {
+		t.Fatalf("unexpected int64 value from variant: %d", i)
+	} else if s, ok := v.String(); ok {
+		t.Fatalf("unexpected string value from variant: %s", s)
+	}
+}

--- a/lib/column/codegen/column.tpl
+++ b/lib/column/codegen/column.tpl
@@ -130,6 +130,8 @@ func (t Type) Column(name string, tz *time.Location) (Interface, error) {
 		return (&Map{name: name}).parse(t, tz)
 	case strings.HasPrefix(string(t), "Tuple("):
 		return (&Tuple{name: name}).parse(t, tz)
+	case strings.HasPrefix(string(t), "Variant("):
+		return (&ColVariant{name: name}).parse(t, tz)
 	case strings.HasPrefix(string(t), "Decimal("):
 		return (&Decimal{name: name}).parse(t)
 	case strings.HasPrefix(strType, "Nested("):

--- a/lib/column/column_gen.go
+++ b/lib/column/column_gen.go
@@ -136,7 +136,7 @@ func (t Type) Column(name string, tz *time.Location) (Interface, error) {
 	case "Point":
 		return &Point{name: name}, nil
 	case "String":
-		return &String{name: name, col: colStrProvider()}, nil
+		return &String{name: name}, nil
 	case "Object('json')":
 		return &JSONObject{name: name, root: true, tz: tz}, nil
 	}
@@ -146,6 +146,8 @@ func (t Type) Column(name string, tz *time.Location) (Interface, error) {
 		return (&Map{name: name}).parse(t, tz)
 	case strings.HasPrefix(string(t), "Tuple("):
 		return (&Tuple{name: name}).parse(t, tz)
+	case strings.HasPrefix(string(t), "Variant("):
+		return (&ColVariant{name: name}).parse(t, tz)
 	case strings.HasPrefix(string(t), "Decimal("):
 		return (&Decimal{name: name}).parse(t)
 	case strings.HasPrefix(strType, "Nested("):

--- a/lib/column/variant.go
+++ b/lib/column/variant.go
@@ -1,0 +1,272 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package column
+
+import (
+	"fmt"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/ch-go/proto"
+)
+
+const NullVariantDiscriminator uint8 = 255
+
+type ColVariant struct {
+	chType Type
+	name   string
+	rows   int
+
+	serializationVersion uint64
+
+	discriminators []uint8
+	offsets        []int
+	lengthsByType  map[uint8]int
+
+	columns []Interface
+	index   map[string]int
+}
+
+func (c *ColVariant) parse(t Type, tz *time.Location) (_ Interface, err error) {
+	c.chType = t
+	var (
+		element       []rune
+		elements      []namedCol
+		brackets      int
+		appendElement = func() {
+			if len(element) != 0 {
+				cType := strings.TrimSpace(string(element))
+				name := ""
+				if parts := strings.SplitN(cType, " ", 2); len(parts) == 2 {
+					if !strings.Contains(parts[0], "(") {
+						name = parts[0]
+						cType = parts[1]
+					}
+				}
+
+				elements = append(elements, namedCol{
+					name:    name,
+					colType: Type(strings.TrimSpace(cType)),
+				})
+			}
+		}
+	)
+
+	for _, r := range t.params() {
+		switch r {
+		case '(':
+			brackets++
+		case ')':
+			brackets--
+		case ',':
+			if brackets == 0 {
+				appendElement()
+				element = element[:0]
+				continue
+			}
+		}
+		element = append(element, r)
+	}
+
+	appendElement()
+	c.index = make(map[string]int)
+
+	for i, ct := range elements {
+		column, err := ct.colType.Column(ct.name, tz)
+		if err != nil {
+			return nil, err
+		}
+
+		c.columns = append(c.columns, column)
+		c.index[ct.name] = i
+	}
+
+	if len(c.columns) != 0 {
+		return c, nil
+	}
+
+	return nil, &UnsupportedColumnTypeError{
+		t: t,
+	}
+}
+
+func (c *ColVariant) Name() string {
+	return c.name
+}
+
+func (c *ColVariant) Type() Type {
+	return c.chType
+}
+
+func (c *ColVariant) Rows() int {
+	return c.rows
+}
+
+func (c *ColVariant) Row(i int, ptr bool) any {
+	typeIndex := c.discriminators[i]
+	if typeIndex == NullVariantDiscriminator {
+		return nil
+	}
+
+	return c.columns[typeIndex].Row(c.offsets[i], ptr)
+}
+
+func (c *ColVariant) ScanRow(dest any, row int) error {
+	typeIndex := c.discriminators[row]
+	offsetIndex := c.offsets[row]
+	var value any
+	if typeIndex != NullVariantDiscriminator {
+		value = c.columns[typeIndex].Row(offsetIndex, false)
+	}
+
+	switch v := dest.(type) {
+	case *chcol.Variant:
+		vt := chcol.NewVariant(value)
+		*v = vt
+	case **chcol.Variant:
+		vt := chcol.NewVariant(value)
+		**v = vt
+	default:
+		if typeIndex == NullVariantDiscriminator {
+			return nil
+		}
+
+		if err := c.columns[typeIndex].ScanRow(dest, offsetIndex); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *ColVariant) Append(v any) (nulls []uint8, err error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *ColVariant) AppendRow(v any) error {
+	if v == nil {
+		c.rows++
+		c.discriminators = append(c.discriminators, NullVariantDiscriminator)
+		return nil
+	}
+
+	var forcedType Type
+	switch v.(type) {
+	case chcol.VariantWithType:
+		forcedType = Type(v.(chcol.VariantWithType).Type())
+	case *chcol.VariantWithType:
+		forcedType = Type(v.(*chcol.VariantWithType).Type())
+	}
+
+	if forcedType != "" {
+		var i int
+		var col Interface
+		var ok bool
+		// TODO: this could be pre-calculated as a map[string]int (name->index)
+		for i, col = range c.columns {
+			if col.Type() == forcedType {
+				ok = true
+				break
+			}
+		}
+
+		if !ok {
+			return fmt.Errorf("value %v cannot be stored in variant column %s %s with forced type %s: type not present in variant", v, c.name, c.chType, forcedType)
+		}
+
+		if err := col.AppendRow(v); err != nil {
+			return fmt.Errorf("value %v cannot be stored in variant column %s %s with forced type %s: %w", v, c.name, c.chType, forcedType, err)
+		}
+
+		c.rows++
+		c.discriminators = append(c.discriminators, uint8(i))
+		return nil
+	}
+
+	// If preferred type wasn't provided, try each column
+	var err error
+	for i, col := range c.columns {
+		if err = col.AppendRow(v); err == nil {
+			c.rows++
+			c.discriminators = append(c.discriminators, uint8(i))
+			return nil
+		}
+	}
+
+	return fmt.Errorf("value %v cannot be stored in variant column %s %s: %w", v, c.name, c.chType, err)
+}
+
+func (c *ColVariant) Encode(buffer *proto.Buffer) {
+	buffer.PutUInt64(c.serializationVersion)
+	buffer.PutRaw(c.discriminators)
+
+	for _, col := range c.columns {
+		col.Encode(buffer)
+	}
+}
+
+func (c *ColVariant) ScanType() reflect.Type {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *ColVariant) Reset() {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c *ColVariant) Decode(reader *proto.Reader, rows int) error {
+	c.rows = rows
+	var err error
+	c.serializationVersion, err = reader.UInt64()
+	if err != nil {
+		return fmt.Errorf("failed to read variant serialization version: %w", err)
+	}
+
+	c.discriminators = make([]uint8, c.rows)
+	c.offsets = make([]int, c.rows)
+	c.lengthsByType = make(map[uint8]int, len(c.columns))
+
+	for i := 0; i < c.rows; i++ {
+		disc, err := reader.ReadByte()
+		if err != nil {
+			return fmt.Errorf("failed to read variant discriminator at index %d: %w", i, err)
+		}
+
+		c.discriminators[i] = disc
+		if c.lengthsByType[disc] == 0 {
+			c.lengthsByType[disc] = 1
+		} else {
+			c.lengthsByType[disc]++
+		}
+
+		c.offsets[i] = c.lengthsByType[disc] - 1
+	}
+
+	for i, col := range c.columns {
+		cRows := c.lengthsByType[uint8(i)]
+		if err := col.Decode(reader, cRows); err != nil {
+			return fmt.Errorf("failed to decode variant column with %s type: %w", col.Type(), err)
+		}
+	}
+
+	return nil
+}

--- a/tests/variant_test.go
+++ b/tests/variant_test.go
@@ -1,0 +1,116 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tests
+
+import (
+	"context"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestVariant(t *testing.T) {
+	ctx := context.Background()
+
+	conn, err := GetNativeConnection(clickhouse.Settings{
+		"max_execution_time":              60,
+		"allow_experimental_variant_type": true,
+	}, nil, &clickhouse.Compression{
+		Method: clickhouse.CompressionLZ4,
+	})
+	require.NoError(t, err)
+
+	const ddl = `
+			CREATE TABLE IF NOT EXISTS test_variant (
+				  c Variant(Array(UInt8), Bool, Int64, String)                  
+			) Engine = MergeTree() ORDER BY tuple()
+		`
+	require.NoError(t, conn.Exec(ctx, ddl))
+	defer func() {
+		require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_variant"))
+	}()
+
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_variant (c)")
+	require.NoError(t, err)
+	require.NoError(t, batch.Append(42))
+	require.NoError(t, batch.Append(chcol.NewVariantWithType("test", "String")))
+	require.NoError(t, batch.Append(true))
+	require.NoError(t, batch.Append(chcol.NewVariant([]uint8{0xA, 0xB, 0xC}).WithType("Array(UInt8)")))
+	require.NoError(t, batch.Append(nil))
+	require.NoError(t, batch.Append(84))
+	require.NoError(t, batch.Append(chcol.NewVariantWithType("test2", "String")))
+	require.NoError(t, batch.Append(true))
+	require.NoError(t, batch.Append(chcol.NewVariant([]uint8{0xD, 0xE, 0xF}).WithType("Array(UInt8)")))
+	require.NoError(t, batch.Send())
+
+	rows, err := conn.Query(ctx, "SELECT c from test_variant")
+	require.NoError(t, err)
+
+	var row chcol.Variant
+
+	require.True(t, rows.Next())
+	err = rows.Scan(&row)
+	require.NoError(t, err)
+	require.Equal(t, int64(42), row.MustInt64())
+
+	require.True(t, rows.Next())
+	err = rows.Scan(&row)
+	require.NoError(t, err)
+	require.Equal(t, "test", row.MustString())
+
+	require.True(t, rows.Next())
+	err = rows.Scan(&row)
+	require.NoError(t, err)
+	require.Equal(t, true, row.MustBool())
+
+	require.True(t, rows.Next())
+	err = rows.Scan(&row)
+	require.NoError(t, err)
+	require.Equal(t, []uint8{0xA, 0xB, 0xC}, row.Any().([]uint8))
+
+	require.True(t, rows.Next())
+	err = rows.Scan(&row)
+	require.NoError(t, err)
+	require.Equal(t, nil, row.Any())
+
+	var i int64
+	require.True(t, rows.Next())
+	err = rows.Scan(&i)
+	require.NoError(t, err)
+	require.Equal(t, int64(84), i)
+
+	var s string
+	require.True(t, rows.Next())
+	err = rows.Scan(&s)
+	require.NoError(t, err)
+	require.Equal(t, "test2", s)
+
+	var b bool
+	require.True(t, rows.Next())
+	err = rows.Scan(&b)
+	require.NoError(t, err)
+	require.Equal(t, true, b)
+
+	var u8s []uint8
+	require.True(t, rows.Next())
+	err = rows.Scan(&u8s)
+	require.NoError(t, err)
+	require.Equal(t, []uint8{0xD, 0xE, 0xF}, u8s)
+
+}


### PR DESCRIPTION
## Summary
Draft PR to discuss the possible `Variant` implementations. By implementing `Variant`, we can re-use a large portion of the logic for `Dynamic`, and then `JSON`. Partially resolves #1430.

# Implementation

This implementation adds 3 major types to the module:
- `ColVariant` - the column implementation for (de)serialization
- `Variant` - a container to hold variant values (optional for (de)serialization)
- `VariantWithType` - an extension of `Variant`, with the ability to provide a preferred type in cases where it is ambiguous to existing column type detection (such as `Array(UInt8)` vs `String`)

### `ColVariant`

#### Serialization

```go
// Variant(Array(Map(String, String)), Array(UInt8), Bool, Int64, String)
batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_variant (c)")
require.NoError(t, err)
require.NoError(t, batch.Append(42)) // Accepts primitives
require.NoError(t, batch.Append(chcol.NewVariantWithType("test", "String"))) // Accepts Variants with type preference
require.NoError(t, batch.Append(true))
require.NoError(t, batch.Append(chcol.NewVariant([]uint8{0xA, 0xB, 0xC}).WithType("Array(UInt8)"))) 
require.NoError(t, batch.Append(nil)) // Accepts nil
require.NoError(t, batch.Append([]map[string]string{{"key1": "val1"}, {"key2": "val2"}})) // Accepts complex types
```

When values are appended via `col.AppendRow()`, the input `v interface{}` type is checked. If it is `nil`, a `Null` discriminator is appended. If it is a `VariantWithType`, then the specified column type will be appended along with its matching discriminator. The underlying column's `AppendRow` function is re-used so that we don't need to re-implement its logic.

As a catch-all, the input value will be tested against each column type until it succeeds. For example, `Variant(Bool, Int64, String)` will try to append as `bool`, `int64`, then `string`. If a value does not fit into any column type, it will return an error.

Sometimes types will conflict. Due to alphabetical sorting of the type, `Array(UInt8)` would be used before `String` since `Array` allows for `string` input. I have researched different solutions to this, including a [type priority system](https://github.com/ClickHouse/ClickHouse/blob/1aceb608f3863822277fed9f34021178118e4c5b/src/DataTypes/Serializations/SerializationVariant.cpp#L671-L815), but it would be complex to implement. For now it is easiest to let the user simply input `NewVariantWithType(int64(42), "Int64")` or `NewVariant(int64(42)).WithType("Int64")` if they want a specific type within the variant. For complex types like maps, reflection will be used if a type isn't specified.

After all rows are appended, the Native format is used to serialize the data into the buffer. First with `serializationVersion`, then the `uint8` array for `discriminators`, then each column's `Encode` function is re-used as usual (similar to `Tuple`).


#### Deserialization

The Native format deserializes the `discriminators` and builds a set of `offsets` for each column. This allows for storing multiple columns with mixed lengths. When the user wants to read a row, we can index into the correct row of each column to get the corresponding type.

In practice this looks like this:

```go
var row chcol.Variant // Scan into variant

require.True(t, rows.Next())
err = rows.Scan(&row)
require.NoError(t, err)
require.Equal(t, int64(42), row.MustInt64()) // Variant provides convenience functions for returning a primitive
```

Or, if you know your types ahead of time, you can also scan directly into it:
```go
var i int64 // Scan directly into int64
require.True(t, rows.Next())
err = rows.Scan(&i)
require.NoError(t, err)
require.Equal(t, int64(84), i)
```

This pattern works by simply calling the underlying column's `ScanRow` function. It is safest to scan into `Variant` however.
If you need to switch types on `Variant` for your own type detection, you can use `variantRow.Any()` or `variantRow.Interface()` to return `any`/`interface{}` respectively (provided both for preferred semantics).

### `Variant`

Variant is simply a wrapper around `any`. It implements stdlib sql interfaces such as `driver.Value` and `Scan`. It also has convenience functions for primitives such as `Int64`. If you need to access the underlying value you can use `Any()`. This type can be constructed with the `NewVariant(v)` function.

The `Variant` type should be used in structs and when scanning from `ColVariant`. It can also be used for insertion, although `VariantWithType` may be required if there's overlap between types.

### `VariantWithType`

`VariantWithType` is the same as `Variant`, but with a `string` included to specify the preferred type. You can use this for insertion when the Variant column has types that overlap. For example if you had `Variant(Array(UInt8), String)`, a Go `string` would be inserted as an `Array(UInt8)`. If you wanted to force this to be a ClickHouse `String`, you could use `NewVariantWithType(v, "String")` to provide the preferred type. If the preferred type is not present in the Variant, the row will fail to append to the block. Types can be added on an existing `Variant` by calling `exampleVariant.WithType(t string)`, which will return a new `VariantWithType`.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
