### PR TITLE
feat: `clickhouse.JSON` Serializer interface

### DIFF
--- a/benchmark/json_test.go
+++ b/benchmark/json_test.go
@@ -5,12 +5,10 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"os"
 	"testing"
-	"time"
 )
 
 const testSet string = "json_bench"
@@ -79,7 +77,7 @@ func prepareJSONReadTest(ctx context.Context, b *testing.B) (driver.Conn, driver
 		b.Fatal(err)
 	}
 
-	jsonRow := buildTestJSONPaths()
+	jsonRow := clickhouse_tests.BuildFastTestJSONStruct()
 	for i := 0; i < b.N; i++ {
 		if err := batch.Append(jsonRow); err != nil {
 			b.Fatal(err)
@@ -98,86 +96,6 @@ func prepareJSONReadTest(ctx context.Context, b *testing.B) (driver.Conn, driver
 	return conn, rows
 }
 
-var jsonTestDate, _ = time.Parse(time.RFC3339, "2024-12-13T02:09:30.123Z")
-
-type Address struct {
-	Street  string `chType:"String"`
-	City    string `chType:"String"`
-	Country string `chType:"String"`
-}
-
-type TestStruct struct {
-	Name   string
-	Age    int64
-	Active bool
-	Score  float64
-
-	Tags    []string
-	Numbers []int64
-
-	Address Address
-
-	KeysNumbers map[string]int64
-	Metadata    map[string]interface{}
-
-	Timestamp time.Time `chType:"DateTime64(3)"`
-
-	DynamicString chcol.Dynamic
-	DynamicInt    chcol.Dynamic
-	DynamicMap    chcol.Dynamic
-}
-
-func buildTestJSONPaths() *chcol.JSON {
-	jsonRow := chcol.NewJSON()
-	jsonRow.SetValueAtPath("Name", "JSON")
-	jsonRow.SetValueAtPath("Age", int64(42))
-	jsonRow.SetValueAtPath("Active", true)
-	jsonRow.SetValueAtPath("Score", 3.14)
-	jsonRow.SetValueAtPath("Tags", []string{"a", "b"})
-	jsonRow.SetValueAtPath("Numbers", []int64{20, 40})
-	jsonRow.SetValueAtPath("Address.Street", "Street")
-	jsonRow.SetValueAtPath("Address.City", "City")
-	jsonRow.SetValueAtPath("Address.Country", "Country")
-	jsonRow.SetValueAtPath("KeysNumbers", map[string]int64{"FieldA": 42, "FieldB": 32})
-	jsonRow.SetValueAtPath("Metadata.FieldA", "a")
-	jsonRow.SetValueAtPath("Metadata.FieldB", "b")
-	jsonRow.SetValueAtPath("Metadata.FieldC.FieldD", "d")
-	jsonRow.SetValueAtPath("Timestamp", jsonTestDate)
-	jsonRow.SetValueAtPath("DynamicString", clickhouse.NewDynamic("str"))
-	jsonRow.SetValueAtPath("DynamicInt", clickhouse.NewDynamic(int64(48)))
-	jsonRow.SetValueAtPath("DynamicMap", clickhouse.NewDynamic(map[string]string{"a": "a", "b": "b"}))
-
-	return jsonRow
-}
-
-func buildTestJSONStruct() TestStruct {
-	return TestStruct{
-		Name:    "JSON",
-		Age:     42,
-		Active:  true,
-		Score:   3.14,
-		Tags:    []string{"a", "b"},
-		Numbers: []int64{20, 40},
-		Address: Address{
-			Street:  "Street",
-			City:    "City",
-			Country: "Country",
-		},
-		KeysNumbers: map[string]int64{"FieldA": 42, "FieldB": 32},
-		Metadata: map[string]interface{}{
-			"FieldA": "a",
-			"FieldB": "b",
-			"FieldC": map[string]interface{}{
-				"FieldD": "d",
-			},
-		},
-		Timestamp:     jsonTestDate,
-		DynamicString: chcol.NewDynamic("str").WithType("String"),
-		DynamicInt:    chcol.NewDynamic(int64(48)).WithType("Int64"),
-		DynamicMap:    chcol.NewDynamic(map[string]string{"a": "a", "b": "b"}).WithType("Map(String, String)"),
-	}
-}
-
 // BenchmarkJSONInsert tests the performance for appending to a JSON column batch
 func BenchmarkJSONInsert(b *testing.B) {
 	b.Run("paths", func(b *testing.B) {
@@ -185,7 +103,7 @@ func BenchmarkJSONInsert(b *testing.B) {
 		conn, batch := prepareJSONInsertTest(ctx, b)
 		defer conn.Close()
 
-		jsonRow := buildTestJSONPaths()
+		jsonRow := clickhouse_tests.BuildTestJSONPaths()
 
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -202,31 +120,7 @@ func BenchmarkJSONInsert(b *testing.B) {
 		conn, batch := prepareJSONInsertTest(ctx, b)
 		defer conn.Close()
 
-		inputRow := TestStruct{
-			Name:    "JSON",
-			Age:     42,
-			Active:  true,
-			Score:   3.14,
-			Tags:    []string{"a", "b"},
-			Numbers: []int64{20, 40},
-			Address: Address{
-				Street:  "Street",
-				City:    "City",
-				Country: "Country",
-			},
-			KeysNumbers: map[string]int64{"FieldA": 42, "FieldB": 32},
-			Metadata: map[string]interface{}{
-				"FieldA": "a",
-				"FieldB": "b",
-				"FieldC": map[string]interface{}{
-					"FieldD": "d",
-				},
-			},
-			Timestamp:     jsonTestDate,
-			DynamicString: chcol.NewDynamic("str").WithType("String"),
-			DynamicInt:    chcol.NewDynamic(int64(48)).WithType("Int64"),
-			DynamicMap:    chcol.NewDynamic(map[string]string{"a": "a", "b": "b"}).WithType("Map(String, String)"),
-		}
+		inputRow := clickhouse_tests.BuildTestJSONStruct()
 
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -238,12 +132,29 @@ func BenchmarkJSONInsert(b *testing.B) {
 		b.StopTimer()
 	})
 
+	b.Run("fast_structs", func(b *testing.B) {
+		ctx := context.Background()
+		conn, batch := prepareJSONInsertTest(ctx, b)
+		defer conn.Close()
+
+		inputRow := clickhouse_tests.BuildFastTestJSONStruct()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := batch.Append(&inputRow); err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.StopTimer()
+	})
+
 	b.Run("marshal_strings", func(b *testing.B) {
 		ctx := context.Background()
 		conn, batch := prepareJSONInsertTest(ctx, b)
 		defer conn.Close()
 
-		inputRow := buildTestJSONStruct()
+		inputRow := clickhouse_tests.BuildTestJSONStruct()
 
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -265,7 +176,7 @@ func BenchmarkJSONInsert(b *testing.B) {
 		conn, batch := prepareJSONInsertTest(ctx, b)
 		defer conn.Close()
 
-		inputRow := buildTestJSONStruct()
+		inputRow := clickhouse_tests.BuildTestJSONStruct()
 
 		inputRowStr, err := json.Marshal(inputRow)
 		if err != nil {
@@ -314,7 +225,26 @@ func BenchmarkJSONRead(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			rows.Next()
 
-			var row TestStruct
+			var row clickhouse_tests.TestStruct
+			err := rows.Scan(&row)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.StopTimer()
+	})
+
+	b.Run("fast_structs", func(b *testing.B) {
+		ctx := context.Background()
+		conn, rows := prepareJSONReadTest(ctx, b)
+		defer conn.Close()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			rows.Next()
+
+			var row clickhouse_tests.FastTestStruct
 			err := rows.Scan(&row)
 			if err != nil {
 				b.Fatal(err)
@@ -334,21 +264,8 @@ func BenchmarkJSONRead(b *testing.B) {
 
 // BenchmarkJSONMarshal compares the different ways to turn JSON data back into a string
 func BenchmarkJSONMarshal(b *testing.B) {
-	b.Run("paths_direct", func(b *testing.B) {
-		pathsRow := buildTestJSONPaths()
-
-		b.ReportAllocs()
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			_, err := pathsRow.MarshalJSON()
-			if err != nil {
-				b.Fatal(err)
-			}
-		}
-	})
-
 	b.Run("paths", func(b *testing.B) {
-		pathsRow := buildTestJSONPaths()
+		pathsRow := clickhouse_tests.BuildTestJSONPaths()
 
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -361,7 +278,7 @@ func BenchmarkJSONMarshal(b *testing.B) {
 	})
 
 	b.Run("structs", func(b *testing.B) {
-		structRow := buildTestJSONStruct()
+		structRow := clickhouse_tests.BuildTestJSONStruct()
 
 		b.ReportAllocs()
 		b.ResetTimer()

--- a/chcol.go
+++ b/chcol.go
@@ -22,11 +22,19 @@ import "github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 // Re-export chcol types/funcs to top level clickhouse package
 
 type (
+	// Variant represents a ClickHouse Variant type that can hold multiple possible types
 	Variant = chcol.Variant
+	// Dynamic is an alias for the Variant type
 	Dynamic = chcol.Dynamic
-	JSON    = chcol.JSON
+	// JSON represents a ClickHouse JSON type that can hold multiple possible types
+	JSON = chcol.JSON
 
-	JSONSerializer   = chcol.JSONSerializer
+	// JSONSerializer interface allows a struct to be manually converted to an optimized JSON structure instead of relying
+	// on recursive reflection.
+	// Note that the struct must be a pointer in order for the interface to be matched, reflection will be used otherwise.
+	JSONSerializer = chcol.JSONSerializer
+	// JSONDeserializer interface allows a struct to load its data from an optimized JSON structure instead of relying
+	// on recursive reflection to set its fields.
 	JSONDeserializer = chcol.JSONDeserializer
 )
 

--- a/chcol.go
+++ b/chcol.go
@@ -25,6 +25,9 @@ type (
 	Variant = chcol.Variant
 	Dynamic = chcol.Dynamic
 	JSON    = chcol.JSON
+
+	JSONSerializer   = chcol.JSONSerializer
+	JSONDeserializer = chcol.JSONDeserializer
 )
 
 // NewVariant creates a new Variant with the given value
@@ -50,4 +53,10 @@ func NewDynamicWithType(v any, chType string) Dynamic {
 // NewJSON creates a new empty JSON value
 func NewJSON() *JSON {
 	return chcol.NewJSON()
+}
+
+// ExtractJSONPathAs is a convenience function for asserting a path to a specific type.
+// The underlying value is also extracted from its Dynamic wrapper if present.
+func ExtractJSONPathAs[T any](o *JSON, path string) (valueAs T, ok bool) {
+	return chcol.ExtractJSONPathAs[T](o, path)
 }

--- a/examples/clickhouse_api/json_fast_structs.go
+++ b/examples/clickhouse_api/json_fast_structs.go
@@ -40,8 +40,8 @@ type FastProduct struct {
 	CreatedAt time.Time          `json:"created_at" chType:"DateTime64(3)"`
 }
 
-// ToClickHouseJSON implements clickhouse.JSONSerializer for faster struct appending
-func (p *FastProduct) ToClickHouseJSON() (*clickhouse.JSON, error) {
+// SerializeClickHouseJSON implements clickhouse.JSONSerializer for faster struct appending
+func (p *FastProduct) SerializeClickHouseJSON() (*clickhouse.JSON, error) {
 	obj := clickhouse.NewJSON()
 	obj.SetValueAtPath("id", p.ID)
 	obj.SetValueAtPath("name", p.Name)
@@ -55,8 +55,8 @@ func (p *FastProduct) ToClickHouseJSON() (*clickhouse.JSON, error) {
 	return obj, nil
 }
 
-// FromClickHouseJSON implements clickhouse.JSONDeserializer for faster struct scanning
-func (p *FastProduct) FromClickHouseJSON(obj *clickhouse.JSON) error {
+// DeserializeClickHouseJSON implements clickhouse.JSONDeserializer for faster struct scanning
+func (p *FastProduct) DeserializeClickHouseJSON(obj *clickhouse.JSON) error {
 	p.ID, _ = clickhouse.ExtractJSONPathAs[clickhouse.Dynamic](obj, "id")
 	p.Name, _ = clickhouse.ExtractJSONPathAs[string](obj, "name")
 	p.Tags, _ = clickhouse.ExtractJSONPathAs[[]string](obj, "tags")

--- a/examples/clickhouse_api/json_fast_structs.go
+++ b/examples/clickhouse_api/json_fast_structs.go
@@ -1,0 +1,152 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package clickhouse_api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+type FastProductPricing struct {
+	Price    int64  `json:",omitempty"`
+	Currency string `json:",omitempty"`
+}
+
+type FastProduct struct {
+	ID        clickhouse.Dynamic `json:"id"`
+	Name      string             `json:"name"`
+	Tags      []string           `json:"tags"`
+	Pricing   FastProductPricing `json:"pricing"`
+	Metadata  map[string]any     `json:"metadata"`
+	CreatedAt time.Time          `json:"created_at" chType:"DateTime64(3)"`
+}
+
+// ToClickHouseJSON implements clickhouse.JSONSerializer for faster struct appending
+func (p *FastProduct) ToClickHouseJSON() (*clickhouse.JSON, error) {
+	obj := clickhouse.NewJSON()
+	obj.SetValueAtPath("id", p.ID)
+	obj.SetValueAtPath("name", p.Name)
+	obj.SetValueAtPath("tags", p.Tags)
+	obj.SetValueAtPath("pricing.price", p.Pricing.Price)
+	obj.SetValueAtPath("pricing.currency", p.Pricing.Currency)
+	obj.SetValueAtPath("metadata.region", p.Metadata["region"])
+	obj.SetValueAtPath("metadata.page_count", p.Metadata["page_count"])
+	obj.SetValueAtPath("created_at", p.CreatedAt)
+
+	return obj, nil
+}
+
+// FromClickHouseJSON implements clickhouse.JSONDeserializer for faster struct scanning
+func (p *FastProduct) FromClickHouseJSON(obj *clickhouse.JSON) error {
+	p.ID, _ = clickhouse.ExtractJSONPathAs[clickhouse.Dynamic](obj, "id")
+	p.Name, _ = clickhouse.ExtractJSONPathAs[string](obj, "name")
+	p.Tags, _ = clickhouse.ExtractJSONPathAs[[]string](obj, "tags")
+	p.Pricing.Price, _ = clickhouse.ExtractJSONPathAs[int64](obj, "pricing.price")
+	p.Pricing.Currency, _ = clickhouse.ExtractJSONPathAs[string](obj, "pricing.currency")
+	p.Metadata = make(map[string]any, 2)
+	p.Metadata["region"], _ = clickhouse.ExtractJSONPathAs[string](obj, "metadata.region")
+	p.Metadata["page_count"], _ = clickhouse.ExtractJSONPathAs[int64](obj, "metadata.page_count")
+	p.CreatedAt, _ = clickhouse.ExtractJSONPathAs[time.Time](obj, "created_at")
+
+	return nil
+}
+
+func NewExampleFastProduct() *FastProduct {
+	return &FastProduct{
+		ID:   clickhouse.NewDynamicWithType(uint64(1234), "UInt64"),
+		Name: "Book",
+		Tags: []string{"library", "fiction"},
+		Pricing: FastProductPricing{
+			Price:    750,
+			Currency: "usd",
+		},
+		Metadata: map[string]any{
+			"region":     "us",
+			"page_count": int64(852),
+		},
+		CreatedAt: time.Now().UTC().Truncate(time.Millisecond),
+	}
+}
+
+func JSONFastStructExample() error {
+	ctx := context.Background()
+
+	conn, err := GetNativeConnection(clickhouse.Settings{
+		"allow_experimental_json_type": true,
+	}, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	if !CheckMinServerVersion(conn, 24, 9, 0) {
+		fmt.Print("unsupported clickhouse version for JSON type")
+		return nil
+	}
+
+	err = conn.Exec(ctx, "DROP TABLE IF EXISTS go_json_example")
+	if err != nil {
+		return err
+	}
+
+	err = conn.Exec(ctx, `
+		CREATE TABLE go_json_example (product JSON) ENGINE=Memory
+		`)
+	if err != nil {
+		return err
+	}
+
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO go_json_example (product)")
+	if err != nil {
+		return err
+	}
+
+	insertFastProduct := NewExampleFastProduct()
+
+	if err = batch.Append(insertFastProduct); err != nil {
+		return err
+	}
+
+	if err = batch.Send(); err != nil {
+		return err
+	}
+
+	var selectedFastProduct FastProduct
+
+	if err = conn.QueryRow(ctx, "SELECT product FROM go_json_example").Scan(&selectedFastProduct); err != nil {
+		return err
+	}
+
+	insertFastProductBytes, err := json.Marshal(insertFastProduct)
+	if err != nil {
+		return err
+	}
+
+	selectedFastProductBytes, err := json.Marshal(&selectedFastProduct)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("inserted product: %s\n", string(insertFastProductBytes))
+	fmt.Printf("selected product: %s\n", string(selectedFastProductBytes))
+	fmt.Printf("inserted product matches selected product: %t\n", string(insertFastProductBytes) == string(selectedFastProductBytes))
+	return nil
+}

--- a/examples/clickhouse_api/main_test.go
+++ b/examples/clickhouse_api/main_test.go
@@ -230,6 +230,11 @@ func TestJSONStructExample(t *testing.T) {
 	require.NoError(t, JSONStructExample())
 }
 
+func TestJSONFastStructExample(t *testing.T) {
+	clickhouse_tests.SkipOnCloud(t, "cannot modify JSON settings on cloud")
+	require.NoError(t, JSONFastStructExample())
+}
+
 func TestJSONStringExample(t *testing.T) {
 	clickhouse_tests.SkipOnCloud(t, "cannot modify JSON settings on cloud")
 	t.Skip("client cannot receive JSON strings")

--- a/lib/chcol/json.go
+++ b/lib/chcol/json.go
@@ -29,13 +29,13 @@ import (
 // on recursive reflection.
 // Note that the struct must be a pointer in order for the interface to be matched, reflection will be used otherwise.
 type JSONSerializer interface {
-	ToClickHouseJSON() (*JSON, error)
+	SerializeClickHouseJSON() (*JSON, error)
 }
 
 // JSONDeserializer interface allows a struct to load its data from an optimized JSON structure instead of relying
 // on recursive reflection to set its fields.
 type JSONDeserializer interface {
-	FromClickHouseJSON(*JSON) error
+	DeserializeClickHouseJSON(*JSON) error
 }
 
 // ExtractJSONPathAs is a convenience function for asserting a path to a specific type.

--- a/lib/chcol/json.go
+++ b/lib/chcol/json.go
@@ -87,7 +87,7 @@ func (o *JSON) NestedMap() map[string]any {
 }
 
 // MarshalJSON implements the json.Marshaler interface
-func (o JSON) MarshalJSON() ([]byte, error) {
+func (o *JSON) MarshalJSON() ([]byte, error) {
 	return json.Marshal(o.NestedMap())
 }
 

--- a/lib/chcol/json.go
+++ b/lib/chcol/json.go
@@ -27,6 +27,7 @@ import (
 
 // JSONSerializer interface allows a struct to be manually converted to an optimized JSON structure instead of relying
 // on recursive reflection.
+// Note that the struct must be a pointer in order for the interface to be matched, reflection will be used otherwise.
 type JSONSerializer interface {
 	ToClickHouseJSON() (*JSON, error)
 }

--- a/lib/chcol/json_test.go
+++ b/lib/chcol/json_test.go
@@ -1,6 +1,7 @@
 package chcol
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -81,4 +82,21 @@ func TestNestedMap(t *testing.T) {
 			require.Equal(t, c.expected, actual)
 		})
 	}
+}
+
+func TestJSONMarshal(t *testing.T) {
+	obj := &JSON{
+		valuesByPath: map[string]any{
+			"x.a":     NewVariant(42),
+			"x.b":     NewVariant(64),
+			"x.b.c.d": NewVariant(96),
+			"a.b.c":   NewVariant(128),
+		},
+	}
+
+	objStr := []byte("{\"a\":{\"b\":{\"c\":128}},\"x\":{\"a\":42,\"b\":64,\"c\":{\"d\":96}}}")
+
+	jsonStr, err := json.Marshal(obj)
+	require.NoError(t, err)
+	require.Equal(t, objStr, jsonStr)
 }

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -323,6 +323,9 @@ func (c *JSON) Append(v any) (nulls []uint8, err error) {
 		case []*chcol.JSON:
 			c.serializationVersion = JSONObjectSerializationVersion
 			return c.appendObject(v)
+		case []chcol.JSONSerializer:
+			c.serializationVersion = JSONObjectSerializationVersion
+			return c.appendObject(v)
 		}
 
 		var err error
@@ -350,6 +353,15 @@ func (c *JSON) appendObject(v any) (nulls []uint8, err error) {
 
 		return nil, nil
 	case []*chcol.JSON:
+		for i, obj := range vv {
+			err := c.AppendRow(obj)
+			if err != nil {
+				return nil, fmt.Errorf("failed to AppendRow at index %d: %w", i, err)
+			}
+		}
+
+		return nil, nil
+	case []chcol.JSONSerializer:
 		for i, obj := range vv {
 			err := c.AppendRow(obj)
 			if err != nil {
@@ -403,6 +415,9 @@ func (c *JSON) AppendRow(v any) error {
 		case *chcol.JSON:
 			c.serializationVersion = JSONObjectSerializationVersion
 			return c.appendRowObject(v)
+		case chcol.JSONSerializer:
+			c.serializationVersion = JSONObjectSerializationVersion
+			return c.appendRowObject(v)
 		}
 
 		var err error
@@ -414,7 +429,7 @@ func (c *JSON) AppendRow(v any) error {
 			return nil
 		}
 
-		return fmt.Errorf("unsupported type \"%s\" for JSON column, must use string, []byte, struct, map, or *%s: %w", reflect.TypeOf(v).String(), scanTypeJSON.String(), err)
+		return fmt.Errorf("unsupported type \"%s\" for JSON column, must use string, []byte, *struct, map, or *clickhouse.JSON: %w", reflect.TypeOf(v).String(), err)
 	}
 }
 

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -282,6 +282,14 @@ func (c *JSON) scanRowObject(dest any, row int) error {
 		obj := c.rowAsJSON(row)
 		**v = *obj
 		return nil
+	case chcol.JSONDeserializer:
+		obj := c.rowAsJSON(row)
+		err := v.FromClickHouseJSON(obj)
+		if err != nil {
+			return fmt.Errorf("failed to deserialize using FromClickHouseJSON: %w", err)
+		}
+
+		return nil
 	}
 
 	switch val := reflect.ValueOf(dest); val.Kind() {
@@ -417,6 +425,12 @@ func (c *JSON) appendRowObject(v any) error {
 		obj = &vv
 	case *chcol.JSON:
 		obj = vv
+	case chcol.JSONSerializer:
+		var err error
+		obj, err = vv.ToClickHouseJSON()
+		if err != nil {
+			return fmt.Errorf("failed to serialize using ToClickHouseJSON: %w", err)
+		}
 	}
 
 	if obj == nil && v != nil {

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -284,9 +284,9 @@ func (c *JSON) scanRowObject(dest any, row int) error {
 		return nil
 	case chcol.JSONDeserializer:
 		obj := c.rowAsJSON(row)
-		err := v.FromClickHouseJSON(obj)
+		err := v.DeserializeClickHouseJSON(obj)
 		if err != nil {
-			return fmt.Errorf("failed to deserialize using FromClickHouseJSON: %w", err)
+			return fmt.Errorf("failed to deserialize using DeserializeClickHouseJSON: %w", err)
 		}
 
 		return nil
@@ -442,9 +442,9 @@ func (c *JSON) appendRowObject(v any) error {
 		obj = vv
 	case chcol.JSONSerializer:
 		var err error
-		obj, err = vv.ToClickHouseJSON()
+		obj, err = vv.SerializeClickHouseJSON()
 		if err != nil {
-			return fmt.Errorf("failed to serialize using ToClickHouseJSON: %w", err)
+			return fmt.Errorf("failed to serialize using SerializeClickHouseJSON: %w", err)
 		}
 	}
 

--- a/tests/json_helper.go
+++ b/tests/json_helper.go
@@ -1,9 +1,10 @@
 package tests
 
 import (
+	"time"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
-	"time"
 )
 
 var JSONTestDate, _ = time.Parse(time.RFC3339, "2024-12-13T02:09:30.123Z")
@@ -41,8 +42,8 @@ type FastTestStruct struct {
 	ts TestStruct
 }
 
-// ToClickHouseJSON implements clickhouse.JSONSerializer for faster struct appending
-func (fts *FastTestStruct) ToClickHouseJSON() (*clickhouse.JSON, error) {
+// SerializeClickHouseJSON implements clickhouse.JSONSerializer for faster struct appending
+func (fts *FastTestStruct) SerializeClickHouseJSON() (*clickhouse.JSON, error) {
 	obj := chcol.NewJSON()
 	obj.SetValueAtPath("Name", fts.ts.Name)
 	obj.SetValueAtPath("Age", fts.ts.Age)
@@ -65,8 +66,8 @@ func (fts *FastTestStruct) ToClickHouseJSON() (*clickhouse.JSON, error) {
 	return obj, nil
 }
 
-// FromClickHouseJSON implements clickhouse.JSONDeserializer for faster struct scanning
-func (fts *FastTestStruct) FromClickHouseJSON(obj *clickhouse.JSON) error {
+// DeserializeClickHouseJSON implements clickhouse.JSONDeserializer for faster struct scanning
+func (fts *FastTestStruct) DeserializeClickHouseJSON(obj *clickhouse.JSON) error {
 	fts.ts.Name, _ = clickhouse.ExtractJSONPathAs[string](obj, "Name")
 	fts.ts.Age, _ = clickhouse.ExtractJSONPathAs[int64](obj, "Age")
 	fts.ts.Active, _ = clickhouse.ExtractJSONPathAs[bool](obj, "Active")
@@ -93,7 +94,7 @@ func (fts *FastTestStruct) FromClickHouseJSON(obj *clickhouse.JSON) error {
 func BuildTestJSONPaths() *chcol.JSON {
 	ts := BuildTestJSONStruct()
 	fts := FastTestStruct{ts: ts}
-	jsonObj, _ := fts.ToClickHouseJSON()
+	jsonObj, _ := fts.SerializeClickHouseJSON()
 	return jsonObj
 }
 

--- a/tests/json_helper.go
+++ b/tests/json_helper.go
@@ -1,0 +1,131 @@
+package tests
+
+import (
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+	"time"
+)
+
+var JSONTestDate, _ = time.Parse(time.RFC3339, "2024-12-13T02:09:30.123Z")
+
+type TestStructAddress struct {
+	Street  string `chType:"String"`
+	City    string `chType:"String"`
+	Country string `chType:"String"`
+}
+
+type TestStruct struct {
+	Name   string
+	Age    int64
+	Active bool
+	Score  float64
+
+	Tags    []string
+	Numbers []int64
+
+	Address TestStructAddress
+
+	KeysNumbers map[string]int64
+	Metadata    map[string]interface{}
+
+	Timestamp time.Time `chType:"DateTime64(3)"`
+
+	DynamicString chcol.Dynamic
+	DynamicInt    chcol.Dynamic
+	DynamicMap    chcol.Dynamic
+}
+
+// FastTestStruct is a distinctly separate type that implements clickhouse.JSONSerializer and clickhouse.JSONDeserializer
+// The struct must be a separate type since the JSON column is unable to ignore the interface implementation.
+type FastTestStruct struct {
+	ts TestStruct
+}
+
+// ToClickHouseJSON implements clickhouse.JSONSerializer for faster struct appending
+func (fts *FastTestStruct) ToClickHouseJSON() (*clickhouse.JSON, error) {
+	obj := chcol.NewJSON()
+	obj.SetValueAtPath("Name", fts.ts.Name)
+	obj.SetValueAtPath("Age", fts.ts.Age)
+	obj.SetValueAtPath("Active", fts.ts.Active)
+	obj.SetValueAtPath("Score", fts.ts.Score)
+	obj.SetValueAtPath("Tags", fts.ts.Tags)
+	obj.SetValueAtPath("Numbers", fts.ts.Numbers)
+	obj.SetValueAtPath("Address.Street", fts.ts.Address.Street)
+	obj.SetValueAtPath("Address.City", fts.ts.Address.City)
+	obj.SetValueAtPath("Address.Country", fts.ts.Address.Country)
+	obj.SetValueAtPath("KeysNumbers", fts.ts.KeysNumbers)
+	obj.SetValueAtPath("Metadata.FieldA", fts.ts.Metadata["FieldA"])
+	obj.SetValueAtPath("Metadata.FieldB", fts.ts.Metadata["FieldB"])
+	obj.SetValueAtPath("Metadata.FieldC.FieldD", fts.ts.Metadata["FieldC"].(map[string]any)["FieldD"])
+	obj.SetValueAtPath("Timestamp", fts.ts.Timestamp)
+	obj.SetValueAtPath("DynamicString", fts.ts.DynamicString)
+	obj.SetValueAtPath("DynamicInt", fts.ts.DynamicInt)
+	obj.SetValueAtPath("DynamicMap", fts.ts.DynamicMap)
+
+	return obj, nil
+}
+
+// FromClickHouseJSON implements clickhouse.JSONDeserializer for faster struct scanning
+func (fts *FastTestStruct) FromClickHouseJSON(obj *clickhouse.JSON) error {
+	fts.ts.Name, _ = clickhouse.ExtractJSONPathAs[string](obj, "Name")
+	fts.ts.Age, _ = clickhouse.ExtractJSONPathAs[int64](obj, "Age")
+	fts.ts.Active, _ = clickhouse.ExtractJSONPathAs[bool](obj, "Active")
+	fts.ts.Score, _ = clickhouse.ExtractJSONPathAs[float64](obj, "Score")
+	fts.ts.Tags, _ = clickhouse.ExtractJSONPathAs[[]string](obj, "Tags")
+	fts.ts.Numbers, _ = clickhouse.ExtractJSONPathAs[[]int64](obj, "Numbers")
+	fts.ts.Address.Street, _ = clickhouse.ExtractJSONPathAs[string](obj, "Address.Street")
+	fts.ts.Address.City, _ = clickhouse.ExtractJSONPathAs[string](obj, "Address.City")
+	fts.ts.Address.Country, _ = clickhouse.ExtractJSONPathAs[string](obj, "Address.Country")
+	fts.ts.KeysNumbers, _ = clickhouse.ExtractJSONPathAs[map[string]int64](obj, "KeysNumbers")
+	fts.ts.Metadata = make(map[string]any)
+	fts.ts.Metadata["FieldA"], _ = clickhouse.ExtractJSONPathAs[string](obj, "Metadata.FieldA")
+	fts.ts.Metadata["FieldB"], _ = clickhouse.ExtractJSONPathAs[int64](obj, "Metadata.FieldB")
+	fts.ts.Metadata["FieldC"] = make(map[string]any)
+	fts.ts.Metadata["FieldC"].(map[string]any)["FieldD"], _ = clickhouse.ExtractJSONPathAs[string](obj, "Metadata.FieldC.FieldD")
+	fts.ts.Timestamp, _ = clickhouse.ExtractJSONPathAs[time.Time](obj, "Timestamp")
+	fts.ts.DynamicString, _ = clickhouse.ExtractJSONPathAs[clickhouse.Dynamic](obj, "DynamicString")
+	fts.ts.DynamicInt, _ = clickhouse.ExtractJSONPathAs[clickhouse.Dynamic](obj, "DynamicInt")
+	fts.ts.DynamicMap, _ = clickhouse.ExtractJSONPathAs[clickhouse.Dynamic](obj, "DynamicMap")
+
+	return nil
+}
+
+func BuildTestJSONPaths() *chcol.JSON {
+	ts := BuildTestJSONStruct()
+	fts := FastTestStruct{ts: ts}
+	jsonObj, _ := fts.ToClickHouseJSON()
+	return jsonObj
+}
+
+func BuildTestJSONStruct() TestStruct {
+	return TestStruct{
+		Name:    "JSON",
+		Age:     42,
+		Active:  true,
+		Score:   3.14,
+		Tags:    []string{"a", "b"},
+		Numbers: []int64{20, 40},
+		Address: TestStructAddress{
+			Street:  "Street",
+			City:    "City",
+			Country: "Country",
+		},
+		KeysNumbers: map[string]int64{"FieldA": 42, "FieldB": 32},
+		Metadata: map[string]interface{}{
+			"FieldA": "a",
+			"FieldB": "b",
+			"FieldC": map[string]interface{}{
+				"FieldD": "d",
+			},
+		},
+		Timestamp:     JSONTestDate,
+		DynamicString: chcol.NewDynamic("str").WithType("String"),
+		DynamicInt:    chcol.NewDynamic(int64(48)).WithType("Int64"),
+		DynamicMap:    chcol.NewDynamic(map[string]string{"a": "a", "b": "b"}).WithType("Map(String, String)"),
+	}
+}
+
+func BuildFastTestJSONStruct() FastTestStruct {
+	ts := BuildTestJSONStruct()
+	return FastTestStruct{ts: ts}
+}


### PR DESCRIPTION
## Summary
After running benchmarks (#1490), it's clear that the `clickhouse.JSON` type is the fastest way to append JSON data (excluding strings).

Right now the only way to convert a struct to this JSON data is to use reflection magic and walk the struct recursively. A user could also write their own functions to convert their struct to `clickhouse.JSON`. To make this optimization more apparent, I have added interfaces for `clickhouse.JSONSerializer` and `clickhouse.JSONDeserializer`.

If you have a custom struct you can implement these and the JSON column will make use of them when reading/writing data.
A helper function has also been included for easily reading these paths with a specific type in mind (`clickhouse.ExtractJSONPathAs[T](jsonObj, path)`). The user can also do this manually if they choose to.

Other changes:
- Added test for `json.Marshal` to confirm it is using the `NestedMap` func
- Reduced duplicated struct code for JSON tests

## Example

Example:
```go

type ProductPricing struct {
	Price    int64  `json:",omitempty"`
	Currency string `json:",omitempty"`
}

type Product struct {
	ID        clickhouse.Dynamic `json:"id"`
	Name      string             `json:"name"`
	Tags      []string           `json:"tags"`
	Pricing   ProductPricing     `json:"pricing"`
	Metadata  map[string]any     `json:"metadata"`
	CreatedAt time.Time          `json:"created_at" chType:"DateTime64(3)"`
}

// ToClickHouseJSON implements clickhouse.JSONSerializer for faster struct appending
func (p *Product) ToClickHouseJSON() (*clickhouse.JSON, error) {
	obj := clickhouse.NewJSON()
	obj.SetValueAtPath("id", p.ID)
	obj.SetValueAtPath("name", p.Name)
	obj.SetValueAtPath("tags", p.Tags)
	obj.SetValueAtPath("pricing.price", p.Pricing.Price)
	obj.SetValueAtPath("pricing.currency", p.Pricing.Currency)
	obj.SetValueAtPath("metadata.region", p.Metadata["region"])
	obj.SetValueAtPath("metadata.page_count", p.Metadata["page_count"])
	obj.SetValueAtPath("created_at", p.CreatedAt)

	return obj, nil
}

// FromClickHouseJSON implements clickhouse.JSONDeserializer for faster struct scanning
func (p *Product) FromClickHouseJSON(obj *clickhouse.JSON) error {
	p.ID, _ = clickhouse.ExtractJSONPathAs[clickhouse.Dynamic](obj, "id")
	p.Name, _ = clickhouse.ExtractJSONPathAs[string](obj, "name")
	p.Tags, _ = clickhouse.ExtractJSONPathAs[[]string](obj, "tags")
	p.Pricing.Price, _ = clickhouse.ExtractJSONPathAs[int64](obj, "pricing.price")
	p.Pricing.Currency, _ = clickhouse.ExtractJSONPathAs[string](obj, "pricing.currency")
	p.Metadata = make(map[string]any, 2)
	p.Metadata["region"], _ = clickhouse.ExtractJSONPathAs[string](obj, "metadata.region")
	p.Metadata["page_count"], _ = clickhouse.ExtractJSONPathAs[int64](obj, "metadata.page_count")
	p.CreatedAt, _ = clickhouse.ExtractJSONPathAs[time.Time](obj, "created_at")

	return nil
}
```

Then inside a batch append:

```go
batch.Append(&product)
```

The underlying column implementation will then choose to use the user's `clickhouse.JSON` instead of building its own from reflection.

The same applies to `Scan`:

```go
var row TestStruct
err := rows.Scan(&row)
```

The test struct will be populated using the implemented interface.

## Performance

By having the user choose exactly how the object is serialized/deserialized, we can save on CPU and memory allocations:

Serialization:
```
BenchmarkJSONInsert/structs-32       	  275416	      3923 ns/op	    5421 B/op	      55 allocs/op
BenchmarkJSONInsert/fast_structs-32  	  468788	      2497 ns/op	    4968 B/op	      27 allocs/op
```

Deserialization:
```
BenchmarkJSONRead/structs-32                   	 2793265	       410.0 ns/op	     416 B/op	      15 allocs/op
BenchmarkJSONRead/fast_structs-32              	 3078796	       346.9 ns/op	    1040 B/op	       8 allocs/op
```

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
