### PR TITLE
fix: Prevent panic on slice map keys

### DIFF
--- a/lib/column/map.go
+++ b/lib/column/map.go
@@ -83,11 +83,14 @@ func (col *Map) parse(t Type, tz *time.Location) (_ Interface, err error) {
 		if col.values, err = Type(strings.TrimSpace(types[1])).Column(col.name, tz); err != nil {
 			return nil, err
 		}
-		col.scanType = reflect.MapOf(
-			col.keys.ScanType(),
-			col.values.ScanType(),
-		)
-		return col, nil
+
+		if col.keys.ScanType().Comparable() {
+			col.scanType = reflect.MapOf(
+				col.keys.ScanType(),
+				col.values.ScanType(),
+			)
+			return col, nil
+		}
 	}
 	return nil, &UnsupportedColumnTypeError{
 		t: t,

--- a/tests/issues/1565_test.go
+++ b/tests/issues/1565_test.go
@@ -1,0 +1,19 @@
+package issues
+
+import (
+	"context"
+	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestIssue1565(t *testing.T) {
+	ctx := context.Background()
+
+	conn, err := tests.GetConnection("issues", nil, nil, nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	row := conn.QueryRow(ctx, "SELECT map(['success', 'failure'], [10, 5]) as value")
+	require.ErrorContains(t, row.Err(), "clickhouse: unsupported column type")
+}


### PR DESCRIPTION
## Summary
Fixes https://github.com/ClickHouse/clickhouse-go/issues/1565

Go's type system doesn't allow slices as map keys so representing `Map(Array, T)` is not possible as a native map.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
