### PR TITLE
Add LZ4HC compression, update compressor functions, security patch

### DIFF
--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -42,6 +42,8 @@ func (c CompressionMethod) String() string {
 		return "zstd"
 	case CompressionLZ4:
 		return "lz4"
+	case CompressionLZ4HC:
+		return "lz4hc"
 	case CompressionGZIP:
 		return "gzip"
 	case CompressionDeflate:
@@ -56,6 +58,7 @@ func (c CompressionMethod) String() string {
 const (
 	CompressionNone    = CompressionMethod(compress.None)
 	CompressionLZ4     = CompressionMethod(compress.LZ4)
+	CompressionLZ4HC   = CompressionMethod(compress.LZ4HC)
 	CompressionZSTD    = CompressionMethod(compress.ZSTD)
 	CompressionGZIP    = CompressionMethod(0x95)
 	CompressionDeflate = CompressionMethod(0x96)
@@ -66,6 +69,7 @@ var compressionMap = map[string]CompressionMethod{
 	"none":    CompressionNone,
 	"zstd":    CompressionZSTD,
 	"lz4":     CompressionLZ4,
+	"lz4hc":   CompressionLZ4HC,
 	"gzip":    CompressionGZIP,
 	"deflate": CompressionDeflate,
 	"br":      CompressionBrotli,
@@ -79,7 +83,7 @@ type Auth struct { // has_control_character
 
 type Compression struct {
 	Method CompressionMethod
-	// this only applies to zlib and brotli compression algorithms
+	// this only applies to lz4, lz4hc, zlib, and brotli compression algorithms
 	Level int
 }
 

--- a/conn.go
+++ b/conn.go
@@ -73,14 +73,22 @@ func dial(ctx context.Context, addr string, num int, opt *Options) (*connect, er
 		}
 	}
 
-	compression := CompressionNone
+	var (
+		compression CompressionMethod
+		compressor  *compress.Writer
+	)
 	if opt.Compression != nil {
 		switch opt.Compression.Method {
-		case CompressionLZ4, CompressionZSTD, CompressionNone:
+		case CompressionLZ4, CompressionLZ4HC, CompressionZSTD, CompressionNone:
 			compression = opt.Compression.Method
 		default:
 			return nil, fmt.Errorf("unsupported compression method for native protocol")
 		}
+
+		compressor = compress.NewWriter(compress.Level(opt.Compression.Level), compress.Method(opt.Compression.Method))
+	} else {
+		compression = CompressionNone
+		compressor = compress.NewWriter(compress.LevelZero, compress.None)
 	}
 
 	var (
@@ -95,7 +103,7 @@ func dial(ctx context.Context, addr string, num int, opt *Options) (*connect, er
 			structMap:            &structMap{},
 			compression:          compression,
 			connectedAt:          time.Now(),
-			compressor:           compress.NewWriter(),
+			compressor:           compressor,
 			readTimeout:          opt.ReadTimeout,
 			blockBufferSize:      opt.BlockBufferSize,
 			maxCompressionBuffer: opt.MaxCompressionBuffer,
@@ -246,7 +254,7 @@ func (c *connect) exception() error {
 func (c *connect) compressBuffer(start int) error {
 	if c.compression != CompressionNone && len(c.buffer.Buf) > 0 {
 		data := c.buffer.Buf[start:]
-		if err := c.compressor.Compress(compress.Method(c.compression), data); err != nil {
+		if err := c.compressor.Compress(data); err != nil {
 			return errors.Wrap(err, "compress")
 		}
 		c.buffer.Buf = append(c.buffer.Buf[:start], c.compressor.Data...)

--- a/conn_http.go
+++ b/conn_http.go
@@ -230,7 +230,7 @@ func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpCon
 		url:             u,
 		buffer:          new(chproto.Buffer),
 		compression:     opt.Compression.Method,
-		blockCompressor: compress.NewWriter(),
+		blockCompressor: compress.NewWriter(compress.Level(opt.Compression.Level), compress.Method(opt.Compression.Method)),
 		compressionPool: compressionPool,
 		blockBufferSize: opt.BlockBufferSize,
 		headers:         headers,
@@ -256,7 +256,7 @@ func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpCon
 		url:             u,
 		buffer:          new(chproto.Buffer),
 		compression:     opt.Compression.Method,
-		blockCompressor: compress.NewWriter(),
+		blockCompressor: compress.NewWriter(compress.Level(opt.Compression.Level), compress.Method(opt.Compression.Method)),
 		compressionPool: compressionPool,
 		location:        location,
 		blockBufferSize: opt.BlockBufferSize,
@@ -377,7 +377,7 @@ func (h *httpConnect) writeData(block *proto.Block) error {
 	if h.compression == CompressionLZ4 || h.compression == CompressionZSTD {
 		// Performing compression. Supported and requires
 		data := h.buffer.Buf[start:]
-		if err := h.blockCompressor.Compress(compress.Method(h.compression), data); err != nil {
+		if err := h.blockCompressor.Compress(data); err != nil {
 			return errors.Wrap(err, "compress")
 		}
 		h.buffer.Buf = append(h.buffer.Buf[:start], h.blockCompressor.Data...)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.23.5
 
 require (
-	github.com/ClickHouse/ch-go v0.64.1
+	github.com/ClickHouse/ch-go v0.65.0
 	github.com/ClickHouse/clickhouse-go v1.5.4
 	github.com/andybalholm/brotli v1.1.1
 	github.com/docker/docker v27.5.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/ClickHouse/ch-go v0.64.1 h1:FWpP+QU4KchgzpEekuv8YoI/fUc4H2r6Bwc5WwrzvcI=
-github.com/ClickHouse/ch-go v0.64.1/go.mod h1:RBUynvczWwVzhS6Up9lPKlH1mrk4UAmle6uzCiW4Pkc=
+github.com/ClickHouse/ch-go v0.65.0 h1:vZAXfTQliuNNefqkPDewX3kgRxN6Q4vUENnnY+ynTRY=
+github.com/ClickHouse/ch-go v0.65.0/go.mod h1:tCM0XEH5oWngoi9Iu/8+tjPBo04I/FxNIffpdjtwx3k=
 github.com/ClickHouse/clickhouse-go v1.5.4 h1:cKjXeYLNWVJIx2J1K6H2CqyRmfwVJVY1OV1coaaFcI0=
 github.com/ClickHouse/clickhouse-go v1.5.4/go.mod h1:EaI/sW7Azgz9UATzd5ZdZHRUhHgv5+JMS9NSr2smCJI=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=


### PR DESCRIPTION
## Summary
- Update to ch-go v0.65.0
- Included security patch from ch-go
- Adds LZ4HC compression from ch-go
- Reduce memory usage by ~1MB using new ch-go compressor functions
- Updated compression tests to use lz4hc + levels

Related ch-go PRs:
- https://github.com/ClickHouse/ch-go/pull/1039
- https://github.com/ClickHouse/ch-go/pull/1040
- https://github.com/ClickHouse/ch-go/pull/1041

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
