### PR TITLE
add revision to decode/encode + prefix interfaces

### DIFF
--- a/lib/column/bigint.go
+++ b/lib/column/bigint.go
@@ -21,9 +21,10 @@ import (
 	"database/sql/driver"
 	"encoding/binary"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"math/big"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type BigInt struct {
@@ -154,11 +155,11 @@ func (col *BigInt) AppendRow(v any) error {
 	return nil
 }
 
-func (col *BigInt) Decode(reader *proto.Reader, rows int) error {
+func (col *BigInt) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *BigInt) Encode(buffer *proto.Buffer) {
+func (col *BigInt) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 

--- a/lib/column/bool.go
+++ b/lib/column/bool.go
@@ -21,8 +21,9 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type Bool struct {
@@ -175,11 +176,11 @@ func (col *Bool) AppendRow(v any) error {
 	return nil
 }
 
-func (col *Bool) Decode(reader *proto.Reader, rows int) error {
+func (col *Bool) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *Bool) Encode(buffer *proto.Buffer) {
+func (col *Bool) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 

--- a/lib/column/codegen/column.tpl
+++ b/lib/column/codegen/column.tpl
@@ -436,11 +436,11 @@ func (col *{{ .ChType }}) AppendRow(v any) error {
 	return nil
 }
 
-func (col *{{ .ChType }}) Decode(reader *proto.Reader, rows int) error {
+func (col *{{ .ChType }}) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *{{ .ChType }}) Encode(buffer *proto.Buffer) {
+func (col *{{ .ChType }}) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 

--- a/lib/column/column.go
+++ b/lib/column/column.go
@@ -82,13 +82,13 @@ type Interface interface {
 	ScanRow(dest any, row int) error
 	Append(v any) (nulls []uint8, err error)
 	AppendRow(v any) error
-	Decode(reader *proto.Reader, rows int) error
-	Encode(buffer *proto.Buffer)
+	Decode(reader *proto.Reader, revision uint64, rows int) error
+	Encode(buffer *proto.Buffer, revision uint64)
 	ScanType() reflect.Type
 	Reset()
 }
 
 type CustomSerialization interface {
-	ReadStatePrefix(*proto.Reader) error
-	WriteStatePrefix(*proto.Buffer) error
+	ReadStatePrefix(reader *proto.Reader, revision uint64) error
+	WriteStatePrefix(buffer *proto.Buffer, revision uint64) error
 }

--- a/lib/column/column_gen.go
+++ b/lib/column/column_gen.go
@@ -400,11 +400,11 @@ func (col *Float32) AppendRow(v any) error {
 	return nil
 }
 
-func (col *Float32) Decode(reader *proto.Reader, rows int) error {
+func (col *Float32) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *Float32) Encode(buffer *proto.Buffer) {
+func (col *Float32) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 
@@ -570,11 +570,11 @@ func (col *Float64) AppendRow(v any) error {
 	return nil
 }
 
-func (col *Float64) Decode(reader *proto.Reader, rows int) error {
+func (col *Float64) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *Float64) Encode(buffer *proto.Buffer) {
+func (col *Float64) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 
@@ -750,11 +750,11 @@ func (col *Int8) AppendRow(v any) error {
 	return nil
 }
 
-func (col *Int8) Decode(reader *proto.Reader, rows int) error {
+func (col *Int8) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *Int8) Encode(buffer *proto.Buffer) {
+func (col *Int8) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 
@@ -920,11 +920,11 @@ func (col *Int16) AppendRow(v any) error {
 	return nil
 }
 
-func (col *Int16) Decode(reader *proto.Reader, rows int) error {
+func (col *Int16) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *Int16) Encode(buffer *proto.Buffer) {
+func (col *Int16) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 
@@ -1090,11 +1090,11 @@ func (col *Int32) AppendRow(v any) error {
 	return nil
 }
 
-func (col *Int32) Decode(reader *proto.Reader, rows int) error {
+func (col *Int32) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *Int32) Encode(buffer *proto.Buffer) {
+func (col *Int32) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 
@@ -1266,11 +1266,11 @@ func (col *Int64) AppendRow(v any) error {
 	return nil
 }
 
-func (col *Int64) Decode(reader *proto.Reader, rows int) error {
+func (col *Int64) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *Int64) Encode(buffer *proto.Buffer) {
+func (col *Int64) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 
@@ -1420,11 +1420,11 @@ func (col *UInt8) AppendRow(v any) error {
 	return nil
 }
 
-func (col *UInt8) Decode(reader *proto.Reader, rows int) error {
+func (col *UInt8) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *UInt8) Encode(buffer *proto.Buffer) {
+func (col *UInt8) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 
@@ -1561,11 +1561,11 @@ func (col *UInt16) AppendRow(v any) error {
 	return nil
 }
 
-func (col *UInt16) Decode(reader *proto.Reader, rows int) error {
+func (col *UInt16) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *UInt16) Encode(buffer *proto.Buffer) {
+func (col *UInt16) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 
@@ -1702,11 +1702,11 @@ func (col *UInt32) AppendRow(v any) error {
 	return nil
 }
 
-func (col *UInt32) Decode(reader *proto.Reader, rows int) error {
+func (col *UInt32) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *UInt32) Encode(buffer *proto.Buffer) {
+func (col *UInt32) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 
@@ -1843,10 +1843,10 @@ func (col *UInt64) AppendRow(v any) error {
 	return nil
 }
 
-func (col *UInt64) Decode(reader *proto.Reader, rows int) error {
+func (col *UInt64) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *UInt64) Encode(buffer *proto.Buffer) {
+func (col *UInt64) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }

--- a/lib/column/date.go
+++ b/lib/column/date.go
@@ -259,11 +259,11 @@ func (col *Date) parseDate(value string) (tv time.Time, err error) {
 	return parseDate(value, minDate, maxDate, col.location)
 }
 
-func (col *Date) Decode(reader *proto.Reader, rows int) error {
+func (col *Date) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *Date) Encode(buffer *proto.Buffer) {
+func (col *Date) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 

--- a/lib/column/date32.go
+++ b/lib/column/date32.go
@@ -236,11 +236,11 @@ func (col *Date32) parseDate(value string) (datetime time.Time, err error) {
 	return parseDate(value, minDate32, maxDate32, col.location)
 }
 
-func (col *Date32) Decode(reader *proto.Reader, rows int) error {
+func (col *Date32) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *Date32) Encode(buffer *proto.Buffer) {
+func (col *Date32) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 

--- a/lib/column/datetime.go
+++ b/lib/column/datetime.go
@@ -289,11 +289,11 @@ func (col *DateTime) AppendRow(v any) error {
 	return nil
 }
 
-func (col *DateTime) Decode(reader *proto.Reader, rows int) error {
+func (col *DateTime) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *DateTime) Encode(buffer *proto.Buffer) {
+func (col *DateTime) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 

--- a/lib/column/datetime64.go
+++ b/lib/column/datetime64.go
@@ -287,11 +287,11 @@ func (col *DateTime64) AppendRow(v any) error {
 	return nil
 }
 
-func (col *DateTime64) Decode(reader *proto.Reader, rows int) error {
+func (col *DateTime64) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *DateTime64) Encode(buffer *proto.Buffer) {
+func (col *DateTime64) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 

--- a/lib/column/decimal.go
+++ b/lib/column/decimal.go
@@ -302,11 +302,11 @@ func (col *Decimal) append(v *decimal.Decimal) {
 	}
 }
 
-func (col *Decimal) Decode(reader *proto.Reader, rows int) error {
+func (col *Decimal) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *Decimal) Encode(buffer *proto.Buffer) {
+func (col *Decimal) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 

--- a/lib/column/enum16.go
+++ b/lib/column/enum16.go
@@ -21,8 +21,9 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type Enum16 struct {
@@ -270,11 +271,11 @@ func (col *Enum16) AppendRow(elem any) error {
 	return nil
 }
 
-func (col *Enum16) Decode(reader *proto.Reader, rows int) error {
+func (col *Enum16) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *Enum16) Encode(buffer *proto.Buffer) {
+func (col *Enum16) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 

--- a/lib/column/enum8.go
+++ b/lib/column/enum8.go
@@ -21,8 +21,9 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type Enum8 struct {
@@ -261,11 +262,11 @@ func (col *Enum8) AppendRow(elem any) error {
 	return nil
 }
 
-func (col *Enum8) Decode(reader *proto.Reader, rows int) error {
+func (col *Enum8) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *Enum8) Encode(buffer *proto.Buffer) {
+func (col *Enum8) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 

--- a/lib/column/fixed_string.go
+++ b/lib/column/fixed_string.go
@@ -324,11 +324,11 @@ func (col *FixedString) AppendRow(v any) error {
 	return nil
 }
 
-func (col *FixedString) Decode(reader *proto.Reader, rows int) error {
+func (col *FixedString) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *FixedString) Encode(buffer *proto.Buffer) {
+func (col *FixedString) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 

--- a/lib/column/geo_multi_polygon.go
+++ b/lib/column/geo_multi_polygon.go
@@ -20,8 +20,9 @@ package column
 import (
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 
 	"github.com/paulmach/orb"
 )
@@ -145,12 +146,12 @@ func (col *MultiPolygon) AppendRow(v any) error {
 	}
 }
 
-func (col *MultiPolygon) Decode(reader *proto.Reader, rows int) error {
-	return col.set.Decode(reader, rows)
+func (col *MultiPolygon) Decode(reader *proto.Reader, revision uint64, rows int) error {
+	return col.set.Decode(reader, revision, rows)
 }
 
-func (col *MultiPolygon) Encode(buffer *proto.Buffer) {
-	col.set.Encode(buffer)
+func (col *MultiPolygon) Encode(buffer *proto.Buffer, revision uint64) {
+	col.set.Encode(buffer, revision)
 }
 
 func (col *MultiPolygon) row(i int) orb.MultiPolygon {

--- a/lib/column/geo_point.go
+++ b/lib/column/geo_point.go
@@ -20,8 +20,9 @@ package column
 import (
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 
 	"github.com/paulmach/orb"
 )
@@ -155,11 +156,11 @@ func (col *Point) AppendRow(v any) error {
 	return nil
 }
 
-func (col *Point) Decode(reader *proto.Reader, rows int) error {
+func (col *Point) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *Point) Encode(buffer *proto.Buffer) {
+func (col *Point) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 

--- a/lib/column/geo_polygon.go
+++ b/lib/column/geo_polygon.go
@@ -20,8 +20,9 @@ package column
 import (
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 
 	"github.com/paulmach/orb"
 )
@@ -145,12 +146,12 @@ func (col *Polygon) AppendRow(v any) error {
 	}
 }
 
-func (col *Polygon) Decode(reader *proto.Reader, rows int) error {
-	return col.set.Decode(reader, rows)
+func (col *Polygon) Decode(reader *proto.Reader, revision uint64, rows int) error {
+	return col.set.Decode(reader, revision, rows)
 }
 
-func (col *Polygon) Encode(buffer *proto.Buffer) {
-	col.set.Encode(buffer)
+func (col *Polygon) Encode(buffer *proto.Buffer, revision uint64) {
+	col.set.Encode(buffer, revision)
 }
 
 func (col *Polygon) row(i int) orb.Polygon {

--- a/lib/column/geo_ring.go
+++ b/lib/column/geo_ring.go
@@ -20,8 +20,9 @@ package column
 import (
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 
 	"github.com/paulmach/orb"
 )
@@ -145,12 +146,12 @@ func (col *Ring) AppendRow(v any) error {
 	}
 }
 
-func (col *Ring) Decode(reader *proto.Reader, rows int) error {
-	return col.set.Decode(reader, rows)
+func (col *Ring) Decode(reader *proto.Reader, revision uint64, rows int) error {
+	return col.set.Decode(reader, revision, rows)
 }
 
-func (col *Ring) Encode(buffer *proto.Buffer) {
-	col.set.Encode(buffer)
+func (col *Ring) Encode(buffer *proto.Buffer, revision uint64) {
+	col.set.Encode(buffer, revision)
 }
 
 func (col *Ring) row(i int) orb.Ring {

--- a/lib/column/interval.go
+++ b/lib/column/interval.go
@@ -20,9 +20,10 @@ package column
 import (
 	"errors"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
 	"strings"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type Interval struct {
@@ -90,11 +91,11 @@ func (Interval) AppendRow(any) error {
 	}
 }
 
-func (col *Interval) Decode(reader *proto.Reader, rows int) error {
+func (col *Interval) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (Interval) Encode(buffer *proto.Buffer) {
+func (Interval) Encode(buffer *proto.Buffer, revision uint64) {
 }
 
 func (col *Interval) row(i int) string {

--- a/lib/column/ipv4.go
+++ b/lib/column/ipv4.go
@@ -22,10 +22,11 @@ import (
 	"database/sql/driver"
 	"encoding/binary"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"net"
 	"net/netip"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type IPv4 struct {
@@ -305,11 +306,11 @@ func (col *IPv4) AppendRow(v any) (err error) {
 	return
 }
 
-func (col *IPv4) Decode(reader *proto.Reader, rows int) error {
+func (col *IPv4) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *IPv4) Encode(buffer *proto.Buffer) {
+func (col *IPv4) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 

--- a/lib/column/ipv6.go
+++ b/lib/column/ipv6.go
@@ -21,10 +21,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"net"
 	"net/netip"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type IPv6 struct {
@@ -352,11 +353,11 @@ func (col *IPv6) AppendRow(v any) (err error) {
 	return
 }
 
-func (col *IPv6) Decode(reader *proto.Reader, rows int) error {
+func (col *IPv6) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *IPv6) Encode(buffer *proto.Buffer) {
+func (col *IPv6) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 

--- a/lib/column/map.go
+++ b/lib/column/map.go
@@ -274,48 +274,48 @@ func (col *Map) AppendRow(v any) error {
 
 }
 
-func (col *Map) Decode(reader *proto.Reader, rows int) error {
+func (col *Map) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	if err := col.offsets.col.DecodeColumn(reader, rows); err != nil {
 		return err
 	}
 	if i := col.offsets.Rows(); i != 0 {
 		size := int(col.offsets.col.Row(i - 1))
-		if err := col.keys.Decode(reader, size); err != nil {
+		if err := col.keys.Decode(reader, revision, size); err != nil {
 			return err
 		}
-		return col.values.Decode(reader, size)
+		return col.values.Decode(reader, revision, size)
 	}
 	return nil
 }
 
-func (col *Map) Encode(buffer *proto.Buffer) {
+func (col *Map) Encode(buffer *proto.Buffer, revision uint64) {
 	col.offsets.col.EncodeColumn(buffer)
-	col.keys.Encode(buffer)
-	col.values.Encode(buffer)
+	col.keys.Encode(buffer, revision)
+	col.values.Encode(buffer, revision)
 }
 
-func (col *Map) ReadStatePrefix(reader *proto.Reader) error {
+func (col *Map) ReadStatePrefix(reader *proto.Reader, revision uint64) error {
 	if serialize, ok := col.keys.(CustomSerialization); ok {
-		if err := serialize.ReadStatePrefix(reader); err != nil {
+		if err := serialize.ReadStatePrefix(reader, revision); err != nil {
 			return err
 		}
 	}
 	if serialize, ok := col.values.(CustomSerialization); ok {
-		if err := serialize.ReadStatePrefix(reader); err != nil {
+		if err := serialize.ReadStatePrefix(reader, revision); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (col *Map) WriteStatePrefix(encoder *proto.Buffer) error {
+func (col *Map) WriteStatePrefix(encoder *proto.Buffer, revision uint64) error {
 	if serialize, ok := col.keys.(CustomSerialization); ok {
-		if err := serialize.WriteStatePrefix(encoder); err != nil {
+		if err := serialize.WriteStatePrefix(encoder, revision); err != nil {
 			return err
 		}
 	}
 	if serialize, ok := col.values.(CustomSerialization); ok {
-		if err := serialize.WriteStatePrefix(encoder); err != nil {
+		if err := serialize.WriteStatePrefix(encoder, revision); err != nil {
 			return err
 		}
 	}

--- a/lib/column/nested.go
+++ b/lib/column/nested.go
@@ -88,18 +88,18 @@ func nestedColumns(raw string) (columns []namedCol) {
 	return
 }
 
-func (col *Nested) ReadStatePrefix(reader *proto.Reader) error {
+func (col *Nested) ReadStatePrefix(reader *proto.Reader, revision uint64) error {
 	if serialize, ok := col.Interface.(CustomSerialization); ok {
-		if err := serialize.ReadStatePrefix(reader); err != nil {
+		if err := serialize.ReadStatePrefix(reader, revision); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (col *Nested) WriteStatePrefix(buffer *proto.Buffer) error {
+func (col *Nested) WriteStatePrefix(buffer *proto.Buffer, revision uint64) error {
 	if serialize, ok := col.Interface.(CustomSerialization); ok {
-		if err := serialize.WriteStatePrefix(buffer); err != nil {
+		if err := serialize.WriteStatePrefix(buffer, revision); err != nil {
 			return err
 		}
 	}

--- a/lib/column/nothing.go
+++ b/lib/column/nothing.go
@@ -19,8 +19,9 @@ package column
 
 import (
 	"errors"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type Nothing struct {
@@ -56,11 +57,11 @@ func (col Nothing) AppendRow(any) error {
 	}
 }
 
-func (col Nothing) Decode(reader *proto.Reader, rows int) error {
+func (col Nothing) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (Nothing) Encode(buffer *proto.Buffer) {
+func (Nothing) Encode(buffer *proto.Buffer, revision uint64) {
 }
 
 var _ Interface = (*Nothing)(nil)

--- a/lib/column/nullable.go
+++ b/lib/column/nullable.go
@@ -20,9 +20,10 @@ package column
 import (
 	"database/sql"
 	"database/sql/driver"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
 	"time"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type Nullable struct {
@@ -164,23 +165,23 @@ func (col *Nullable) AppendRow(v any) error {
 	return col.base.AppendRow(v)
 }
 
-func (col *Nullable) Decode(reader *proto.Reader, rows int) error {
+func (col *Nullable) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	if col.enable {
 		if err := col.nulls.DecodeColumn(reader, rows); err != nil {
 			return err
 		}
 	}
-	if err := col.base.Decode(reader, rows); err != nil {
+	if err := col.base.Decode(reader, revision, rows); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (col *Nullable) Encode(buffer *proto.Buffer) {
+func (col *Nullable) Encode(buffer *proto.Buffer, revision uint64) {
 	if col.enable {
 		col.nulls.EncodeColumn(buffer)
 	}
-	col.base.Encode(buffer)
+	col.base.Encode(buffer, revision)
 }
 
 var _ Interface = (*Nullable)(nil)

--- a/lib/column/object_json.go
+++ b/lib/column/object_json.go
@@ -925,25 +925,25 @@ func (jCol *JSONObject) AppendRow(v any) error {
 	return nil
 }
 
-func (jCol *JSONObject) Decode(reader *proto.Reader, rows int) error {
+func (jCol *JSONObject) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	panic("Not implemented")
 }
 
-func (jCol *JSONObject) Encode(buffer *proto.Buffer) {
+func (jCol *JSONObject) Encode(buffer *proto.Buffer, revision uint64) {
 	if jCol.root && jCol.encoding == 0 {
 		buffer.PutString(string(jCol.FullType()))
 	}
 	for _, c := range jCol.columns {
-		c.Encode(buffer)
+		c.Encode(buffer, revision)
 	}
 }
 
-func (jCol *JSONObject) ReadStatePrefix(reader *proto.Reader) error {
+func (jCol *JSONObject) ReadStatePrefix(reader *proto.Reader, revision uint64) error {
 	_, err := reader.UInt8()
 	return err
 }
 
-func (jCol *JSONObject) WriteStatePrefix(buffer *proto.Buffer) error {
+func (jCol *JSONObject) WriteStatePrefix(buffer *proto.Buffer, revision uint64) error {
 	buffer.PutUInt8(jCol.encoding)
 	return nil
 }

--- a/lib/column/simple_aggregate_function.go
+++ b/lib/column/simple_aggregate_function.go
@@ -18,10 +18,11 @@
 package column
 
 import (
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type SimpleAggregateFunction struct {
@@ -70,11 +71,11 @@ func (col *SimpleAggregateFunction) Append(v any) ([]uint8, error) {
 func (col *SimpleAggregateFunction) AppendRow(v any) error {
 	return col.base.AppendRow(v)
 }
-func (col *SimpleAggregateFunction) Decode(reader *proto.Reader, rows int) error {
-	return col.base.Decode(reader, rows)
+func (col *SimpleAggregateFunction) Decode(reader *proto.Reader, revision uint64, rows int) error {
+	return col.base.Decode(reader, revision, rows)
 }
-func (col *SimpleAggregateFunction) Encode(buffer *proto.Buffer) {
-	col.base.Encode(buffer)
+func (col *SimpleAggregateFunction) Encode(buffer *proto.Buffer, revision uint64) {
+	col.base.Encode(buffer, revision)
 }
 
 var _ Interface = (*SimpleAggregateFunction)(nil)

--- a/lib/column/string.go
+++ b/lib/column/string.go
@@ -23,8 +23,9 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/binary"
 )
@@ -219,11 +220,11 @@ func (col *String) Append(v any) (nulls []uint8, err error) {
 	return
 }
 
-func (col *String) Decode(reader *proto.Reader, rows int) error {
+func (col *String) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *String) Encode(buffer *proto.Buffer) {
+func (col *String) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 

--- a/lib/column/tuple.go
+++ b/lib/column/tuple.go
@@ -641,25 +641,25 @@ func (col *Tuple) AppendRow(v any) error {
 	}
 }
 
-func (col *Tuple) Decode(reader *proto.Reader, rows int) error {
+func (col *Tuple) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	for _, c := range col.columns {
-		if err := c.Decode(reader, rows); err != nil {
+		if err := c.Decode(reader, revision, rows); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (col *Tuple) Encode(buffer *proto.Buffer) {
+func (col *Tuple) Encode(buffer *proto.Buffer, revision uint64) {
 	for _, c := range col.columns {
-		c.Encode(buffer)
+		c.Encode(buffer, revision)
 	}
 }
 
-func (col *Tuple) ReadStatePrefix(reader *proto.Reader) error {
+func (col *Tuple) ReadStatePrefix(reader *proto.Reader, revision uint64) error {
 	for _, c := range col.columns {
 		if serialize, ok := c.(CustomSerialization); ok {
-			if err := serialize.ReadStatePrefix(reader); err != nil {
+			if err := serialize.ReadStatePrefix(reader, revision); err != nil {
 				return err
 			}
 		}
@@ -667,10 +667,10 @@ func (col *Tuple) ReadStatePrefix(reader *proto.Reader) error {
 	return nil
 }
 
-func (col *Tuple) WriteStatePrefix(buffer *proto.Buffer) error {
+func (col *Tuple) WriteStatePrefix(buffer *proto.Buffer, revision uint64) error {
 	for _, c := range col.columns {
 		if serialize, ok := c.(CustomSerialization); ok {
-			if err := serialize.WriteStatePrefix(buffer); err != nil {
+			if err := serialize.WriteStatePrefix(buffer, revision); err != nil {
 				return err
 			}
 		}

--- a/lib/column/uuid.go
+++ b/lib/column/uuid.go
@@ -21,8 +21,9 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 
 	"github.com/google/uuid"
 )
@@ -208,11 +209,11 @@ func (col *UUID) AppendRow(v any) error {
 	return nil
 }
 
-func (col *UUID) Decode(reader *proto.Reader, rows int) error {
+func (col *UUID) Decode(reader *proto.Reader, revision uint64, rows int) error {
 	return col.col.DecodeColumn(reader, rows)
 }
 
-func (col *UUID) Encode(buffer *proto.Buffer) {
+func (col *UUID) Encode(buffer *proto.Buffer, revision uint64) {
 	col.col.EncodeColumn(buffer)
 }
 


### PR DESCRIPTION
## Summary
In order to prevent breaking changes from #1590, we need a way to decode based on server revision.

This PR changes the interface for `Column` and `CustomSerialization` to accept a `revision` number. This will allow us to change our decoding logic based on server revision.

