### PR TITLE
Release compressor on close

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -215,6 +215,7 @@ func (c *connect) close() error {
 	}
 
 	c.buffer = nil
+	c.compressor = nil
 
 	c.readerMutex.Lock()
 	c.reader = nil

--- a/tests/conn_test.go
+++ b/tests/conn_test.go
@@ -358,8 +358,7 @@ func TestConnectionExpiresIdleConnection(t *testing.T) {
 			defer wg.Done()
 			r, err := conn.Query(ctx, "SELECT 1")
 			require.NoError(t, err)
-
-			r.Close()
+			require.NoError(t, r.Close())
 		}()
 	}
 	wg.Wait()
@@ -390,8 +389,8 @@ func TestConnectionCloseIdle(t *testing.T) {
 		conn, err := TestClientWithDefaultSettings(testEnv)
 		require.NoError(t, err)
 		err = conn.Ping(ctx)
-		conn.Close()
 		require.NoError(t, err)
+		require.NoError(t, conn.Close())
 	}
 	time.Sleep(100 * time.Millisecond) // wait for all connections closed
 	finalGoroutine := runtime.NumGoroutine()

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -127,7 +127,7 @@ func CreateClickHouseTestEnvironment(testSet string) (ClickHouseTestEnvironment,
 	// create a ClickHouse Container
 	ctx := context.Background()
 	// attempt use docker for CI
-	provider, err := testcontainers.ProviderDocker.GetProvider()
+	provider, err := testcontainers.ProviderDefault.GetProvider()
 	if err != nil {
 		fmt.Printf("Docker is not running and no clickhouse connections details were provided. Skipping tests: %s\n", err)
 		os.Exit(0)


### PR DESCRIPTION
## Summary

`compressor` is used along with `buffer` to compress buffer contents.
We have seen that when the `conn_max_lifetime` is somewhat low, the compressor still holds references to big hashtables that are no longer used.
I'm still not sure if there's actually a memory leak somewhere.  

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
