### PR TITLE
Fix clickhouse proxy issue, add support for database as query string DSN

### DIFF
--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -302,6 +302,8 @@ func (o *Options) fromDSN(in string) error {
 			o.Auth.Username = params.Get(v)
 		case "password":
 			o.Auth.Password = params.Get(v)
+		case "database":
+			o.Auth.Database = params.Get(v)
 		case "client_info_product":
 			chunks := strings.Split(params.Get(v), ",")
 

--- a/clickhouse_options_test.go
+++ b/clickhouse_options_test.go
@@ -482,6 +482,21 @@ func TestParseDSN(t *testing.T) {
 			},
 			"",
 		},
+		{
+			"clickhouse proxy with database as query string",
+			"tcp://127.0.0.1/?database=bla",
+			&Options{
+				Protocol: Native,
+				TLS:      nil,
+				Addr:     []string{"127.0.0.1"},
+				Settings: Settings{},
+				Auth: Auth{
+					Database: `bla`,
+				},
+				scheme: "tcp",
+			},
+			"",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,7 @@
 module github.com/ClickHouse/clickhouse-go/v2
 
-go 1.23.0
-
-toolchain go1.24.2
+go 1.22.0
+toolchain go1.24.1
 
 require (
 	github.com/ClickHouse/ch-go v0.65.1

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/ClickHouse/clickhouse-go/v2
 
-go 1.22.0
-toolchain go1.24.1
+go 1.23.0
+
+toolchain go1.24.2
 
 require (
 	github.com/ClickHouse/ch-go v0.65.1


### PR DESCRIPTION
## Summary
some clickhouse proxy use `database=bla` as dsn not the path

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
