### PR TITLE
Fix clickhouse proxy issue: hosts as query string DSN not parsed, also add alt_hosts support for DSN

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ conn.SetConnMaxLifetime(time.Hour)
 
 ## DSN
 
-* hosts  - comma-separated list of single address hosts for load-balancing and failover
+* hosts/alt_hosts  - comma-separated list of single address hosts for load-balancing and failover
 * username/password - auth credentials
 * database - select the current default database
 * dial_timeout -  a duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix such as "300ms", "1s". Valid time units are "ms", "s", "m". (default 30s)

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ conn.SetConnMaxLifetime(time.Hour)
 
 ## DSN
 
-* hosts/alt_hosts - comma-separated list of additional single address hosts for load-balancing and failover; appended after the host(s) given in the URL authority (which may itself be a comma-separated list)
+* hosts/alt_hosts - comma-separated lists of additional single address hosts for load-balancing and failover; `hosts` are prepended before, and `alt_hosts` appended after, the host(s) given in the URL authority (which may itself be a comma-separated list)
 * username/password - auth credentials
 * database - select the current default database
 * dial_timeout -  a duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix such as "300ms", "1s". Valid time units are "ms", "s", "m". (default 30s)

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ conn.SetConnMaxLifetime(time.Hour)
 
 ## DSN
 
-* hosts/alt_hosts  - comma-separated list of single address hosts for load-balancing and failover
+* hosts/alt_hosts - comma-separated list of additional single address hosts for load-balancing and failover; appended after the host(s) given in the URL authority (which may itself be a comma-separated list)
 * username/password - auth credentials
 * database - select the current default database
 * dial_timeout -  a duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix such as "300ms", "1s". Valid time units are "ms", "s", "m". (default 30s)

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -212,7 +212,8 @@ func (o *Options) fromDSN(in string) error {
 	for v := range params {
 		switch v {
 		case "hosts", "alt_hosts":
-			o.Addr = append(o.Addr, strings.Split(params.Get(v), ",")...)
+			// These are appended below in a fixed order so map iteration cannot
+			// change the failover order.
 		case "debug":
 			o.Debug, _ = strconv.ParseBool(params.Get(v))
 		case "compress":
@@ -370,6 +371,13 @@ func (o *Options) fromDSN(in string) error {
 				} else {
 					o.Settings[v] = p
 				}
+			}
+		}
+	}
+	for _, key := range []string{"hosts", "alt_hosts"} {
+		for _, host := range strings.Split(params.Get(key), ",") {
+			if host = strings.TrimSpace(host); host != "" {
+				o.Addr = append(o.Addr, host)
 			}
 		}
 	}

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -211,9 +211,10 @@ func (o *Options) fromDSN(in string) error {
 
 	for v := range params {
 		switch v {
-		case "hosts", "alt_hosts":
-			// These are appended below in a fixed order so map iteration cannot
-			// change the failover order.
+		case "hosts":
+			o.Addr = append(parseHostList(params.Get(v)), o.Addr...)
+		case "alt_hosts":
+			o.Addr = append(o.Addr, parseHostList(params.Get(v))...)
 		case "debug":
 			o.Debug, _ = strconv.ParseBool(params.Get(v))
 		case "compress":
@@ -374,13 +375,6 @@ func (o *Options) fromDSN(in string) error {
 			}
 		}
 	}
-	for _, key := range []string{"hosts", "alt_hosts"} {
-		for _, host := range strings.Split(params.Get(key), ",") {
-			if host = strings.TrimSpace(host); host != "" {
-				o.Addr = append(o.Addr, host)
-			}
-		}
-	}
 	if tlsServerName != "" && !secure {
 		return fmt.Errorf("clickhouse [dsn parse]: tls_server_name requires secure=true")
 	}
@@ -406,6 +400,16 @@ func (o *Options) fromDSN(in string) error {
 		o.Protocol = Native
 	}
 	return nil
+}
+
+func parseHostList(value string) []string {
+	var hosts []string
+	for _, host := range strings.Split(value, ",") {
+		if host = strings.TrimSpace(host); host != "" {
+			hosts = append(hosts, host)
+		}
+	}
+	return hosts
 }
 
 // receive copy of Options, so we don't modify original - so its reusable

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -211,6 +211,8 @@ func (o *Options) fromDSN(in string) error {
 
 	for v := range params {
 		switch v {
+		case "hosts", "alt_hosts":
+			o.Addr = append(o.Addr, strings.Split(params.Get(v), ",")...)
 		case "debug":
 			o.Debug, _ = strconv.ParseBool(params.Get(v))
 		case "compress":

--- a/clickhouse_options_test.go
+++ b/clickhouse_options_test.go
@@ -536,7 +536,7 @@ func TestParseDSN(t *testing.T) {
 			&Options{
 				Protocol: Native,
 				TLS:      nil,
-				Addr:     []string{"127.0.0.1", "127.0.0.2", "127.0.0.3"},
+				Addr:     []string{"127.0.0.2", "127.0.0.1", "127.0.0.3"},
 				Settings: Settings{},
 				Auth:     Auth{},
 				scheme:   "tcp",
@@ -549,7 +549,7 @@ func TestParseDSN(t *testing.T) {
 			&Options{
 				Protocol: Native,
 				TLS:      nil,
-				Addr:     []string{"127.0.0.1", "a", "b"},
+				Addr:     []string{"a", "b", "127.0.0.1"},
 				Settings: Settings{},
 				Auth:     Auth{},
 				scheme:   "tcp",

--- a/clickhouse_options_test.go
+++ b/clickhouse_options_test.go
@@ -531,6 +531,45 @@ func TestParseDSN(t *testing.T) {
 			"",
 		},
 		{
+			"clickhouse proxy with hosts and alt_hosts as query strings",
+			"tcp://127.0.0.1/?hosts=127.0.0.2&alt_hosts=127.0.0.3",
+			&Options{
+				Protocol: Native,
+				TLS:      nil,
+				Addr:     []string{"127.0.0.1", "127.0.0.2", "127.0.0.3"},
+				Settings: Settings{},
+				Auth:     Auth{},
+				scheme:   "tcp",
+			},
+			"",
+		},
+		{
+			"clickhouse proxy trims and skips empty query string hosts",
+			"tcp://127.0.0.1/?hosts=%20%20a,%20b,,&alt_hosts=%20",
+			&Options{
+				Protocol: Native,
+				TLS:      nil,
+				Addr:     []string{"127.0.0.1", "a", "b"},
+				Settings: Settings{},
+				Auth:     Auth{},
+				scheme:   "tcp",
+			},
+			"",
+		},
+		{
+			"clickhouse proxy ignores empty hosts query string",
+			"tcp://127.0.0.1/?hosts=",
+			&Options{
+				Protocol: Native,
+				TLS:      nil,
+				Addr:     []string{"127.0.0.1"},
+				Settings: Settings{},
+				Auth:     Auth{},
+				scheme:   "tcp",
+			},
+			"",
+		},
+		{
 			"http protocol with custom http_path",
 			"https://127.0.0.1/clickhouse?secure=true&skip_verify=true&http_path=/clickhouse",
 			&Options{


### PR DESCRIPTION
Addresses #2001 

## Summary
some clickhouse proxy dsn use `hosts` (already on readme but not working) and/or `alt_hosts`, currently `hosts` not parsed into `Addr`, this causing settings considered a custom and those 2 key being injected when creating prepared statement, making prepared statements failing.

```
prepare: code: 115, message: Unknown setting alt_hosts
prepare: code: 115, message: Unknown setting hosts
```

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
