### PR TITLE
fix: JSON NestedMap + add tests

### DIFF
--- a/lib/chcol/json.go
+++ b/lib/chcol/json.go
@@ -51,11 +51,15 @@ func (o *JSON) ValueAtPath(path string) (any, bool) {
 
 // NestedMap converts the flattened JSON data into a nested structure
 func (o *JSON) NestedMap() map[string]any {
-	nested := make(map[string]any)
+	result := make(map[string]any)
 
 	for key, value := range o.valuesByPath {
+		if vt, ok := value.(Variant); ok && vt.Nil() {
+			continue
+		}
+
 		parts := strings.Split(key, ".")
-		current := nested
+		current := result
 
 		for i := 0; i < len(parts)-1; i++ {
 			part := parts[i]
@@ -64,13 +68,14 @@ func (o *JSON) NestedMap() map[string]any {
 				current[part] = make(map[string]any)
 			}
 
-			current = current[part].(map[string]any)
+			if next, ok := current[part].(map[string]any); ok {
+				current = next
+			}
 		}
-
 		current[parts[len(parts)-1]] = value
 	}
 
-	return nested
+	return result
 }
 
 // MarshalJSON implements the json.Marshaler interface

--- a/lib/chcol/json.go
+++ b/lib/chcol/json.go
@@ -21,6 +21,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -53,12 +54,19 @@ func (o *JSON) ValueAtPath(path string) (any, bool) {
 func (o *JSON) NestedMap() map[string]any {
 	result := make(map[string]any)
 
-	for key, value := range o.valuesByPath {
+	sortedPaths := make([]string, 0, len(o.valuesByPath))
+	for path := range o.valuesByPath {
+		sortedPaths = append(sortedPaths, path)
+	}
+	slices.Sort(sortedPaths)
+
+	for _, path := range sortedPaths {
+		value := o.valuesByPath[path]
 		if vt, ok := value.(Variant); ok && vt.Nil() {
 			continue
 		}
 
-		parts := strings.Split(key, ".")
+		parts := strings.Split(path, ".")
 		current := result
 
 		for i := 0; i < len(parts)-1; i++ {

--- a/lib/chcol/json_test.go
+++ b/lib/chcol/json_test.go
@@ -1,8 +1,9 @@
 package chcol
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNestedMap(t *testing.T) {
@@ -38,7 +39,7 @@ func TestNestedMap(t *testing.T) {
 			},
 		},
 		{
-			name: "nested object with only top level key present",
+			name: "nested object with only top level path present",
 			input: &JSON{
 				valuesByPath: map[string]any{
 					"x":       NewVariant(42),

--- a/lib/chcol/json_test.go
+++ b/lib/chcol/json_test.go
@@ -1,0 +1,83 @@
+package chcol
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestNestedMap(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    *JSON
+		expected map[string]any
+	}{
+		{
+			name: "nested object with values present",
+			input: &JSON{
+				valuesByPath: map[string]any{
+					"x":       NewVariant(nil),
+					"x.a":     NewVariant(42),
+					"x.b":     NewVariant(64),
+					"x.b.c.d": NewVariant(96),
+					"a.b.c":   NewVariant(128),
+				},
+			},
+			expected: map[string]any{
+				"x": map[string]any{
+					"a": NewVariant(42),
+					"b": NewVariant(64),
+					"c": map[string]any{
+						"d": NewVariant(96),
+					},
+				},
+				"a": map[string]any{
+					"b": map[string]any{
+						"c": NewVariant(128),
+					},
+				},
+			},
+		},
+		{
+			name: "nested object with only top level key present",
+			input: &JSON{
+				valuesByPath: map[string]any{
+					"x":       NewVariant(42),
+					"x.a":     NewVariant(nil),
+					"x.b":     NewVariant(nil),
+					"x.b.c.d": NewVariant(nil),
+					"a.b.c":   NewVariant(nil),
+				},
+			},
+			expected: map[string]any{
+				"x": NewVariant(42),
+			},
+		},
+		{
+			name: "nested object with typed paths",
+			input: &JSON{
+				valuesByPath: map[string]any{
+					"x":   42,
+					"a.b": "test value",
+				},
+			},
+			expected: map[string]any{
+				"x": 42,
+				"a": map[string]any{
+					"b": "test value",
+				},
+			},
+		},
+		{
+			name:     "empty object",
+			input:    NewJSON(),
+			expected: map[string]any{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := c.input.NestedMap()
+			require.Equal(t, c.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
The NestedMap function converts a flat `map[string]any` into a structure usable by `json.Marshal`. The behavior has been updated to match that of ClickHouse server. A good example of this feature in use is the Grafana integration.

The main change here is the exclusion of `nil` values from encoding.

### Comparison
Here is the outputs before/after for comparison (the sorting is inconsistent since there's no sorting key)

ClickHouse Server (expected output):
```sql
SELECT *
FROM test2

Query id: e7dc18ee-ddd1-47ee-9263-3750f6a298c4

   ┌─json─┐
1. │ {}   │
   └──────┘
   ┌─json────────────────────────────────────────┐
2. │ {"a":{"b":"42"},"c":["1","2","3"]}          │
3. │ {"f":"Hello, World!"}                       │
4. │ {"a":{"b":"43","e":"10"},"c":["4","5","6"]} │
   └─────────────────────────────────────────────┘
   ┌─json────────────────────────────────────────┐
5. │ {"a":{"b":"42"},"c":["1","2","3"]}          │
6. │ {"f":"Hello, World!"}                       │
7. │ {"a":{"b":"43","e":"10"},"c":["4","5","6"]} │
   └─────────────────────────────────────────────┘
    ┌─json────────────────────────────────────────┐
 8. │ {"a":{"b":"42"},"c":["1","2","3"]}          │
 9. │ {"f":"Hello, World!"}                       │
10. │ {"a":{"b":"43","e":"10"},"c":["4","5","6"]} │
    └─────────────────────────────────────────────┘

10 rows in set. Elapsed: 0.001 sec. 
```

Grafana output (incorrect, nulls are included):
![json output in Grafana not matching ClickHouse server](https://github.com/user-attachments/assets/dade4076-54ff-4c49-b8e1-455cb38b2c04)


Grafana output (corrected):
![json output in Grafana matching ClickHouse server](https://github.com/user-attachments/assets/ace80a99-c0ab-4cca-a863-261e60086bc1)



## Checklist
- [x] Unit and integration tests covering the common scenarios were added
