### PR TITLE
Add handling for struct in named tuples

### DIFF
--- a/lib/column/tuple.go
+++ b/lib/column/tuple.go
@@ -511,6 +511,55 @@ func (col *Tuple) AppendRow(v any) error {
 		value = value.Elem()
 	}
 	switch value.Kind() {
+	case reflect.Struct:
+		if !col.isNamed {
+			return &Error{
+				ColumnType: string(col.chType),
+				Err:        fmt.Errorf("converting from %T is not supported for unnamed tuples - use a slice", v),
+			}
+		}
+
+		valueType := value.Type()
+		fieldNames := make(map[string]struct{}, value.NumField())
+		for i := 0; i < value.NumField(); i++ {
+			if !value.Field(i).CanInterface() {
+				// can't interface - likely not exported so ignore the field
+				continue
+			}
+			name, omit := getStructFieldName(valueType.Field(i))
+			if omit {
+				continue
+			}
+			fieldNames[name] = struct{}{}
+		}
+
+		if len(fieldNames) != len(col.columns) {
+			return &Error{
+				ColumnType: string(col.chType),
+				Err:        fmt.Errorf("invalid size. expected %d got %d", len(col.columns), len(fieldNames)),
+			}
+		}
+
+		for i := 0; i < value.NumField(); i++ {
+			if !value.Field(i).CanInterface() {
+				// can't interface - likely not exported so ignore the field
+				continue
+			}
+			name, omit := getStructFieldName(valueType.Field(i))
+			if omit {
+				continue
+			}
+			if _, ok := col.index[name]; !ok {
+				return &Error{
+					ColumnType: string(col.chType),
+					Err:        fmt.Errorf("sub column '%s' does not exist in %s", name, col.Name()),
+				}
+			}
+			if err := col.columns[col.index[name]].AppendRow(value.Field(i).Interface()); err != nil {
+				return err
+			}
+		}
+		return nil
 	case reflect.Map:
 		if !col.isNamed {
 			return &Error{

--- a/lib/column/tuple.go
+++ b/lib/column/tuple.go
@@ -512,6 +512,19 @@ func (col *Tuple) AppendRow(v any) error {
 	}
 	switch value.Kind() {
 	case reflect.Struct:
+		if valuer, ok := v.(driver.Valuer); ok {
+			val, err := valuer.Value()
+			if err != nil {
+				return &ColumnConverterError{
+					Op:   "AppendRow",
+					To:   string(col.chType),
+					From: fmt.Sprintf("%T", v),
+					Hint: "could not get driver.Valuer value",
+				}
+			}
+			return col.AppendRow(val)
+		}
+
 		if !col.isNamed {
 			return &Error{
 				ColumnType: string(col.chType),


### PR DESCRIPTION
## Summary
Add support for converting Go structs to ClickHouse named tuples.
Closes #1010 

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added

