### PR TITLE
object_json: split JSON tag to remove any trailing omitempty

### DIFF
--- a/lib/column/object_json.go
+++ b/lib/column/object_json.go
@@ -214,7 +214,8 @@ func getStructFieldName(field reflect.StructField) (string, bool) {
 		return name, true
 	}
 	if tag != "" {
-		return tag, false
+		// Some JSON tags contain omitempty after a comma but we don't want those in our field name.
+		return strings.Split(tag, ",")[0], false
 	}
 	// support ch tag as well as this is used elsewhere
 	tag = field.Tag.Get("ch")


### PR DESCRIPTION
When calling AppendStruct if the struct has a tuple inside it the json will be used.

This is already handled similarly with iterateStruct

https://github.com/ClickHouse/clickhouse-go/blob/b66234469b8bd16ca99e0b3dbf999b1ab0184d0d/lib/column/json_reflect.go#L84

Example:
https://gist.github.com/dschofie/ab5337b4b0d678b3d2cdb90cfc03cb90

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
