### PR TITLE
fix: namedValue namedDatevalue usage error

### DIFF
--- a/tests/std/query_parameters_test.go
+++ b/tests/std/query_parameters_test.go
@@ -19,6 +19,7 @@ package std
 
 import (
 	"fmt"
+	"time"
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
@@ -89,7 +90,24 @@ func TestQueryParameters(t *testing.T) {
 					1234,
 					"String",
 				)
-				require.ErrorIs(t, row.Err(), clickhouse.ErrExpectedStringValueInNamedValueForQueryParameter)
+				require.ErrorIs(t, row.Err(), clickhouse.ErrUnsupportedQueryParameter)
+			})
+
+			t.Run("invalid NamedDateValue", func(t *testing.T) {
+				row := conn.QueryRow(
+					"SELECT {ts:DateTime}",
+					clickhouse.DateNamed("ts", time.Time{}, clickhouse.Seconds), // zero time
+				)
+				require.ErrorIs(t, row.Err(), clickhouse.ErrInvalidValueInNamedDateValue)
+			})
+
+			t.Run("valid named args", func(t *testing.T) {
+				row := conn.QueryRow(
+					"SELECT {str:String}, {ts:DateTime}",
+					clickhouse.Named("str", "hi"),
+					clickhouse.DateNamed("ts", time.Now(), clickhouse.Seconds),
+				)
+				require.NoError(t, row.Err())
 			})
 
 			t.Run("with bind backwards compatibility", func(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes  #1555 query parameter binding for queries using named date values such as clickhouse.DateNamed(...).

Previously, if the query contained Named parameters (e.g., {table:Identifier}) and also used DateNamed, the driver returned ErrExpectedStringValueInNamedValueForQueryParameter.

This update extends bindQueryOrAppendParameters to support driver.NamedDateValue types and formats them using formatTimeWithScale, ensuring proper formatting and compatibility with the query parameter protocol.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG

