### PR TITLE
fix concurrent map write errors with context

### DIFF
--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -306,8 +306,8 @@ func (std *stdDriver) ExecContext(ctx context.Context, query string, args []driv
 	}
 
 	var err error
-	if options := queryOptions(ctx); options.async.ok {
-		err = std.conn.asyncInsert(ctx, query, options.async.wait, rebind(args)...)
+	if asyncOpt := queryOptionsAsync(ctx); asyncOpt.ok {
+		err = std.conn.asyncInsert(ctx, query, asyncOpt.wait, rebind(args)...)
 	} else {
 		err = std.conn.exec(ctx, query, rebind(args)...)
 	}

--- a/conn.go
+++ b/conn.go
@@ -344,10 +344,10 @@ func (c *connect) readData(ctx context.Context, packet byte, compressible bool) 
 		defer c.reader.DisableCompression()
 	}
 
-	opts := queryOptions(ctx)
+	userLocation := queryOptionsUserLocation(ctx)
 	location := c.server.Timezone
-	if opts.userLocation != nil {
-		location = opts.userLocation
+	if userLocation != nil {
+		location = userLocation
 	}
 
 	block := proto.Block{Timezone: location}

--- a/context.go
+++ b/context.go
@@ -19,6 +19,7 @@ package clickhouse
 
 import (
 	"context"
+	"maps"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/ext"
@@ -43,12 +44,13 @@ type CustomSetting struct {
 type Parameters map[string]string
 type (
 	QueryOption  func(*QueryOptions) error
+	AsyncOptions struct {
+		ok   bool
+		wait bool
+	}
 	QueryOptions struct {
-		span  trace.SpanContext
-		async struct {
-			ok   bool
-			wait bool
-		}
+		span     trace.SpanContext
+		async    AsyncOptions
 		queryID  string
 		quotaKey string
 		events   struct {
@@ -163,26 +165,67 @@ func ignoreExternalTables() QueryOption {
 	}
 }
 
+// Context applies ClickHouse QueryOptions to the current context.
+// The QueryOptions Settings map will be initialized if nil.
 func Context(parent context.Context, options ...QueryOption) context.Context {
-	opt := queryOptions(parent)
+	var opt QueryOptions
+	if ctxOpt, ok := parent.Value(_contextOptionKey).(QueryOptions); ok {
+		opt = ctxOpt
+	}
+
 	for _, f := range options {
 		f(&opt)
 	}
+
+	if opt.settings == nil {
+		opt.settings = make(Settings)
+	}
+
 	return context.WithValue(parent, _contextOptionKey, opt)
 }
 
+// queryOptions returns a mutable copy of the QueryOptions struct within the given context.
+// If ClickHouse context was not provided, an empty struct with a valid Settings map is returned.
+// If the context has a deadline greater than 1s then max_execution_time setting is appended.
 func queryOptions(ctx context.Context) QueryOptions {
-	if o, ok := ctx.Value(_contextOptionKey).(QueryOptions); ok {
-		if deadline, ok := ctx.Deadline(); ok {
-			if sec := time.Until(deadline).Seconds(); sec > 1 {
-				o.settings["max_execution_time"] = int(sec + 5)
-			}
+	var opt QueryOptions
+
+	if ctxOpt, ok := ctx.Value(_contextOptionKey).(QueryOptions); ok {
+		opt = ctxOpt.clone()
+	} else {
+		opt = QueryOptions{
+			settings: make(Settings),
 		}
-		return o
 	}
-	return QueryOptions{
-		settings: make(Settings),
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return opt
 	}
+
+	if sec := time.Until(deadline).Seconds(); sec > 1 {
+		opt.settings["max_execution_time"] = int(sec + 5)
+	}
+
+	return opt
+}
+
+// queryOptionsAsync returns the AsyncOptions struct within the given context's QueryOptions.
+func queryOptionsAsync(ctx context.Context) AsyncOptions {
+	if opt, ok := ctx.Value(_contextOptionKey).(QueryOptions); ok {
+		return opt.async
+	}
+
+	return AsyncOptions{}
+}
+
+// queryOptionsUserLocation returns the *time.Location within the given context's QueryOptions.
+func queryOptionsUserLocation(ctx context.Context) *time.Location {
+	if opt, ok := ctx.Value(_contextOptionKey).(QueryOptions); ok {
+		return opt.userLocation
+	}
+
+	return nil
 }
 
 func (q *QueryOptions) onProcess() *onProcess {
@@ -210,4 +253,32 @@ func (q *QueryOptions) onProcess() *onProcess {
 			}
 		},
 	}
+}
+
+// clone returns a copy of QueryOptions where Settings and Parameters are safely mutable.
+func (q *QueryOptions) clone() QueryOptions {
+	c := QueryOptions{
+		span:            q.span,
+		async:           q.async,
+		queryID:         q.queryID,
+		quotaKey:        q.quotaKey,
+		events:          q.events,
+		settings:        nil,
+		parameters:      nil,
+		external:        q.external,
+		blockBufferSize: q.blockBufferSize,
+		userLocation:    q.userLocation,
+	}
+
+	if q.settings != nil {
+		c.settings = make(Settings, len(q.settings))
+		maps.Copy(c.settings, q.settings)
+	}
+
+	if q.parameters != nil {
+		c.parameters = make(Parameters, len(q.parameters))
+		maps.Copy(c.parameters, q.parameters)
+	}
+
+	return c
 }

--- a/context.go
+++ b/context.go
@@ -165,7 +165,8 @@ func ignoreExternalTables() QueryOption {
 	}
 }
 
-// Context applies ClickHouse QueryOptions to the current context.
+// Context returns a derived context with the given ClickHouse QueryOptions.
+// Existing QueryOptions will be overwritten per option if present.
 // The QueryOptions Settings map will be initialized if nil.
 func Context(parent context.Context, options ...QueryOption) context.Context {
 	var opt QueryOptions

--- a/tests/issues/1503_test.go
+++ b/tests/issues/1503_test.go
@@ -1,3 +1,5 @@
+//go:build !race
+
 package issues
 
 import (
@@ -31,7 +33,7 @@ func TestIssue1503(t *testing.T) {
 		require.NoError(t, err)
 		wg.Done()
 	}
-	
+
 	attempts := 10
 	concurrency := 5
 

--- a/tests/issues/1503_test.go
+++ b/tests/issues/1503_test.go
@@ -1,0 +1,46 @@
+package issues
+
+import (
+	"context"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/require"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestIssue1503(t *testing.T) {
+	conn, err := tests.GetConnection("issues", nil, nil, nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Settings gets re-used between contexts
+	settings := clickhouse.Settings{
+		"async_insert": "0",
+	}
+
+	// Try to force a concurrent map write error from re-using the same settings map
+	var wg sync.WaitGroup
+	testInsert := func() {
+		ctx = clickhouse.Context(ctx, clickhouse.WithSettings(settings))
+		err = conn.Exec(ctx, "INSERT INTO function null('x UInt64') VALUES (1)")
+		require.NoError(t, err)
+		wg.Done()
+	}
+	
+	attempts := 10
+	concurrency := 5
+
+	for i := 0; i < attempts; i++ {
+		wg.Add(concurrency)
+		for j := 0; j < concurrency; j++ {
+			go testInsert()
+		}
+
+		wg.Wait()
+	}
+}


### PR DESCRIPTION
## Summary
closes #1503 

This PR fixes 3 bugs:
1. A concurrent map write error where `clickhouse.WithSettings()` maps are re-used between context/calls
2. Per-query settings will no longer override subsequent queries
3. An edge case where an empty `clickhouse.WithSettings(nil)` map could result in a nil write panic

The root cause of #1503 is that maps were being shared between contexts. This is fine when nesting contexts, but there are some cases where the driver will override settings. For example `max_execution_time` is always overridden when the context has a deadline. Another example is `async_insert` being changed when using `AsyncInsert`. When the driver overrides these settings, the settings are persisted for the following queries. This leads to unexpected behavior as well as concurrency issues when overriding settings.

As a fix, the `Settings` map will now always be copied when read in the driver. This is because the deadline context is almost always modified, and settings are almost always overridden (this will increase garbage but it's negligible).

There were two places in the code where the settings are read but not modified: reading async status and reading user timezone location. I added two functions for these cases so we don't need to make an unnecessary copy.

I added many tests to solidify the behavior of the driver's context wrapper. I also added a test case that forces a concurrent map write issue (which doesn't fail anymore since it's fixed).

Function documentation has been updated too to make it clearer in the future. The code is also a bit more readable and easy to follow when seeing where the `Settings` map is initialized.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
