### PR TITLE
allow to build decimal from string

### DIFF
--- a/lib/column/decimal.go
+++ b/lib/column/decimal.go
@@ -201,6 +201,12 @@ func (col *Decimal) AppendRow(v any) error {
 		if v != nil {
 			value = *v
 		}
+	case string:
+		d, err := decimal.NewFromString(v)
+		if err != nil {
+			return fmt.Errorf("%v could not be converted to decimal %w", v, err)
+		}
+		value = d
 	case nil:
 	default:
 		if valuer, ok := v.(driver.Valuer); ok {


### PR DESCRIPTION
## Summary
Some decimal libraries implements database/sql.Valuer interface by using string representation
allowing it in the driver helps to support wider list of 3d-party libraries for decimal type

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
