### PR TITLE
Fix false positives in TestInterfaceArray (#1569)

### DIFF
--- a/tests/array_test.go
+++ b/tests/array_test.go
@@ -143,11 +143,10 @@ func TestInterfaceArray(t *testing.T) {
 	rows, err := conn.Query(ctx, "SELECT * FROM test_array")
 	require.NoError(t, err)
 	for rows.Next() {
-		var (
-			col1 any
-		)
+		var col1 []string
 		require.NoError(t, rows.Scan(&col1))
-		assert.ObjectsAreEqual(col1Data, col1)
+		require.Equal(t, col1Data, col1)
+
 	}
 	require.NoError(t, rows.Close())
 	require.NoError(t, rows.Err())


### PR DESCRIPTION
Fixes #1569


## Summary

Replaced the use of any and assert.ObjectsAreEqual in TestInterfaceArray with a direct scan into []string and a proper require.Equal assertion.
* The original code used any for the scanned value, which required additional type handling and relied on assert.ObjectsAreEqual, a helper that only returns a boolean and does not fail the test on mismatch.
* This meant that the test would silently pass even if the result was incorrect.
* The updated code scans directly into []string, which is supported by the ClickHouse Go driver, and uses require.Equal, ensuring test correctness with proper failure output.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
