### PR TITLE
limit MaxConnsPerHost for http.Transport

### DIFF
--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -149,6 +149,7 @@ type Options struct {
 	FreeBufOnConnRelease bool              // drop preserved memory buffer after each query
 	HttpHeaders          map[string]string // set additional headers on HTTP requests
 	HttpUrlPath          string            // set additional URL path for HTTP requests
+	HttpMaxConnsPerHost  int               // MaxConnsPerHost for http.Transport
 	BlockBufferSize      uint8             // default 2 - can be overwritten on query
 	MaxCompressionBuffer int               // default 10485760 - measured in bytes  i.e.
 

--- a/conn_http.go
+++ b/conn_http.go
@@ -212,6 +212,7 @@ func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpCon
 			Timeout: opt.DialTimeout,
 		}).DialContext,
 		MaxIdleConns:          1,
+		MaxConnsPerHost:       opt.HttpMaxConnsPerHost,
 		IdleConnTimeout:       opt.ConnMaxLifetime,
 		ResponseHeaderTimeout: opt.ReadTimeout,
 		TLSClientConfig:       opt.TLS,


### PR DESCRIPTION
Hello, we've hit a problem with clickhouse-client.
We have a scenario with bad connectivity to CH, our query calls timeout, but the way http.Transport works is that readLoop/writeLoop is asynchronous and might "linger" for some time before stopping these goroutines.
In case of retries it tries to create new connections and generates more and more goroutines.

MaxConnsPerHost limits the total number of connections including in "dialing" state

An example of what it looks like for us:
```
goroutine profile: total 6284
3106 @ 0x474e6e 0x437277 0x474165 0x524687 0x52597a 0x525968 0x5e2ac5 0x5f27a5 0x65409b 0x4c41d8 0x65427e 0x65138f 0x657bf0 0x657bf1 0x95654a 0x6f1f83 0x6f20b3 0x957085 0x47d041
#	0x474164	internal/poll.runtime_pollWait+0x84		GOROOT/src/runtime/netpoll.go:351
#	0x524686	internal/poll.(*pollDesc).wait+0x26		GOROOT/src/internal/poll/fd_poll_runtime.go:84
#	0x525979	internal/poll.(*pollDesc).waitRead+0x279	GOROOT/src/internal/poll/fd_poll_runtime.go:89
#	0x525967	internal/poll.(*FD).Read+0x267			GOROOT/src/internal/poll/fd_unix.go:165
#	0x5e2ac4	net.(*netFD).Read+0x24				GOROOT/src/net/fd_posix.go:55
#	0x5f27a4	net.(*conn).Read+0x44				GOROOT/src/net/net.go:189
#	0x65409a	crypto/tls.(*atLeastReader).Read+0x3a		GOROOT/src/crypto/tls/conn.go:809
#	0x4c41d7	bytes.(*Buffer).ReadFrom+0x97			GOROOT/src/bytes/buffer.go:211
#	0x65427d	crypto/tls.(*Conn).readFromUntil+0xdd		GOROOT/src/crypto/tls/conn.go:831
#	0x65138e	crypto/tls.(*Conn).readRecordOrCCS+0x3ce	GOROOT/src/crypto/tls/conn.go:629
#	0x657bef	crypto/tls.(*Conn).readRecord+0x14f		GOROOT/src/crypto/tls/conn.go:591
#	0x657bf0	crypto/tls.(*Conn).Read+0x150			GOROOT/src/crypto/tls/conn.go:1385
#	0x956549	net/http.(*persistConn).Read+0x49		GOROOT/src/net/http/transport.go:2052
#	0x6f1f82	bufio.(*Reader).fill+0x102			GOROOT/src/bufio/bufio.go:110
#	0x6f20b2	bufio.(*Reader).Peek+0x52			GOROOT/src/bufio/bufio.go:148
#	0x957084	net/http.(*persistConn).readLoop+0x184		GOROOT/src/net/http/transport.go:2205

3106 @ 0x474e6e 0x450ae5 0x958a87 0x47d041
#	0x958a86	net/http.(*persistConn).writeLoop+0xe6	GOROOT/src/net/http/transport.go:2519
```