### PR TITLE
add HTTP wait condition for container tests

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -167,6 +167,7 @@ func CreateClickHouseTestEnvironment(testSet string) (ClickHouseTestEnvironment,
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort("9000/tcp"),
 			wait.ForListeningPort("8123/tcp"),
+			wait.ForHTTP("/").WithPort("8123/tcp"),
 		).WithDeadline(time.Second * 120),
 		Mounts: []testcontainers.ContainerMount{
 			testcontainers.BindMount(path.Join(basePath, "./resources/custom.xml"), "/etc/clickhouse-server/config.d/custom.xml"),


### PR DESCRIPTION
## Summary
Adds an HTTP check to verify the container is ready for connections. This should help the CI run consistently.

Closes #1586
