### PR TITLE
Add length check to `FixedString` to prevent panic

### DIFF
--- a/lib/column/fixed_string.go
+++ b/lib/column/fixed_string.go
@@ -111,32 +111,61 @@ func (col *FixedString) ScanRow(dest any, row int) error {
 	return nil
 }
 
+// safeAppendRow appends the value to the underlying column with a length check.
+// This re-implements the logic from ch-go but without the panic.
+// It also fills unused space with zeros.
+func (col *FixedString) safeAppendRow(v []byte) error {
+	if col.col.Size == 0 {
+		// If unset, use first value's length for the string size
+		col.col.Size = len(v)
+	}
+
+	if len(v) > col.col.Size {
+		return fmt.Errorf("input value with length %d exceeds FixedString(%d) capacity", len(v), col.col.Size)
+	}
+
+	col.col.Buf = append(col.col.Buf, v...)
+
+	// Fill the unused space of the fixed string with zeros
+	padding := col.col.Size - len(v)
+	for i := 0; i < padding; i++ {
+		col.col.Buf = append(col.col.Buf, 0)
+	}
+
+	return nil
+}
+
 func (col *FixedString) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []string:
 		nulls = make([]uint8, len(v))
 		for _, v := range v {
+			var err error
 			if v == "" {
-				col.col.Append(make([]byte, col.col.Size))
+				err = col.safeAppendRow(nil)
 			} else {
-				col.col.Append(binary.Str2Bytes(v, col.col.Size))
+				err = col.safeAppendRow(binary.Str2Bytes(v, col.col.Size))
+			}
+
+			if err != nil {
+				return nil, err
 			}
 		}
 	case []*string:
 		nulls = make([]uint8, len(v))
 		for i, v := range v {
+			var err error
 			if v == nil {
 				nulls[i] = 1
+				err = col.safeAppendRow(nil)
+			} else if *v == "" {
+				err = col.safeAppendRow(nil)
+			} else {
+				err = col.safeAppendRow(binary.Str2Bytes(*v, col.col.Size))
 			}
-			switch {
-			case v == nil:
-				col.col.Append(make([]byte, col.col.Size))
-			default:
-				if *v == "" {
-					col.col.Append(make([]byte, col.col.Size))
-				} else {
-					col.col.Append(binary.Str2Bytes(*v, col.col.Size))
-				}
+
+			if err != nil {
+				return nil, err
 			}
 		}
 	case encoding.BinaryMarshaler:
@@ -144,7 +173,11 @@ func (col *FixedString) Append(v any) (nulls []uint8, err error) {
 		if err != nil {
 			return nil, err
 		}
-		col.col.Append(data)
+		err = col.safeAppendRow(data)
+		if err != nil {
+			return nil, err
+		}
+
 		nulls = make([]uint8, len(data)/col.col.Size)
 	case [][]byte:
 		nulls = make([]uint8, len(v))
@@ -153,14 +186,17 @@ func (col *FixedString) Append(v any) (nulls []uint8, err error) {
 				nulls[i] = 1
 			}
 			n := len(v)
+			var err error
 			if n == 0 {
-				col.col.Append(make([]byte, col.col.Size))
+				err = col.safeAppendRow(nil)
 			} else if n >= col.col.Size {
-				col.col.Append(v[0:col.col.Size])
+				err = col.safeAppendRow(v[0:col.col.Size])
 			} else {
-				data := make([]byte, col.col.Size)
-				copy(data, v)
-				col.col.Append(data)
+				err = col.safeAppendRow(v)
+			}
+
+			if err != nil {
+				return nil, err
 			}
 		}
 	default:
@@ -174,7 +210,10 @@ func (col *FixedString) Append(v any) (nulls []uint8, err error) {
 				e := rv.Index(i)
 				data := make([]byte, e.Len())
 				reflect.Copy(reflect.ValueOf(data), e)
-				col.col.Append(data)
+				err := col.safeAppendRow(data)
+				if err != nil {
+					return nil, err
+				}
 			}
 			return
 		}
@@ -200,24 +239,41 @@ func (col *FixedString) Append(v any) (nulls []uint8, err error) {
 	return
 }
 
-func (col *FixedString) AppendRow(v any) (err error) {
-	data := make([]byte, col.col.Size)
+func (col *FixedString) AppendRow(v any) error {
 	switch v := v.(type) {
 	case []byte:
-		copy(data, v)
+		err := col.safeAppendRow(v)
+		if err != nil {
+			return err
+		}
 	case string:
-		if v != "" {
-			data = binary.Str2Bytes(v, col.col.Size)
+		err := col.safeAppendRow(binary.Str2Bytes(v, col.col.Size))
+		if err != nil {
+			return err
 		}
 	case *string:
+		var data []byte
 		if v != nil {
-			if *v != "" {
-				data = binary.Str2Bytes(*v, col.col.Size)
-			}
+			data = binary.Str2Bytes(*v, col.col.Size)
+		}
+
+		err := col.safeAppendRow(data)
+		if err != nil {
+			return err
 		}
 	case nil:
+		err := col.safeAppendRow(nil)
+		if err != nil {
+			return err
+		}
 	case encoding.BinaryMarshaler:
-		if data, err = v.MarshalBinary(); err != nil {
+		data, err := v.MarshalBinary()
+		if err != nil {
+			return err
+		}
+
+		err = col.safeAppendRow(data)
+		if err != nil {
 			return err
 		}
 	default:
@@ -230,8 +286,14 @@ func (col *FixedString) AppendRow(v any) (err error) {
 					Hint: fmt.Sprintf("invalid size %d, expect %d", t.Len(), col.col.Size),
 				}
 			}
+
+			data := make([]byte, col.col.Size)
 			reflect.Copy(reflect.ValueOf(data), reflect.ValueOf(v))
-			col.col.Append(data)
+			err := col.safeAppendRow(data)
+			if err != nil {
+				return err
+			}
+
 			return nil
 		}
 
@@ -258,7 +320,7 @@ func (col *FixedString) AppendRow(v any) (err error) {
 			From: fmt.Sprintf("%T", v),
 		}
 	}
-	col.col.Append(data)
+
 	return nil
 }
 

--- a/tests/fixed_string_test.go
+++ b/tests/fixed_string_test.go
@@ -125,7 +125,8 @@ func TestEmptyFixedString(t *testing.T) {
 	const ddl = `
 			CREATE TABLE test_fixed_string_empty (
 				Col1 FixedString(2),
-				Col2 FixedString(2)
+				Col2 FixedString(2),
+				Col3 FixedString(2),
 			) Engine MergeTree() ORDER BY tuple()
 		`
 	defer func() {
@@ -135,19 +136,51 @@ func TestEmptyFixedString(t *testing.T) {
 	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_fixed_string_empty")
 	require.NoError(t, err)
 	var (
-		col1Data = ""
-		col2Data = "US"
+		col1Data         = ""
+		col2Data         = "US"
+		col3Data *string = nil
 	)
-	require.NoError(t, batch.Append(col1Data, col2Data))
+	require.NoError(t, batch.Append(col1Data, col2Data, col3Data))
 	require.Equal(t, 1, batch.Rows())
 	require.NoError(t, batch.Send())
 	var (
 		col1 string
 		col2 string
+		col3 string
 	)
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_fixed_string_empty").Scan(&col1, &col2))
-	assert.Equal(t, string([]byte{0x00, 0x00}), col1)
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_fixed_string_empty").Scan(&col1, &col2, &col3))
+	emptyVal := string([]byte{0, 0})
+	assert.Equal(t, emptyVal, col1)
 	assert.Equal(t, col2Data, col2)
+	assert.Equal(t, emptyVal, col3)
+}
+
+func TestOverflowFixedString(t *testing.T) {
+	conn, err := GetNativeConnection(nil, nil, nil)
+	ctx := context.Background()
+	require.NoError(t, err)
+
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO function null('x FixedString(16)')")
+	require.NoError(t, err)
+
+	input := "this is NOT the correct length."
+
+	err = batch.Append(input)
+	require.ErrorContains(t, err, "input value with length")
+	require.ErrorContains(t, err, "exceeds FixedString(16) capacity")
+}
+
+func TestPaddedFixedString(t *testing.T) {
+	conn, err := GetNativeConnection(nil, nil, nil)
+	ctx := context.Background()
+	require.NoError(t, err)
+
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO function null('x FixedString(16)')")
+	require.NoError(t, err)
+
+	input := "str too short"
+	err = batch.Append(input)
+	require.NoError(t, err)
 }
 
 func TestNullableFixedString(t *testing.T) {
@@ -157,16 +190,16 @@ func TestNullableFixedString(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, err)
 	const ddl = `
-		CREATE TABLE test_fixed_string (
+		CREATE TABLE test_nullable_fixed_string (
 			  Col1 Nullable(FixedString(10))
 			, Col2 Nullable(FixedString(10))
 		) Engine MergeTree() ORDER BY tuple()
 		`
 	defer func() {
-		conn.Exec(ctx, "DROP TABLE IF EXISTS test_fixed_string")
+		conn.Exec(ctx, "DROP TABLE IF EXISTS test_nullable_fixed_string")
 	}()
 	require.NoError(t, conn.Exec(ctx, ddl))
-	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_fixed_string")
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_nullable_fixed_string")
 	require.NoError(t, err)
 	var (
 		col1Data = "ClickHouse"
@@ -181,11 +214,11 @@ func TestNullableFixedString(t *testing.T) {
 		col1 string
 		col2 BinFixedString
 	)
-	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_fixed_string").Scan(&col1, &col2))
+	require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_nullable_fixed_string").Scan(&col1, &col2))
 	assert.Equal(t, col1Data, col1)
 	assert.Equal(t, col2Data.data, col2.data)
-	require.NoError(t, conn.Exec(ctx, "TRUNCATE TABLE test_fixed_string"))
-	batch, err = conn.PrepareBatch(ctx, "INSERT INTO test_fixed_string")
+	require.NoError(t, conn.Exec(ctx, "TRUNCATE TABLE test_nullable_fixed_string"))
+	batch, err = conn.PrepareBatch(ctx, "INSERT INTO test_nullable_fixed_string")
 	require.NoError(t, err)
 	col1Data = "ClickHouse"
 	require.NoError(t, batch.Append(col1Data, nil))
@@ -196,7 +229,7 @@ func TestNullableFixedString(t *testing.T) {
 			col1 *string
 			col2 *string
 		)
-		require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_fixed_string").Scan(&col1, &col2))
+		require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_nullable_fixed_string").Scan(&col1, &col2))
 		require.Nil(t, col2)
 		assert.Equal(t, col1Data, *col1)
 	}

--- a/tests/fixed_string_test.go
+++ b/tests/fixed_string_test.go
@@ -330,7 +330,7 @@ func BenchmarkFixedString(b *testing.B) {
 	const rowsInBlock = 10_000_000
 
 	for n := 0; n < b.N; n++ {
-		batch, err := conn.PrepareBatch(ctx, "INSERT INTO benchmark_fixed_string VALUES")
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO benchmark_fixed_string")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -368,7 +368,7 @@ func BenchmarkColumnarFixedString(b *testing.B) {
 		col2 []string
 	)
 	for n := 0; n < b.N; n++ {
-		batch, err := conn.PrepareBatch(ctx, "INSERT INTO benchmark_fixed_string VALUES")
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO benchmark_fixed_string")
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/tests/std/fixed_string_test.go
+++ b/tests/std/fixed_string_test.go
@@ -55,22 +55,22 @@ func TestStdFixedString(t *testing.T) {
 			conn, err := GetStdDSNConnection(protocol, useSSL, nil)
 			require.NoError(t, err)
 			const ddl = `
-		CREATE TABLE test_fixed_string (
-				Col1 FixedString(10)
-			, Col2 FixedString(10)
-			, Col3 Nullable(FixedString(10))
-			, Col4 Array(FixedString(10))
-			, Col5 Array(Nullable(FixedString(10)))
-		) Engine MergeTree() ORDER BY tuple()
-		`
+				CREATE TABLE test_std_fixed_string (
+						Col1 FixedString(10)
+					, Col2 FixedString(10)
+					, Col3 Nullable(FixedString(10))
+					, Col4 Array(FixedString(10))
+					, Col5 Array(Nullable(FixedString(10)))
+				) Engine MergeTree() ORDER BY tuple()
+			`
 			defer func() {
-				conn.Exec("DROP TABLE test_fixed_string")
+				conn.Exec("DROP TABLE test_std_fixed_string")
 			}()
 			_, err = conn.Exec(ddl)
 			require.NoError(t, err)
 			scope, err := conn.Begin()
 			require.NoError(t, err)
-			batch, err := scope.Prepare("INSERT INTO test_fixed_string")
+			batch, err := scope.Prepare("INSERT INTO test_std_fixed_string")
 			require.NoError(t, err)
 			var (
 				col1Data = "ClickHouse"
@@ -91,7 +91,7 @@ func TestStdFixedString(t *testing.T) {
 				col4 []string
 				col5 []*string
 			)
-			require.NoError(t, conn.QueryRow("SELECT * FROM test_fixed_string").Scan(&col1, &col2, &col3, &col4, &col5))
+			require.NoError(t, conn.QueryRow("SELECT * FROM test_std_fixed_string").Scan(&col1, &col2, &col3, &col4, &col5))
 			assert.Equal(t, col1Data, col1)
 			assert.Equal(t, col2Data.data, col2.data)
 			assert.Equal(t, col3Data, col3)


### PR DESCRIPTION
## Summary
Fixes https://github.com/ClickHouse/ch-go/issues/1056 by adding a length check in the FixedString implementation for clickhouse-go.

I reorganized some code related to how FixedStrings are appended to the buffer. ch-go was causing a panic if the input was not equal to the column size, so I re-wrote the append block to return an error instead. This change also has some negligible performance improvements since there's fewer allocations being made per append call.

Also added/updated tests

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
