### PR TITLE
Fix Native API HTTP bugs

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -64,12 +64,12 @@ func dial(ctx context.Context, addr string, num int, opt *Options) (*connect, er
 		if opt.Debugf != nil {
 			debugf = func(format string, v ...any) {
 				opt.Debugf(
-					"[clickhouse][conn=%d][%s] "+format,
-					append([]interface{}{num, conn.RemoteAddr()}, v...)...,
+					"[clickhouse][%s][id=%d] "+format,
+					append([]interface{}{conn.RemoteAddr(), num}, v...)...,
 				)
 			}
 		} else {
-			debugf = log.New(os.Stdout, fmt.Sprintf("[clickhouse][conn=%d][%s]", num, conn.RemoteAddr()), 0).Printf
+			debugf = log.New(os.Stdout, fmt.Sprintf("[clickhouse][%s][id=%d]", conn.RemoteAddr(), num), 0).Printf
 		}
 	}
 

--- a/conn_http.go
+++ b/conn_http.go
@@ -216,6 +216,7 @@ func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpCon
 	}
 
 	query.Set("default_format", "Native")
+	query.Set("client_protocol_version", strconv.Itoa(ClientTCPProtocolVersion))
 	u.RawQuery = query.Encode()
 
 	httpProxy := http.ProxyFromEnvironment
@@ -241,13 +242,17 @@ func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpCon
 		}
 	}
 
-	// Temporary conn for determining timezone + version
-	conn := &httpConnect{
-		opt: opt,
+	conn := httpConnect{
+		id:          num,
+		connectedAt: time.Now(),
+		released:    false,
+		debugfFunc:  debugf,
+		opt:         opt,
 		client: &http.Client{
 			Transport: t,
 		},
 		url:             u,
+		revision:        ClientTCPProtocolVersion,
 		buffer:          new(chproto.Buffer),
 		compression:     opt.Compression.Method,
 		blockCompressor: compress.NewWriter(compress.Level(opt.Compression.Level), compress.Method(opt.Compression.Method)),
@@ -259,30 +264,9 @@ func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpCon
 	if err != nil {
 		return nil, fmt.Errorf("failed to query server hello: %w", err)
 	}
-	// Close temp connection, important for freeing session_id if set
-	_ = conn.close()
+	conn.handshake = handshake
 
-	// Set client revision so we can decode updated versions of Native format
-	query.Set("client_protocol_version", strconv.Itoa(int(handshake.Revision)))
-	u.RawQuery = query.Encode()
-
-	return &httpConnect{
-		id:          num,
-		connectedAt: time.Now(),
-		released:    false,
-		debugfFunc:  debugf,
-		opt:         opt,
-		client: &http.Client{
-			Transport: t,
-		},
-		url:             u,
-		buffer:          new(chproto.Buffer),
-		compression:     opt.Compression.Method,
-		blockCompressor: compress.NewWriter(compress.Level(opt.Compression.Level), compress.Method(opt.Compression.Method)),
-		compressionPool: compressionPool,
-		blockBufferSize: opt.BlockBufferSize,
-		handshake:       handshake,
-	}, nil
+	return &conn, nil
 }
 
 type httpConnect struct {
@@ -291,6 +275,7 @@ type httpConnect struct {
 	released        bool
 	debugfFunc      func(format string, v ...any)
 	opt             *Options
+	revision        uint64
 	url             *url.URL
 	client          *http.Client
 	buffer          *chproto.Buffer
@@ -421,7 +406,7 @@ func createCompressionPool(compression *Compression) (Pool[HTTPReaderWriter], er
 func (h *httpConnect) writeData(block *proto.Block) error {
 	// Saving offset of compressible data
 	start := len(h.buffer.Buf)
-	if err := block.Encode(h.buffer, 0); err != nil {
+	if err := block.Encode(h.buffer, h.revision); err != nil {
 		return err
 	}
 	if h.compression == CompressionLZ4 || h.compression == CompressionZSTD {
@@ -446,7 +431,7 @@ func (h *httpConnect) readData(reader *chproto.Reader, timezone *time.Location) 
 		reader.EnableCompression()
 		defer reader.DisableCompression()
 	}
-	if err := block.Decode(reader, h.handshake.Revision); err != nil {
+	if err := block.Decode(reader, h.revision); err != nil {
 		return nil, fmt.Errorf("block decode: %w", err)
 	}
 	return &block, nil
@@ -565,7 +550,7 @@ func (h *httpConnect) createRequestWithExternalTables(ctx context.Context, query
 			return nil, err
 		}
 		buf.Reset()
-		err = table.Block().Encode(buf, 0)
+		err = table.Block().Encode(buf, h.revision)
 		if err != nil {
 			return nil, err
 		}

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -121,9 +121,10 @@ func newBlock(h *httpConnect, release nativeTransportRelease, ctx context.Contex
 }
 
 func (h *httpConnect) prepareBatch(ctx context.Context, release nativeTransportRelease, acquire nativeTransportAcquire, query string, opts driver.PrepareBatchOptions) (driver.Batch, error) {
-	// release is not used for newBlock since the connection is held for the batch.
+	// release is not used within newBlock since the connection is held for the batch.
 	query, block, err := newBlock(h, func(nativeTransport, error) {}, ctx, query)
 	if err != nil {
+		release(h, err)
 		return nil, fmt.Errorf("failed to init block for HTTP batch: %w", err)
 	}
 

--- a/conn_http_query.go
+++ b/conn_http_query.go
@@ -29,7 +29,7 @@ import (
 
 // release is ignored, because http used by std with empty release function
 func (h *httpConnect) query(ctx context.Context, release nativeTransportRelease, query string, args ...any) (*rows, error) {
-	h.debugf("[query] %s", query)
+	h.debugf("[http query] \"%s\"", query)
 	options := queryOptions(ctx)
 	query, err := bindQueryOrAppendParameters(true, &options, query, h.handshake.Timezone, args...)
 	if err != nil {

--- a/tests/issues/stress_http_batch_test.go
+++ b/tests/issues/stress_http_batch_test.go
@@ -1,0 +1,113 @@
+package issues
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/require"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestStressHTTPBatchConcurrency(t *testing.T) {
+	t.Skip("intense test for local debugging")
+
+	env, err := tests.GetTestEnvironment("issues")
+	require.NoError(t, err)
+	useSSL, err := strconv.ParseBool(tests.GetEnv("CLICKHOUSE_USE_SSL", "false"))
+	require.NoError(t, err)
+	port := env.HttpPort
+	var tlsConfig *tls.Config
+	if useSSL {
+		tlsConfig = &tls.Config{}
+		port = env.HttpsPort
+	}
+	conn, err := tests.GetConnectionWithOptions(&clickhouse.Options{
+		Protocol: clickhouse.HTTP,
+		Addr:     []string{fmt.Sprintf("%s:%d", env.Host, port)},
+		Auth: clickhouse.Auth{
+			Database: "default",
+			Username: env.Username,
+			Password: env.Password,
+		},
+		Debug: true,
+		Debugf: func(format string, v ...any) {
+			t.Logf(format, v...)
+		},
+		Compression: &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		},
+		TLS:          tlsConfig,
+		MaxIdleConns: 10,
+		MaxOpenConns: 10, // intense concurrency
+	})
+	defer conn.Close()
+
+	err = conn.Exec(context.Background(), `CREATE TABLE http_batch_issue (x String) ENGINE Memory`)
+	require.NoError(t, err)
+	defer func() {
+		err := conn.Exec(context.Background(), "DROP TABLE http_batch_issue")
+		if err != nil {
+			t.Log("failed drop table", err)
+		}
+	}()
+
+	var totalCount atomic.Int64
+
+	doBatchInsert := func(id, batchID int, conn clickhouse.Conn) error {
+		ctx := context.Background()
+		t.Log(id, "PreparingBatch")
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO http_batch_issue")
+		if err != nil {
+			return fmt.Errorf("prepare: %w", err)
+		}
+		defer func() {
+			err := batch.Close()
+			if err != nil {
+				t.Log("failed batch close", err)
+			}
+		}()
+
+		for i := 0; i < 5_000; i++ {
+			totalCount.Add(1)
+			str := strings.Repeat("longlongstring", 100)
+			err := batch.Append(fmt.Sprintf("%s=%d;", str, i))
+			if err != nil {
+				return fmt.Errorf("append: %w", err)
+			}
+		}
+
+		count := batch.Rows()
+		err = batch.Send()
+		if err != nil {
+			return fmt.Errorf("send: %w", err)
+		}
+
+		t.Logf("[%d] inserted %d for batch %d", id, count, batchID)
+
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				err := doBatchInsert(i, j, conn)
+				if err != nil {
+					t.Fatal("index", i, "failed insert for batch", j, err)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	t.Log("Total rows:", totalCount.Load())
+}


### PR DESCRIPTION
## Summary

With the new Native API, there were some bugs appearing that were previously undetected in the `database/sql` interface.

Changes:
- Fixed unreleased connection in Native API HTTP batches. When `DESC TABLE` failed it would cause the pool to run out of connections.
- Removed empty `proto.Block` from being encoded in HTTP batches. This was causing completely random and inconsistent HTTP 400s to be sent from the server, even though the raw payload was the same. This took an embarassingly long amount of time using the debugger, `printf`, `tcpdump`, Wireshark, and ImHex to debug. I believe this went unnoticed in the `database/sql` implementation because the connections get closed on `tx.Rollback` (which Go code will often call via `defer` after `COMMIT` as a safety). This code was there for 3 years, but it slowly corrupts the HTTP connection.
- Reuse HTTP connection from handshake. Previously this was opening/closing a connection just to pull version info.
- Added + enhanced `debugf` output

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
