### PR TITLE
Remove forced string conversions for Tuple

### DIFF
--- a/lib/column/tuple.go
+++ b/lib/column/tuple.go
@@ -200,13 +200,6 @@ func setJSONFieldValue(field reflect.Value, value reflect.Value) error {
 		}
 	}
 
-	// check if our target is a string
-	if field.Kind() == reflect.String {
-		if v := reflect.ValueOf(fmt.Sprint(value.Interface())); v.Type().AssignableTo(field.Type()) {
-			field.Set(v)
-			return nil
-		}
-	}
 	if value.CanConvert(field.Type()) {
 		field.Set(value.Convert(field.Type()))
 		return nil

--- a/tests/issues/1446_test.go
+++ b/tests/issues/1446_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,19 +51,12 @@ func TestIssue1446(t *testing.T) {
 
 	failRow := sampleFailRow{}
 	err = conn.QueryRow(ctx, "SELECT * FROM issue_1446 LIMIT 1").ScanStruct(&failRow)
-	if err == nil {
-		t.Errorf("expected column convert error for tuple *string to string")
-	}
+	assert.EqualError(t, err, "clickhouse [ScanRow]: (my_tuple) converting *string to string is unsupported")
 
 	okRow := sampleOkRow{}
 	err = conn.QueryRow(ctx, "SELECT * FROM issue_1446 LIMIT 1").ScanStruct(&okRow)
 	require.NoError(t, err)
 
-	if *okRow.MyTuple.TupleOne != "one" {
-		t.Errorf("expected 'one' but got '%s'", *okRow.MyTuple.TupleOne)
-	}
-
-	if *okRow.MyTuple.TupleTwo != "two" {
-		t.Errorf("expected 'two' but got '%s'", *okRow.MyTuple.TupleTwo)
-	}
+	assert.Equal(t, "one", *okRow.MyTuple.TupleOne)
+	assert.Equal(t, "two", *okRow.MyTuple.TupleTwo)
 }

--- a/tests/issues/1446_test.go
+++ b/tests/issues/1446_test.go
@@ -1,0 +1,68 @@
+package issues
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/require"
+)
+
+type sampleFailTuple struct {
+	TupleOne string `ch:"tuple_one"`
+	TupleTwo string `ch:"tuple_two"`
+}
+
+type sampleFailRow struct {
+	MyId    uint64          `ch:"my_id"`
+	MyTuple sampleFailTuple `ch:"my_tuple"`
+}
+
+type sampleOkTuple struct {
+	TupleOne *string `ch:"tuple_one"`
+	TupleTwo *string `ch:"tuple_two"`
+}
+
+type sampleOkRow struct {
+	MyId    uint64        `ch:"my_id"`
+	MyTuple sampleOkTuple `ch:"my_tuple"`
+}
+
+func TestIssue1446(t *testing.T) {
+	ctx := context.Background()
+
+	conn, err := tests.GetConnection("issues", nil, nil, nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	const ddl = `
+		CREATE TABLE IF NOT EXISTS issue_1446(
+			my_id    UInt64,
+			my_tuple Tuple(tuple_one Nullable(String), tuple_two Nullable(String))
+		) ENGINE = MergeTree PRIMARY KEY (my_id) ORDER BY (my_id)
+	`
+	err = conn.Exec(ctx, ddl)
+	require.NoError(t, err)
+	defer conn.Exec(ctx, "DROP TABLE issue_1446")
+
+	err = conn.Exec(ctx, "INSERT INTO issue_1446(my_id, my_tuple) VALUES (1, tuple('one', 'two'))")
+	require.NoError(t, err)
+
+	failRow := sampleFailRow{}
+	err = conn.QueryRow(ctx, "SELECT * FROM issue_1446 LIMIT 1").ScanStruct(&failRow)
+	if err == nil {
+		t.Errorf("expected column convert error for tuple *string to string")
+	}
+
+	okRow := sampleOkRow{}
+	err = conn.QueryRow(ctx, "SELECT * FROM issue_1446 LIMIT 1").ScanStruct(&okRow)
+	require.NoError(t, err)
+
+	if *okRow.MyTuple.TupleOne != "one" {
+		t.Errorf("expected 'one' but got '%s'", *okRow.MyTuple.TupleOne)
+	}
+
+	if *okRow.MyTuple.TupleTwo != "two" {
+		t.Errorf("expected 'two' but got '%s'", *okRow.MyTuple.TupleTwo)
+	}
+}


### PR DESCRIPTION
closes #1446

## Summary

Tuple scanning was forcing string type conversions using `fmt.Sprint`. This removes that logic to defer to other conversion methods, with a clear conversion error if they fail.

See https://github.com/ClickHouse/clickhouse-go/issues/1446#issuecomment-2573564756 for more details.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
