### PR TITLE
fix: avoid placeholder detection in  SQL comments

### DIFF
--- a/tests/issues/1537_test.go
+++ b/tests/issues/1537_test.go
@@ -1,0 +1,26 @@
+package issues
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue1537_MixedPlaceholdersAndComment(t *testing.T) {
+	ctx := context.Background()
+
+	conn, err := tests.GetConnection("issues", nil, nil, nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// PostgreSQL-style placeholder in query; `?` is in comment and should be ignored
+	row := conn.QueryRow(ctx, "SELECT $1 -- some comment with ?", "clickhouse")
+
+	var s string
+	err = row.Scan(&s)
+	require.NoError(t, err)
+	require.Equal(t, "clickhouse", s)
+}
+


### PR DESCRIPTION
## Summary

This pull request fixes issue #1537, where parameter placeholders such as `?` were incorrectly detected inside `--` single-line SQL comments. This led to false-positive errors like:

    clickhouse [bind]: mixed named, numeric or positional parameters

when using `$1` placeholders together with comments.

### What this patch does

- Adds a `stripLineComments` helper in `bind.go` that removes `--` comments before applying placeholder-detection regexes.
- Ensures that `?` or `$1` inside comments are not interpreted as actual parameter placeholders.
- Adds a regression test under `tests/issues/1537_test.go` to verify the fix and prevent future regressions.

### Limitations

This patch only addresses `--` style comments. It does not currently handle:
- `/* ... */` block comments
- `'string literals'` containing `?` or `$1`

These could be addressed in future improvements if needed.

---

Fixes #1537


## Checklist
- [x] Unit and integration tests covering the common scenarios were added
