### PR TITLE
fix format function to handle pointer of time.Time

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -288,6 +288,11 @@ func format(tz *time.Location, scale TimeUnit, v any) (string, error) {
 		return quote(v), nil
 	case time.Time:
 		return formatTime(tz, scale, v)
+	case *time.Time:
+		if v == nil {
+			return "NULL", nil
+		}
+		return formatTime(tz, scale, *v)
 	case bool:
 		if v {
 			return "1", nil

--- a/bind_test.go
+++ b/bind_test.go
@@ -254,7 +254,15 @@ func TestFormatTime(t *testing.T) {
 			val, _ = format(tz, Seconds, t1)
 			assert.Equal(t, "toDateTime('2022-01-12 15:00:00', 'UTC')", val)
 		}
+
+		// test with pointer to time.Time
+		val, _ = format(t1.Location(), Seconds, &t1)
+		assert.Equal(t, "toDateTime('2022-01-12 15:00:00')", val)
 	}
+
+	// test with nil pointer to time.Time
+	val, _ := format(time.UTC, Seconds, (*time.Time)(nil))
+	assert.Equal(t, "NULL", val)
 }
 
 func TestFormatScaledTime(t *testing.T) {


### PR DESCRIPTION
## Summary

Since the `time.Time` implements `fmt.Stringer` interface, `*time.Time` was formatted with `fmt.Stringer`. To format it with `formatTime`, I added an explicit check for `*time.Time`.

## Checklist

- [x] Unit and integration tests covering the common scenarios were added
