### PR TITLE
Handle json tag without name override

### DIFF
--- a/examples/clickhouse_api/json_structs.go
+++ b/examples/clickhouse_api/json_structs.go
@@ -21,13 +21,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 type ProductPricing struct {
-	Price    int64  `json:"price"`
-	Currency string `json:"currency"`
+	Price    int64  `json:",omitempty"`
+	Currency string `json:",omitempty"`
 }
 
 type Product struct {

--- a/lib/column/json_reflect.go
+++ b/lib/column/json_reflect.go
@@ -78,7 +78,7 @@ func (c *JSON) fillStruct(val reflect.Value, prefix string, row int) error {
 		}
 
 		name := fieldType.Tag.Get("json")
-		if name == "" {
+		if name == "" || name[0] == ',' {
 			name = fieldType.Name
 		} else {
 			name = strings.Split(name, ",")[0]
@@ -311,7 +311,7 @@ func iterateStruct(val reflect.Value, prefix string, json *chcol.JSON) error {
 		}
 
 		name := fieldType.Tag.Get("json")
-		if name == "" {
+		if name == "" || name[0] == ',' {
 			name = fieldType.Name
 		} else {
 			// handle `json:"name,omitempty"`


### PR DESCRIPTION
## Summary
A field in struct that has a json tag without field name override eg.`json:",omitempty"` should use the actual field name instead of empty string.

Issue #1477 

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added