### PR TITLE
`JSON` serialization version 3

### DIFF
--- a/examples/clickhouse_api/dynamic.go
+++ b/examples/clickhouse_api/dynamic.go
@@ -27,13 +27,14 @@ func DynamicExample() error {
 	ctx := context.Background()
 
 	conn, err := GetNativeConnection(clickhouse.Settings{
-		"allow_experimental_dynamic_type": true,
+		"allow_experimental_dynamic_type":                                   true,
+		"output_format_native_use_flattened_dynamic_and_json_serialization": true,
 	}, nil, nil)
 	if err != nil {
 		return err
 	}
 
-	if !CheckMinServerVersion(conn, 24, 8, 0) {
+	if !CheckMinServerVersion(conn, 25, 6, 0) {
 		fmt.Print("unsupported clickhouse version for Dynamic type")
 		return nil
 	}

--- a/examples/clickhouse_api/json_fast_structs.go
+++ b/examples/clickhouse_api/json_fast_structs.go
@@ -91,13 +91,14 @@ func JSONFastStructExample() error {
 	ctx := context.Background()
 
 	conn, err := GetNativeConnection(clickhouse.Settings{
-		"allow_experimental_json_type": true,
+		"allow_experimental_json_type":                                      true,
+		"output_format_native_use_flattened_dynamic_and_json_serialization": true,
 	}, nil, nil)
 	if err != nil {
 		return err
 	}
 
-	if !CheckMinServerVersion(conn, 24, 9, 0) {
+	if !CheckMinServerVersion(conn, 25, 6, 0) {
 		fmt.Print("unsupported clickhouse version for JSON type")
 		return nil
 	}

--- a/examples/clickhouse_api/json_paths.go
+++ b/examples/clickhouse_api/json_paths.go
@@ -28,13 +28,14 @@ func JSONPathsExample() error {
 	ctx := context.Background()
 
 	conn, err := GetNativeConnection(clickhouse.Settings{
-		"allow_experimental_json_type": true,
+		"allow_experimental_json_type":                                      true,
+		"output_format_native_use_flattened_dynamic_and_json_serialization": true,
 	}, nil, nil)
 	if err != nil {
 		return err
 	}
 
-	if !CheckMinServerVersion(conn, 24, 9, 0) {
+	if !CheckMinServerVersion(conn, 25, 6, 0) {
 		fmt.Print("unsupported clickhouse version for JSON type")
 		return nil
 	}

--- a/examples/clickhouse_api/json_strings.go
+++ b/examples/clickhouse_api/json_strings.go
@@ -27,14 +27,15 @@ func JSONStringExample() error {
 	ctx := context.Background()
 
 	conn, err := GetNativeConnection(clickhouse.Settings{
-		"allow_experimental_json_type":              true,
-		"output_format_native_write_json_as_string": true,
+		"allow_experimental_json_type":                                      true,
+		"output_format_native_write_json_as_string":                         true,
+		"output_format_native_use_flattened_dynamic_and_json_serialization": true,
 	}, nil, nil)
 	if err != nil {
 		return err
 	}
 
-	if !CheckMinServerVersion(conn, 24, 9, 0) {
+	if !CheckMinServerVersion(conn, 25, 6, 0) {
 		fmt.Print("unsupported clickhouse version for JSON type")
 		return nil
 	}

--- a/examples/clickhouse_api/json_structs.go
+++ b/examples/clickhouse_api/json_structs.go
@@ -61,13 +61,14 @@ func JSONStructExample() error {
 	ctx := context.Background()
 
 	conn, err := GetNativeConnection(clickhouse.Settings{
-		"allow_experimental_json_type": true,
+		"allow_experimental_json_type":                                      true,
+		"output_format_native_use_flattened_dynamic_and_json_serialization": true,
 	}, nil, nil)
 	if err != nil {
 		return err
 	}
 
-	if !CheckMinServerVersion(conn, 24, 9, 0) {
+	if !CheckMinServerVersion(conn, 25, 6, 0) {
 		fmt.Print("unsupported clickhouse version for JSON type")
 		return nil
 	}

--- a/examples/clickhouse_api/main_test.go
+++ b/examples/clickhouse_api/main_test.go
@@ -234,6 +234,5 @@ func TestJSONFastStructExample(t *testing.T) {
 
 func TestJSONStringExample(t *testing.T) {
 	clickhouse_tests.SkipOnCloud(t, "cannot modify JSON settings on cloud")
-	t.Skip("client cannot receive JSON strings")
 	require.NoError(t, JSONStringExample())
 }

--- a/examples/std/json_paths.go
+++ b/examples/std/json_paths.go
@@ -32,12 +32,16 @@ func JSONPathsExample() error {
 		return err
 	}
 
-	if !CheckMinServerVersion(conn, 24, 9, 0) {
+	if !CheckMinServerVersion(conn, 25, 6, 0) {
 		fmt.Print("unsupported clickhouse version for JSON type")
 		return nil
 	}
 
 	_, err = conn.ExecContext(ctx, "SET allow_experimental_json_type = 1")
+	if err != nil {
+		return err
+	}
+	_, err = conn.ExecContext(ctx, "SET output_format_native_use_flattened_dynamic_and_json_serialization = 1")
 	if err != nil {
 		return err
 	}

--- a/examples/std/main_test.go
+++ b/examples/std/main_test.go
@@ -166,6 +166,5 @@ func TestJSONPathsExample(t *testing.T) {
 
 func TestJSONStringExample(t *testing.T) {
 	clickhouse_tests.SkipOnCloud(t, "cannot modify JSON settings on cloud")
-	t.Skip("client cannot receive JSON strings")
 	require.NoError(t, JSONStringExample())
 }

--- a/lib/column/dynamic.go
+++ b/lib/column/dynamic.go
@@ -321,7 +321,7 @@ func (c *Dynamic) decodeHeader(reader *proto.Reader) error {
 	}
 
 	if dynamicSerializationVersion == DeprecatedSupportedDynamicSerializationVersion {
-		return fmt.Errorf("deprecated dynamic serialization version: %d, enable \"output_format_native_use_flattened_dynamic_and_json_serialization\" in your settings.", dynamicSerializationVersion)
+		return fmt.Errorf("deprecated dynamic serialization version: %d, enable \"output_format_native_use_flattened_dynamic_and_json_serialization\" in your settings", dynamicSerializationVersion)
 	} else if dynamicSerializationVersion != SupportedDynamicSerializationVersion {
 		return fmt.Errorf("unsupported dynamic serialization version: %d", dynamicSerializationVersion)
 	}

--- a/tests/dynamic_test.go
+++ b/tests/dynamic_test.go
@@ -36,7 +36,7 @@ func setupDynamicTest(t *testing.T, protocol clickhouse.Protocol) driver.Conn {
 	conn, err := GetNativeConnection(t, protocol, clickhouse.Settings{
 		"max_execution_time":              60,
 		"allow_experimental_dynamic_type": true,
-		"output_format_native_use_flattened_dynamic_and_json_serialization": 1,
+		"output_format_native_use_flattened_dynamic_and_json_serialization": true,
 	}, nil, &clickhouse.Compression{
 		Method: clickhouse.CompressionLZ4,
 	})

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -20,7 +20,6 @@ package tests
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -31,21 +30,18 @@ import (
 func setupJSONTest(t *testing.T, protocol clickhouse.Protocol) driver.Conn {
 	SkipOnCloud(t, "cannot modify JSON settings on cloud")
 
-	if protocol == clickhouse.HTTP {
-		t.Skip("unsupported serialization version 2 on HTTP")
-	}
-
 	conn, err := GetNativeConnection(t, protocol, clickhouse.Settings{
-		"max_execution_time":              60,
-		"allow_experimental_variant_type": true,
-		"allow_experimental_dynamic_type": true,
-		"allow_experimental_json_type":    true,
+		"max_execution_time":                                                60,
+		"allow_experimental_variant_type":                                   true,
+		"allow_experimental_dynamic_type":                                   true,
+		"allow_experimental_json_type":                                      true,
+		"output_format_native_use_flattened_dynamic_and_json_serialization": true,
 	}, nil, &clickhouse.Compression{
 		Method: clickhouse.CompressionLZ4,
 	})
 	require.NoError(t, err)
 
-	if !CheckMinServerServerVersion(conn, 24, 10, 0) {
+	if !CheckMinServerServerVersion(conn, 25, 6, 0) {
 		t.Skip("unsupported clickhouse version for JSON type")
 	}
 
@@ -58,16 +54,16 @@ func TestJSONPaths(t *testing.T) {
 		ctx := context.Background()
 
 		const ddl = `
-			CREATE TABLE IF NOT EXISTS test_json (
+			CREATE TABLE IF NOT EXISTS test_json_paths (
 				  c JSON(Name String, Age Int64, KeysNumbers Map(String, Int64), SKIP fake.field)
 			) Engine = MergeTree() ORDER BY tuple()
 		`
 		require.NoError(t, conn.Exec(ctx, ddl))
 		defer func() {
-			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_json"))
+			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_json_paths"))
 		}()
 
-		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_json (c)")
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_json_paths (c)")
 		require.NoError(t, err)
 
 		jsonRow := BuildTestJSONPaths()
@@ -75,7 +71,7 @@ func TestJSONPaths(t *testing.T) {
 		require.NoError(t, batch.Append(jsonRow))
 		require.NoError(t, batch.Send())
 
-		rows, err := conn.Query(ctx, "SELECT c FROM test_json")
+		rows, err := conn.Query(ctx, "SELECT c FROM test_json_paths")
 		require.NoError(t, err)
 
 		var row clickhouse.JSON
@@ -115,16 +111,16 @@ func TestJSONArray(t *testing.T) {
 		ctx := context.Background()
 
 		const ddl = `
-			CREATE TABLE IF NOT EXISTS test_json (
+			CREATE TABLE IF NOT EXISTS test_json_array (
 				  c Array(JSON)
 			) Engine = MergeTree() ORDER BY tuple()
 		`
 		require.NoError(t, conn.Exec(ctx, ddl))
 		defer func() {
-			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_json"))
+			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_json_array"))
 		}()
 
-		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_json (c)")
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_json_array (c)")
 		require.NoError(t, err)
 
 		arrJsonRow := []*clickhouse.JSON{clickhouse.NewJSON(), BuildTestJSONPaths()}
@@ -132,7 +128,7 @@ func TestJSONArray(t *testing.T) {
 		require.NoError(t, batch.Append(arrJsonRow))
 		require.NoError(t, batch.Send())
 
-		rows, err := conn.Query(ctx, "SELECT c FROM test_json")
+		rows, err := conn.Query(ctx, "SELECT c FROM test_json_array")
 		require.NoError(t, err)
 
 		var arrRow []*clickhouse.JSON
@@ -183,23 +179,23 @@ func TestJSONEmptyArray(t *testing.T) {
 		ctx := context.Background()
 
 		const ddl = `
-			CREATE TABLE IF NOT EXISTS test_json (
+			CREATE TABLE IF NOT EXISTS test_json_empty_array (
 				  c Array(JSON)
 			) Engine = MergeTree() ORDER BY tuple()
 		`
 		require.NoError(t, conn.Exec(ctx, ddl))
 		defer func() {
-			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_json"))
+			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_json_empty_array"))
 		}()
 
-		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_json (c)")
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_json_empty_array (c)")
 		require.NoError(t, err)
 
 		var arrJsonRow []*clickhouse.JSON
 		require.NoError(t, batch.Append(arrJsonRow))
 		require.NoError(t, batch.Send())
 
-		rows, err := conn.Query(ctx, "SELECT c FROM test_json")
+		rows, err := conn.Query(ctx, "SELECT c FROM test_json_empty_array")
 		require.NoError(t, err)
 
 		var arrRow []*clickhouse.JSON
@@ -220,16 +216,16 @@ func TestJSONStruct(t *testing.T) {
 		ctx := context.Background()
 
 		const ddl = `
-			CREATE TABLE IF NOT EXISTS test_json (
+			CREATE TABLE IF NOT EXISTS test_json_struct (
 				  c JSON(Name String, Age Int64, KeysNumbers Map(String, Int64), SKIP fake.field)
 			) Engine = MergeTree() ORDER BY tuple()
 		`
 		require.NoError(t, conn.Exec(ctx, ddl))
 		defer func() {
-			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_json"))
+			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_json_struct"))
 		}()
 
-		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_json (c)")
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_json_struct (c)")
 		require.NoError(t, err)
 
 		inputRow := BuildTestJSONStruct()
@@ -253,7 +249,7 @@ func TestJSONStruct(t *testing.T) {
 
 		require.NoError(t, batch.Send())
 
-		rows, err := conn.Query(ctx, "SELECT c FROM test_json")
+		rows, err := conn.Query(ctx, "SELECT c FROM test_json_struct")
 		require.NoError(t, err)
 
 		var row TestStruct
@@ -288,16 +284,16 @@ func TestJSONFastStruct(t *testing.T) {
 		ctx := context.Background()
 
 		const ddl = `
-			CREATE TABLE IF NOT EXISTS test_json (
+			CREATE TABLE IF NOT EXISTS test_json_fast_struct (
 				  c JSON(Name String, Age Int64, KeysNumbers Map(String, Int64), SKIP fake.field)
 			) Engine = MergeTree() ORDER BY tuple()
 		`
 		require.NoError(t, conn.Exec(ctx, ddl))
 		defer func() {
-			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_json"))
+			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_json_fast_struct"))
 		}()
 
-		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_json (c)")
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_json_fast_struct (c)")
 		require.NoError(t, err)
 
 		inputRow := BuildFastTestJSONStruct()
@@ -305,7 +301,7 @@ func TestJSONFastStruct(t *testing.T) {
 
 		require.NoError(t, batch.Send())
 
-		rows, err := conn.Query(ctx, "SELECT c FROM test_json")
+		rows, err := conn.Query(ctx, "SELECT c FROM test_json_fast_struct")
 		require.NoError(t, err)
 
 		var row TestStruct
@@ -321,25 +317,24 @@ func TestJSONFastStruct(t *testing.T) {
 }
 
 func TestJSONString(t *testing.T) {
-	t.Skip("client cannot receive JSON strings")
-
 	TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
 		conn := setupJSONTest(t, protocol)
 		ctx := context.Background()
 
 		require.NoError(t, conn.Exec(ctx, "SET output_format_native_write_json_as_string=1"))
+		require.NoError(t, conn.Exec(ctx, "SET output_format_json_quote_64bit_integers=0"))
 
 		const ddl = `
-			CREATE TABLE IF NOT EXISTS test_json (
+			CREATE TABLE IF NOT EXISTS test_json_string (
 				  c JSON(Name String, Age Int64, KeysNumbers Map(String, Int64), SKIP fake.field)
 			) Engine = MergeTree() ORDER BY tuple()
 		`
 		require.NoError(t, conn.Exec(ctx, ddl))
 		defer func() {
-			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_json"))
+			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_json_string"))
 		}()
 
-		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_json (c)")
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_json_string (c)")
 		require.NoError(t, err)
 
 		inputRow := BuildTestJSONStruct()
@@ -349,7 +344,7 @@ func TestJSONString(t *testing.T) {
 		require.NoError(t, batch.Append(inputRowStr))
 		require.NoError(t, batch.Send())
 
-		rows, err := conn.Query(ctx, "SELECT c FROM test_json")
+		rows, err := conn.Query(ctx, "SELECT c FROM test_json_string")
 		require.NoError(t, err)
 
 		var row json.RawMessage
@@ -358,11 +353,14 @@ func TestJSONString(t *testing.T) {
 		err = rows.Scan(&row)
 		require.NoError(t, err)
 
-		require.Equal(t, string(inputRowStr), string(row))
-
 		var rowStruct TestStruct
 		err = json.Unmarshal(row, &rowStruct)
 		require.NoError(t, err)
+
+		// Re-Marshal to get properties in the same order
+		rowStructStr, err := json.Marshal(rowStruct)
+		require.NoError(t, err)
+		require.Equal(t, inputRowStr, rowStructStr)
 
 		require.NoError(t, rows.Close())
 		require.NoError(t, rows.Err())
@@ -370,23 +368,22 @@ func TestJSONString(t *testing.T) {
 }
 
 func TestJSON_BatchFlush(t *testing.T) {
-	t.Skip(fmt.Errorf("server-side JSON bug"))
-
 	TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
+		SkipOnHTTP(t, protocol, "Flush")
 		conn := setupJSONTest(t, protocol)
 		ctx := context.Background()
 
 		const ddl = `
-			CREATE TABLE IF NOT EXISTS test_json (
+			CREATE TABLE IF NOT EXISTS test_json_batch_flush (
 				  c JSON
 			) Engine = MergeTree() ORDER BY tuple()
 		`
 		require.NoError(t, conn.Exec(ctx, ddl))
 		defer func() {
-			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_json"))
+			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_json_batch_flush"))
 		}()
 
-		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_json (c)")
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_json_batch_flush (c)")
 		require.NoError(t, err)
 
 		vals := make([]*clickhouse.JSON, 0, 1000)
@@ -406,7 +403,7 @@ func TestJSON_BatchFlush(t *testing.T) {
 		}
 		require.NoError(t, batch.Send())
 
-		rows, err := conn.Query(ctx, "SELECT c FROM test_json")
+		rows, err := conn.Query(ctx, "SELECT c FROM test_json_batch_flush")
 		require.NoError(t, err)
 
 		i := 0

--- a/tests/std/dynamic_test.go
+++ b/tests/std/dynamic_test.go
@@ -51,6 +51,12 @@ func setupDynamicTest(t *testing.T) *sql.DB {
 		return nil
 	}
 
+	_, err = conn.ExecContext(context.Background(), "SET output_format_native_use_flattened_dynamic_and_json_serialization = 1")
+	if err != nil {
+		t.Fatal(err)
+		return nil
+	}
+
 	return conn
 }
 

--- a/tests/std/json_test.go
+++ b/tests/std/json_test.go
@@ -40,12 +40,18 @@ func setupJSONTest(t *testing.T) *sql.DB {
 	})
 	require.NoError(t, err)
 
-	if !CheckMinServerVersion(conn, 24, 9, 0) {
+	if !CheckMinServerVersion(conn, 25, 6, 0) {
 		t.Skip(fmt.Errorf("unsupported clickhouse version for JSON type"))
 		return nil
 	}
 
 	_, err = conn.ExecContext(context.Background(), "SET allow_experimental_json_type = 1")
+	if err != nil {
+		t.Fatal(err)
+		return nil
+	}
+
+	_, err = conn.ExecContext(context.Background(), "SET output_format_native_use_flattened_dynamic_and_json_serialization = 1")
 	if err != nil {
 		t.Fatal(err)
 		return nil
@@ -254,7 +260,7 @@ func TestJSONStruct(t *testing.T) {
 }
 
 func TestJSONString(t *testing.T) {
-	t.Skip("client cannot receive JSON strings")
+	t.Skip("cannot scan JSON strings")
 
 	ctx := context.Background()
 	conn := setupJSONTest(t)


### PR DESCRIPTION
## Summary
Implements `JSON` serialization version 3 from https://github.com/ClickHouse/ClickHouse/pull/80499

The previous version is deprecated and a warning has been added to the code. This requires ClickHouse v25.6 and `output_format_native_use_flattened_dynamic_and_json_serialization` to be enabled.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
