### PR TITLE
chore: replace github.com/pkg/errors with stdlib

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 var normalizeInsertQueryMatch = regexp.MustCompile(`(?i)(INSERT\s+INTO\s+([^(]+)(?:\s*\([^()]*(?:\([^()]*\)[^()]*)*\))?)(?:\s*VALUES)?`)
@@ -36,7 +34,7 @@ func extractNormalizedInsertQueryAndColumns(query string) (normalizedQuery strin
 
 	matches := normalizeInsertQueryMatch.FindStringSubmatch(query)
 	if len(matches) == 0 {
-		err = errors.Errorf("invalid INSERT query: %s", query)
+		err = fmt.Errorf("invalid INSERT query: %s", query)
 		return
 	}
 

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -20,6 +20,7 @@ package clickhouse
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -29,7 +30,6 @@ import (
 	"time"
 
 	"github.com/ClickHouse/ch-go/compress"
-	"github.com/pkg/errors"
 )
 
 type CompressionMethod byte
@@ -211,7 +211,7 @@ func (o *Options) fromDSN(in string) error {
 		case "compress_level":
 			level, err := strconv.ParseInt(params.Get(v), 10, 8)
 			if err != nil {
-				return errors.Wrap(err, "compress_level invalid value")
+				return fmt.Errorf("compress_level invalid value: %w", err)
 			}
 
 			if o.Compression == nil {
@@ -227,7 +227,7 @@ func (o *Options) fromDSN(in string) error {
 		case "max_compression_buffer":
 			max, err := strconv.Atoi(params.Get(v))
 			if err != nil {
-				return errors.Wrap(err, "max_compression_buffer invalid value")
+				return fmt.Errorf("max_compression_buffer invalid value: %w", err)
 			}
 			o.MaxCompressionBuffer = max
 		case "dial_timeout":
@@ -283,19 +283,19 @@ func (o *Options) fromDSN(in string) error {
 		case "max_open_conns":
 			maxOpenConns, err := strconv.Atoi(params.Get(v))
 			if err != nil {
-				return errors.Wrap(err, "max_open_conns invalid value")
+				return fmt.Errorf("max_open_conns invalid value: %w", err)
 			}
 			o.MaxOpenConns = maxOpenConns
 		case "max_idle_conns":
 			maxIdleConns, err := strconv.Atoi(params.Get(v))
 			if err != nil {
-				return errors.Wrap(err, "max_idle_conns invalid value")
+				return fmt.Errorf("max_idle_conns invalid value: %w", err)
 			}
 			o.MaxIdleConns = maxIdleConns
 		case "conn_max_lifetime":
 			connMaxLifetime, err := time.ParseDuration(params.Get(v))
 			if err != nil {
-				return errors.Wrap(err, "conn_max_lifetime invalid value")
+				return fmt.Errorf("conn_max_lifetime invalid value: %w", err)
 			}
 			o.ConnMaxLifetime = connMaxLifetime
 		case "username":

--- a/conn.go
+++ b/conn.go
@@ -20,6 +20,7 @@ package clickhouse
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -30,7 +31,6 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/resources"
-	"github.com/pkg/errors"
 
 	"github.com/ClickHouse/ch-go/compress"
 	chproto "github.com/ClickHouse/ch-go/proto"
@@ -256,7 +256,7 @@ func (c *connect) compressBuffer(start int) error {
 	if c.compression != CompressionNone && len(c.buffer.Buf) > 0 {
 		data := c.buffer.Buf[start:]
 		if err := c.compressor.Compress(data); err != nil {
-			return errors.Wrap(err, "compress")
+			return fmt.Errorf("compress: %w", err)
 		}
 		c.buffer.Buf = append(c.buffer.Buf[:start], c.compressor.Data...)
 	}
@@ -369,7 +369,7 @@ func (c *connect) flush() error {
 
 	n, err := c.conn.Write(c.buffer.Buf)
 	if err != nil {
-		return errors.Wrap(err, "write")
+		return fmt.Errorf("write: %w", err)
 	}
 
 	if n != len(c.buffer.Buf) {

--- a/conn_batch.go
+++ b/conn_batch.go
@@ -19,14 +19,13 @@ package clickhouse
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
 	"slices"
 	"syscall"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -130,7 +129,7 @@ func (b *batch) Append(v ...any) error {
 	}
 
 	if err := b.block.Append(v...); err != nil {
-		b.err = errors.Wrap(ErrBatchInvalid, err.Error())
+		b.err = fmt.Errorf("%w: %w", ErrBatchInvalid, err)
 		b.release(err)
 		return err
 	}

--- a/conn_http.go
+++ b/conn_http.go
@@ -24,6 +24,7 @@ import (
 	"compress/zlib"
 	"context"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -42,7 +43,6 @@ import (
 	chproto "github.com/ClickHouse/ch-go/proto"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"github.com/andybalholm/brotli"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -379,7 +379,7 @@ func (h *httpConnect) writeData(block *proto.Block) error {
 		// Performing compression. Supported and requires
 		data := h.buffer.Buf[start:]
 		if err := h.blockCompressor.Compress(data); err != nil {
-			return errors.Wrap(err, "compress")
+			return fmt.Errorf("compress: %w", err)
 		}
 		h.buffer.Buf = append(h.buffer.Buf[:start], h.blockCompressor.Data...)
 	}

--- a/conn_process.go
+++ b/conn_process.go
@@ -19,11 +19,11 @@ package clickhouse
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
-	"github.com/pkg/errors"
 )
 
 type onProcess struct {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/mkevac/debugcharts v0.0.0-20191222103121-ae1c48aa8615
 	github.com/paulmach/orb v0.11.1
-	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.4.0
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.33.0
@@ -58,6 +57,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/segmentio/asm v1.2.0 // indirect

--- a/query_parameters.go
+++ b/query_parameters.go
@@ -18,10 +18,11 @@
 package clickhouse
 
 import (
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/pkg/errors"
+	"errors"
 	"regexp"
 	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
 var (

--- a/tests/issues/1395_test.go
+++ b/tests/issues/1395_test.go
@@ -21,11 +21,11 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"fmt"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,7 +46,7 @@ func Test1395(t *testing.T) {
 	tx1 := func(c *sql.Conn) error {
 		tx, err := c.BeginTx(ctx, nil)
 		if err != nil {
-			return errors.Wrap(err, "begin tx")
+			return fmt.Errorf("begin tx: %w", err)
 		}
 		defer tx.Rollback()
 
@@ -57,12 +57,12 @@ ON CLUSTER my
 ENGINE = MergeTree()
 ORDER BY id`)
 		if err != nil {
-			return errors.Wrap(err, "create table")
+			return fmt.Errorf("create table: %w", err)
 		}
 
 		err = tx.Commit()
 		if err != nil {
-			return errors.Wrap(err, "commit tx")
+			return fmt.Errorf("commit tx: %w", err)
 		}
 
 		return nil
@@ -74,17 +74,17 @@ ORDER BY id`)
 	tx2 := func(c *sql.Conn) error {
 		tx, err := c.BeginTx(ctx, nil)
 		if err != nil {
-			return errors.Wrap(err, "begin tx")
+			return fmt.Errorf("begin tx: %w", err)
 		}
 		defer tx.Rollback()
 
 		_, err = tx.ExecContext(ctx, "INSERT INTO test_table (id, name) VALUES (?, ?)", 1, "test_name")
 		if err != nil {
-			return errors.Wrap(err, "failed to insert record")
+			return fmt.Errorf("failed to insert record: %w", err)
 		}
 		err = tx.Commit()
 		if err != nil {
-			return errors.Wrap(err, "commit tx")
+			return fmt.Errorf("commit tx: %w", err)
 		}
 
 		return nil


### PR DESCRIPTION
## Summary
Replace usage of "github.com/pkg/errors" with stdlib "errors" package

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
