### PR TITLE
fix enum parse logic when its last index is zero

### DIFF
--- a/lib/column/enum.go
+++ b/lib/column/enum.go
@@ -179,7 +179,7 @@ func extractEnumNamedValues(chType Type) (typ string, values []string, indexes [
 	}
 
 	// Enum type must have at least one value
-	if valueIndex == 0 {
+	if len(indexes) == 0 {
 		return
 	}
 

--- a/lib/column/enum_test.go
+++ b/lib/column/enum_test.go
@@ -134,6 +134,15 @@ func TestExtractEnumNamedValues(t *testing.T) {
 				2: "",
 			},
 		},
+		{
+			name:         "Enum8 from negative to zero keys",
+			chType:       "Enum8('a'=-1, 'b'=0)",
+			expectedType: "Enum8",
+			expectedValues: map[int]string{
+				-1: "a",
+				0:  "b",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
Fix `invalid Enum` error when enum goes from negative indexes to zero, ex: `Enum8('a'=-1, 'b'=0)`

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
