### PR TITLE
fix: decode nested prefixes in variant

### DIFF
--- a/lib/column/variant.go
+++ b/lib/column/variant.go
@@ -307,6 +307,14 @@ func (c *Variant) decodeHeader(reader *proto.Reader) error {
 		return fmt.Errorf("unsupported variant discriminator version: %d", variantSerializationVersion)
 	}
 
+	for _, col := range c.columns {
+		if serialize, ok := col.(CustomSerialization); ok {
+			if err := serialize.ReadStatePrefix(reader); err != nil {
+				return fmt.Errorf("failed to read prefix for type %s in variant: %w", col.Type(), err)
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
While #1501 added support for Variant/Dynamic/JSON arrays, this PR adds support for nested arrays of those types. For example, `Array(JSON)::Dynamic`.

The issue was that the underlying `Variant` implementation wasn't reading the prefixes of the inner columns. This was only an issue for column types that required a prefix themself, such as `Array(JSON)` inside `Dynamic` or `Variant`. Some tests have been added to verify that there's no errors while decoding these.

closes https://github.com/grafana/clickhouse-datasource/issues/1168

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
