### PR TITLE
Add Array() support for Variant, Dynamic, JSON

### DIFF
--- a/lib/column/dynamic.go
+++ b/lib/column/dynamic.go
@@ -313,8 +313,13 @@ func (c *Dynamic) encodeData(buffer *proto.Buffer) {
 	c.variant.encodeData(buffer)
 }
 
-func (c *Dynamic) Encode(buffer *proto.Buffer) {
+func (c *Dynamic) WriteStatePrefix(buffer *proto.Buffer) error {
 	c.encodeHeader(buffer)
+
+	return nil
+}
+
+func (c *Dynamic) Encode(buffer *proto.Buffer) {
 	c.encodeData(buffer)
 }
 
@@ -393,13 +398,17 @@ func (c *Dynamic) decodeData(reader *proto.Reader, rows int) error {
 	return nil
 }
 
-func (c *Dynamic) Decode(reader *proto.Reader, rows int) error {
+func (c *Dynamic) ReadStatePrefix(reader *proto.Reader) error {
 	err := c.decodeHeader(reader)
 	if err != nil {
 		return fmt.Errorf("failed to decode dynamic header: %w", err)
 	}
 
-	err = c.decodeData(reader, rows)
+	return nil
+}
+
+func (c *Dynamic) Decode(reader *proto.Reader, rows int) error {
+	err := c.decodeData(reader, rows)
 	if err != nil {
 		return fmt.Errorf("failed to decode dynamic data: %w", err)
 	}

--- a/lib/column/variant.go
+++ b/lib/column/variant.go
@@ -275,8 +275,13 @@ func (c *Variant) encodeData(buffer *proto.Buffer) {
 	}
 }
 
-func (c *Variant) Encode(buffer *proto.Buffer) {
+func (c *Variant) WriteStatePrefix(buffer *proto.Buffer) error {
 	c.encodeHeader(buffer)
+
+	return nil
+}
+
+func (c *Variant) Encode(buffer *proto.Buffer) {
 	c.encodeData(buffer)
 }
 
@@ -336,13 +341,17 @@ func (c *Variant) decodeData(reader *proto.Reader, rows int) error {
 	return nil
 }
 
-func (c *Variant) Decode(reader *proto.Reader, rows int) error {
+func (c *Variant) ReadStatePrefix(reader *proto.Reader) error {
 	err := c.decodeHeader(reader)
 	if err != nil {
 		return fmt.Errorf("failed to decode variant header: %w", err)
 	}
 
-	err = c.decodeData(reader, rows)
+	return nil
+}
+
+func (c *Variant) Decode(reader *proto.Reader, rows int) error {
+	err := c.decodeData(reader, rows)
 	if err != nil {
 		return fmt.Errorf("failed to decode variant data: %w", err)
 	}

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -38,7 +38,7 @@ func setupJSONTest(t *testing.T) driver.Conn {
 	})
 	require.NoError(t, err)
 
-	if !CheckMinServerServerVersion(conn, 24, 9, 0) {
+	if !CheckMinServerServerVersion(conn, 24, 10, 0) {
 		t.Skip(fmt.Errorf("unsupported clickhouse version for JSON type"))
 		return nil
 	}

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -72,7 +71,7 @@ func TestJSONPaths(t *testing.T) {
 	rows, err := conn.Query(ctx, "SELECT c FROM test_json")
 	require.NoError(t, err)
 
-	var row chcol.JSON
+	var row clickhouse.JSON
 
 	require.True(t, rows.Next())
 	err = rows.Scan(&row)
@@ -97,6 +96,101 @@ func TestJSONPaths(t *testing.T) {
 
 		require.Equal(t, expectedValue, actualValue)
 	}
+}
+
+func TestJSONArray(t *testing.T) {
+	ctx := context.Background()
+	conn := setupJSONTest(t)
+
+	const ddl = `
+			CREATE TABLE IF NOT EXISTS test_json (
+				  c Array(JSON)
+			) Engine = MergeTree() ORDER BY tuple()
+		`
+	require.NoError(t, conn.Exec(ctx, ddl))
+	defer func() {
+		require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_json"))
+	}()
+
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_json (c)")
+	require.NoError(t, err)
+
+	arrJsonRow := []*clickhouse.JSON{clickhouse.NewJSON(), BuildTestJSONPaths()}
+
+	require.NoError(t, batch.Append(arrJsonRow))
+	require.NoError(t, batch.Send())
+
+	rows, err := conn.Query(ctx, "SELECT c FROM test_json")
+	require.NoError(t, err)
+
+	var arrRow []*clickhouse.JSON
+
+	require.True(t, rows.Next())
+	err = rows.Scan(&arrRow)
+	require.NoError(t, err)
+	require.Len(t, arrRow, 2)
+
+	actualValuesByPathEmpty := arrRow[0].ValuesByPath()
+	for _, actualValue := range actualValuesByPathEmpty {
+		// Allow Nil func to compare values without Dynamic wrapper
+		if v, ok := actualValue.(clickhouse.Dynamic); ok {
+			actualValue = v.Any()
+		}
+
+		require.Nil(t, actualValue)
+	}
+
+	expectedValuesByPath := arrJsonRow[1].ValuesByPath()
+	actualValuesByPath := arrRow[1].ValuesByPath()
+	for path, expectedValue := range expectedValuesByPath {
+		actualValue, ok := actualValuesByPath[path]
+		if !ok {
+			t.Fatalf("result JSON is missing path: %s", path)
+		}
+
+		// Allow Equal func to compare values without Dynamic wrapper
+		if v, ok := expectedValue.(clickhouse.Dynamic); ok {
+			expectedValue = v.Any()
+		}
+
+		if v, ok := actualValue.(clickhouse.Dynamic); ok {
+			actualValue = v.Any()
+		}
+
+		require.Equal(t, expectedValue, actualValue)
+	}
+}
+
+func TestJSONEmptyArray(t *testing.T) {
+	ctx := context.Background()
+	conn := setupJSONTest(t)
+
+	const ddl = `
+			CREATE TABLE IF NOT EXISTS test_json (
+				  c Array(JSON)
+			) Engine = MergeTree() ORDER BY tuple()
+		`
+	require.NoError(t, conn.Exec(ctx, ddl))
+	defer func() {
+		require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_json"))
+	}()
+
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_json (c)")
+	require.NoError(t, err)
+
+	var arrJsonRow []*clickhouse.JSON
+	require.NoError(t, batch.Append(arrJsonRow))
+	require.NoError(t, batch.Send())
+
+	rows, err := conn.Query(ctx, "SELECT c FROM test_json")
+	require.NoError(t, err)
+
+	var arrRow []*clickhouse.JSON
+
+	require.True(t, rows.Next())
+	err = rows.Scan(&arrRow)
+	require.NoError(t, err)
+	require.Len(t, arrRow, 0)
 }
 
 func TestJSONStruct(t *testing.T) {

--- a/tests/variant_test.go
+++ b/tests/variant_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/stretchr/testify/require"
 )
@@ -101,7 +100,7 @@ func TestVariant(t *testing.T) {
 	rows, err := conn.Query(ctx, "SELECT c FROM test_variant")
 	require.NoError(t, err)
 
-	var row chcol.Variant
+	var row clickhouse.Variant
 
 	require.True(t, rows.Next())
 	err = rows.Scan(&row)
@@ -154,6 +153,74 @@ func TestVariant(t *testing.T) {
 	require.Equal(t, colMapStringInt64, row.Any())
 }
 
+func TestVariantArray(t *testing.T) {
+	ctx := context.Background()
+	conn := setupVariantTest(t)
+
+	const ddl = `
+			CREATE TABLE IF NOT EXISTS test_variant (
+				  c Array(Variant(Int64))                  
+			) Engine = MergeTree() ORDER BY tuple()
+		`
+	require.NoError(t, conn.Exec(ctx, ddl))
+	defer func() {
+		require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_variant"))
+	}()
+
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_variant (c)")
+	require.NoError(t, err)
+
+	batch.Append([]clickhouse.Variant{
+		clickhouse.NewVariantWithType(int64(42), "Int64"),
+		clickhouse.NewVariantWithType(int64(84), "Int64"),
+	})
+	require.NoError(t, batch.Send())
+
+	rows, err := conn.Query(ctx, "SELECT c FROM test_variant")
+	require.NoError(t, err)
+
+	var arrRow []clickhouse.Variant
+
+	require.True(t, rows.Next())
+	err = rows.Scan(&arrRow)
+	require.NoError(t, err)
+	require.Len(t, arrRow, 2)
+
+	require.Equal(t, int64(42), arrRow[0].Any())
+	require.Equal(t, int64(84), arrRow[1].Any())
+}
+
+func TestVariantEmptyArray(t *testing.T) {
+	ctx := context.Background()
+	conn := setupVariantTest(t)
+
+	const ddl = `
+			CREATE TABLE IF NOT EXISTS test_variant (
+				  c Array(Variant(Int64))                  
+			) Engine = MergeTree() ORDER BY tuple()
+		`
+	require.NoError(t, conn.Exec(ctx, ddl))
+	defer func() {
+		require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_variant"))
+	}()
+
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_variant (c)")
+	require.NoError(t, err)
+
+	batch.Append([]clickhouse.Variant{})
+	require.NoError(t, batch.Send())
+
+	rows, err := conn.Query(ctx, "SELECT c FROM test_variant")
+	require.NoError(t, err)
+
+	var arrRow []clickhouse.Variant
+
+	require.True(t, rows.Next())
+	err = rows.Scan(&arrRow)
+	require.NoError(t, err)
+	require.Len(t, arrRow, 0)
+}
+
 func TestVariant_ScanWithType(t *testing.T) {
 	ctx := context.Background()
 	conn := setupVariantTest(t)
@@ -179,7 +246,7 @@ func TestVariant_ScanWithType(t *testing.T) {
 	rows, err := conn.Query(ctx, "SELECT c FROM test_variant")
 	require.NoError(t, err)
 
-	var row chcol.Variant
+	var row clickhouse.Variant
 
 	require.True(t, rows.Next())
 	err = rows.Scan(&row)
@@ -235,7 +302,7 @@ func TestVariant_BatchFlush(t *testing.T) {
 
 	i := 0
 	for rows.Next() {
-		var row chcol.Variant
+		var row clickhouse.Variant
 		err = rows.Scan(&row)
 
 		if i%2 == 0 {


### PR DESCRIPTION
## Summary
Implemented the prefix serialization interfaces for Variant, Dynamic, and JSON. This adds support for the `Array` wrapper since these types require their prefix to be encoded before the array data.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
