### PR TITLE
Backwards compatible `Dynamic` and `JSON`

### DIFF
--- a/clickhouse_rows_test.go
+++ b/clickhouse_rows_test.go
@@ -1,6 +1,7 @@
 package clickhouse
 
 import (
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"github.com/stretchr/testify/assert"
 	"strconv"
@@ -10,9 +11,9 @@ import (
 func TestReadWithEmptyBlock(t *testing.T) {
 	blockInitFunc := func() *proto.Block {
 		retVal := &proto.Block{
-			Packet:   0,
-			Columns:  nil,
-			Timezone: nil,
+			Packet:        0,
+			Columns:       nil,
+			ServerContext: &column.ServerContext{},
 		}
 		retVal.AddColumn("col1", ("Int64"))
 		retVal.AddColumn("col2", ("String"))

--- a/conn_batch.go
+++ b/conn_batch.go
@@ -321,7 +321,7 @@ func (b *batch) Columns() []column.Interface {
 }
 
 func (b *batch) closeQuery() error {
-	if err := b.conn.sendData(&proto.Block{}, ""); err != nil {
+	if err := b.conn.sendData(proto.NewBlock(), ""); err != nil {
 		return err
 	}
 

--- a/conn_http.go
+++ b/conn_http.go
@@ -429,7 +429,9 @@ func (h *httpConnect) readData(reader *chproto.Reader, timezone *time.Location) 
 		location = timezone
 	}
 
-	block := proto.Block{Timezone: location}
+	serverContext := serverVersionToContext(h.handshake)
+	serverContext.Timezone = location
+	block := proto.Block{ServerContext: &serverContext}
 	if h.compression == CompressionLZ4 || h.compression == CompressionZSTD {
 		reader.EnableCompression()
 		defer reader.DisableCompression()

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -107,6 +107,8 @@ func newBlock(h *httpConnect, release nativeTransportRelease, ctx context.Contex
 	}
 
 	var block proto.Block
+	serverContext := serverVersionToContext(h.handshake)
+	block.ServerContext = &serverContext
 	for _, col := range columns {
 		if err := block.AddColumn(col.Name, column.Type(col.Type)); err != nil {
 			return "", nil, err

--- a/conn_http_query.go
+++ b/conn_http_query.go
@@ -55,7 +55,7 @@ func (h *httpConnect) query(ctx context.Context, release nativeTransportRelease,
 
 	if res.ContentLength == 0 {
 		discardAndClose(res.Body)
-		block := &proto.Block{}
+		block := proto.NewBlock()
 		release(h, nil)
 		return &rows{
 			block:     block,
@@ -122,7 +122,7 @@ func (h *httpConnect) query(ctx context.Context, release nativeTransportRelease,
 	}()
 
 	if block == nil {
-		block = &proto.Block{}
+		block = proto.NewBlock()
 	}
 
 	return &rows{

--- a/conn_send_query.go
+++ b/conn_send_query.go
@@ -47,7 +47,7 @@ func (c *connect) sendQuery(body string, o *QueryOptions) error {
 			return err
 		}
 	}
-	if err := c.sendData(&proto.Block{}, ""); err != nil {
+	if err := c.sendData(proto.NewBlock(), ""); err != nil {
 		return err
 	}
 	return c.flush()

--- a/ext/ext.go
+++ b/ext/ext.go
@@ -27,7 +27,7 @@ import (
 func NewTable(name string, columns ...func(t *Table) error) (*Table, error) {
 	table := &Table{
 		name:  name,
-		block: &proto.Block{},
+		block: proto.NewBlock(),
 	}
 	for _, column := range columns {
 		if err := column(table); err != nil {

--- a/lib/column/array.go
+++ b/lib/column/array.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
 	"strings"
-	"time"
 )
 
 var scanTypeAny = reflect.TypeOf((*interface{})(nil)).Elem()
@@ -53,7 +52,7 @@ func (col *Array) Name() string {
 	return col.name
 }
 
-func (col *Array) parse(t Type, tz *time.Location) (_ *Array, err error) {
+func (col *Array) parse(t Type, sc *ServerContext) (_ *Array, err error) {
 	col.chType = t
 	var typeStr = string(t)
 
@@ -69,7 +68,7 @@ parse:
 		}
 	}
 	if col.depth != 0 {
-		if col.values, err = Type(typeStr).Column(col.name, tz); err != nil {
+		if col.values, err = Type(typeStr).Column(col.name, sc); err != nil {
 			return nil, err
 		}
 		offsetScanTypes := make([]reflect.Type, 0, col.depth)

--- a/lib/column/codegen/column.tpl
+++ b/lib/column/codegen/column.tpl
@@ -36,7 +36,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 )
 
-func (t Type) Column(name string, tz *time.Location) (Interface, error) {
+func (t Type) Column(name string, sc *ServerContext) (Interface, error) {
 	switch t {
 {{- range . }}
 	case "{{ .ChType }}":
@@ -81,15 +81,15 @@ func (t Type) Column(name string, tz *time.Location) (Interface, error) {
 	case "Bool", "Boolean":
 		return &Bool{name: name}, nil
 	case "Date":
-		return &Date{name: name, location: tz}, nil
+		return &Date{name: name, location: sc.Timezone}, nil
 	case "Date32":
-		return &Date32{name: name, location: tz}, nil
+		return &Date32{name: name, location: sc.Timezone}, nil
 	case "UUID":
 		return &UUID{name: name}, nil
 	case "Nothing":
 		return &Nothing{name: name}, nil
 	case "Ring":
-		set, err := (&Array{name: name}).parse("Array(Point)", tz)
+		set, err := (&Array{name: name}).parse("Array(Point)", sc)
         if err != nil {
             return nil, err
         }
@@ -99,7 +99,7 @@ func (t Type) Column(name string, tz *time.Location) (Interface, error) {
             name: name,
         }, nil
 	case "Polygon":
-		set, err := (&Array{name: name}).parse("Array(Ring)", tz)
+		set, err := (&Array{name: name}).parse("Array(Ring)", sc)
         if err != nil {
             return nil, err
         }
@@ -109,7 +109,7 @@ func (t Type) Column(name string, tz *time.Location) (Interface, error) {
             name: name,
         }, nil
 	case "MultiPolygon":
-		set, err := (&Array{name: name}).parse("Array(Polygon)", tz)
+		set, err := (&Array{name: name}).parse("Array(Polygon)", sc)
         if err != nil {
             return nil, err
         }
@@ -123,42 +123,42 @@ func (t Type) Column(name string, tz *time.Location) (Interface, error) {
 	case "String":
 		return &String{name: name, col: colStrProvider(name)}, nil
 	case "Object('json')":
-	    return &JSONObject{name: name, root: true, tz: tz}, nil
+	    return &JSONObject{name: name, root: true, sc: sc}, nil
 	}
 
 	switch strType := string(t); {
 	case strings.HasPrefix(string(t), "Map("):
-		return (&Map{name: name}).parse(t, tz)
+		return (&Map{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "Tuple("):
-		return (&Tuple{name: name}).parse(t, tz)
+		return (&Tuple{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "Variant("):
-		return (&Variant{name: name}).parse(t, tz)
+		return (&Variant{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "Dynamic"):
-		return (&Dynamic{name: name}).parse(t, tz)
+		return (&Dynamic{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "JSON"):
-		return (&JSON{name: name}).parse(t, tz)
+		return (&JSON{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "Decimal("):
 		return (&Decimal{name: name}).parse(t)
 	case strings.HasPrefix(strType, "Nested("):
-		return (&Nested{name: name}).parse(t, tz)
+		return (&Nested{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "Array("):
-		return (&Array{name: name}).parse(t, tz)
+		return (&Array{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "Interval"):
 		return (&Interval{name: name}).parse(t)
 	case strings.HasPrefix(string(t), "Nullable"):
-		return (&Nullable{name: name}).parse(t, tz)
+		return (&Nullable{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "FixedString"):
 		return (&FixedString{name: name}).parse(t)
 	case strings.HasPrefix(string(t), "LowCardinality"):
-		return (&LowCardinality{name: name}).parse(t, tz)
+		return (&LowCardinality{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "SimpleAggregateFunction"):
-		return (&SimpleAggregateFunction{name: name}).parse(t, tz)
+		return (&SimpleAggregateFunction{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "Enum8") || strings.HasPrefix(string(t), "Enum16"):
 		return Enum(t, name)
 	case strings.HasPrefix(string(t), "DateTime64"):
-		return (&DateTime64{name: name}).parse(t, tz)
+		return (&DateTime64{name: name}).parse(t, sc.Timezone)
 	case strings.HasPrefix(strType, "DateTime") && !strings.HasPrefix(strType, "DateTime64"):
-		return (&DateTime{name: name}).parse(t, tz)
+		return (&DateTime{name: name}).parse(t, sc.Timezone)
 	}
 	return nil, &UnsupportedColumnTypeError{
 		t: t,

--- a/lib/column/codegen/column.tpl
+++ b/lib/column/codegen/column.tpl
@@ -122,6 +122,8 @@ func (t Type) Column(name string, sc *ServerContext) (Interface, error) {
 		return &Point{name: name}, nil
 	case "String":
 		return &String{name: name, col: colStrProvider(name)}, nil
+	case "SharedVariant":
+		return &SharedVariant{name: name}, nil
 	case "Object('json')":
 	    return &JSONObject{name: name, root: true, sc: sc}, nil
 	}
@@ -134,9 +136,17 @@ func (t Type) Column(name string, sc *ServerContext) (Interface, error) {
 	case strings.HasPrefix(string(t), "Variant("):
 		return (&Variant{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "Dynamic"):
-		return (&Dynamic{name: name}).parse(t, sc)
+		if sc.VersionMajor >= 25 && sc.VersionMinor >= 6 {
+			return (&Dynamic{name: name}).parse(t, sc)
+		} else {
+			return (&Dynamic_v1{name: name}).parse(t, sc)
+		}
 	case strings.HasPrefix(string(t), "JSON"):
-		return (&JSON{name: name}).parse(t, sc)
+		if sc.VersionMajor >= 25 && sc.VersionMinor >= 6 {
+			return (&JSON{name: name}).parse(t, sc)
+		} else {
+			return (&JSON_v1{name: name}).parse(t, sc)
+		}
 	case strings.HasPrefix(string(t), "Decimal("):
 		return (&Decimal{name: name}).parse(t)
 	case strings.HasPrefix(strType, "Nested("):

--- a/lib/column/column.go
+++ b/lib/column/column.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"time"
 )
 
 // column names which match this must be escaped - see https://clickhouse.com/docs/en/sql-reference/syntax/#identifiers
@@ -91,4 +92,12 @@ type Interface interface {
 type CustomSerialization interface {
 	ReadStatePrefix(*proto.Reader) error
 	WriteStatePrefix(*proto.Buffer) error
+}
+
+type ServerContext struct {
+	Revision     uint64
+	VersionMajor uint64
+	VersionMinor uint64
+	VersionPatch uint64
+	Timezone     *time.Location
 }

--- a/lib/column/column_gen.go
+++ b/lib/column/column_gen.go
@@ -138,6 +138,8 @@ func (t Type) Column(name string, sc *ServerContext) (Interface, error) {
 		return &Point{name: name}, nil
 	case "String":
 		return &String{name: name, col: colStrProvider(name)}, nil
+	case "SharedVariant":
+		return &SharedVariant{name: name}, nil
 	case "Object('json')":
 		return &JSONObject{name: name, root: true, sc: sc}, nil
 	}
@@ -150,9 +152,17 @@ func (t Type) Column(name string, sc *ServerContext) (Interface, error) {
 	case strings.HasPrefix(string(t), "Variant("):
 		return (&Variant{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "Dynamic"):
-		return (&Dynamic{name: name}).parse(t, sc)
+		if sc.VersionMajor >= 25 && sc.VersionMinor >= 6 {
+			return (&Dynamic{name: name}).parse(t, sc)
+		} else {
+			return (&Dynamic_v1{name: name}).parse(t, sc)
+		}
 	case strings.HasPrefix(string(t), "JSON"):
-		return (&JSON{name: name}).parse(t, sc)
+		if sc.VersionMajor >= 25 && sc.VersionMinor >= 6 {
+			return (&JSON{name: name}).parse(t, sc)
+		} else {
+			return (&JSON_v1{name: name}).parse(t, sc)
+		}
 	case strings.HasPrefix(string(t), "Decimal("):
 		return (&Decimal{name: name}).parse(t)
 	case strings.HasPrefix(strType, "Nested("):

--- a/lib/column/column_gen.go
+++ b/lib/column/column_gen.go
@@ -36,7 +36,7 @@ import (
 	"time"
 )
 
-func (t Type) Column(name string, tz *time.Location) (Interface, error) {
+func (t Type) Column(name string, sc *ServerContext) (Interface, error) {
 	switch t {
 	case "Float32":
 		return &Float32{name: name}, nil
@@ -97,15 +97,15 @@ func (t Type) Column(name string, tz *time.Location) (Interface, error) {
 	case "Bool", "Boolean":
 		return &Bool{name: name}, nil
 	case "Date":
-		return &Date{name: name, location: tz}, nil
+		return &Date{name: name, location: sc.Timezone}, nil
 	case "Date32":
-		return &Date32{name: name, location: tz}, nil
+		return &Date32{name: name, location: sc.Timezone}, nil
 	case "UUID":
 		return &UUID{name: name}, nil
 	case "Nothing":
 		return &Nothing{name: name}, nil
 	case "Ring":
-		set, err := (&Array{name: name}).parse("Array(Point)", tz)
+		set, err := (&Array{name: name}).parse("Array(Point)", sc)
 		if err != nil {
 			return nil, err
 		}
@@ -115,7 +115,7 @@ func (t Type) Column(name string, tz *time.Location) (Interface, error) {
 			name: name,
 		}, nil
 	case "Polygon":
-		set, err := (&Array{name: name}).parse("Array(Ring)", tz)
+		set, err := (&Array{name: name}).parse("Array(Ring)", sc)
 		if err != nil {
 			return nil, err
 		}
@@ -125,7 +125,7 @@ func (t Type) Column(name string, tz *time.Location) (Interface, error) {
 			name: name,
 		}, nil
 	case "MultiPolygon":
-		set, err := (&Array{name: name}).parse("Array(Polygon)", tz)
+		set, err := (&Array{name: name}).parse("Array(Polygon)", sc)
 		if err != nil {
 			return nil, err
 		}
@@ -139,42 +139,42 @@ func (t Type) Column(name string, tz *time.Location) (Interface, error) {
 	case "String":
 		return &String{name: name, col: colStrProvider(name)}, nil
 	case "Object('json')":
-		return &JSONObject{name: name, root: true, tz: tz}, nil
+		return &JSONObject{name: name, root: true, sc: sc}, nil
 	}
 
 	switch strType := string(t); {
 	case strings.HasPrefix(string(t), "Map("):
-		return (&Map{name: name}).parse(t, tz)
+		return (&Map{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "Tuple("):
-		return (&Tuple{name: name}).parse(t, tz)
+		return (&Tuple{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "Variant("):
-		return (&Variant{name: name}).parse(t, tz)
+		return (&Variant{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "Dynamic"):
-		return (&Dynamic{name: name}).parse(t, tz)
+		return (&Dynamic{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "JSON"):
-		return (&JSON{name: name}).parse(t, tz)
+		return (&JSON{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "Decimal("):
 		return (&Decimal{name: name}).parse(t)
 	case strings.HasPrefix(strType, "Nested("):
-		return (&Nested{name: name}).parse(t, tz)
+		return (&Nested{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "Array("):
-		return (&Array{name: name}).parse(t, tz)
+		return (&Array{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "Interval"):
 		return (&Interval{name: name}).parse(t)
 	case strings.HasPrefix(string(t), "Nullable"):
-		return (&Nullable{name: name}).parse(t, tz)
+		return (&Nullable{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "FixedString"):
 		return (&FixedString{name: name}).parse(t)
 	case strings.HasPrefix(string(t), "LowCardinality"):
-		return (&LowCardinality{name: name}).parse(t, tz)
+		return (&LowCardinality{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "SimpleAggregateFunction"):
-		return (&SimpleAggregateFunction{name: name}).parse(t, tz)
+		return (&SimpleAggregateFunction{name: name}).parse(t, sc)
 	case strings.HasPrefix(string(t), "Enum8") || strings.HasPrefix(string(t), "Enum16"):
 		return Enum(t, name)
 	case strings.HasPrefix(string(t), "DateTime64"):
-		return (&DateTime64{name: name}).parse(t, tz)
+		return (&DateTime64{name: name}).parse(t, sc.Timezone)
 	case strings.HasPrefix(strType, "DateTime") && !strings.HasPrefix(strType, "DateTime64"):
-		return (&DateTime{name: name}).parse(t, tz)
+		return (&DateTime{name: name}).parse(t, sc.Timezone)
 	}
 	return nil, &UnsupportedColumnTypeError{
 		t: t,

--- a/lib/column/dynamic.go
+++ b/lib/column/dynamic.go
@@ -28,7 +28,6 @@ import (
 )
 
 const SupportedDynamicSerializationVersion = 3
-const DeprecatedSupportedDynamicSerializationVersion = 1
 const DefaultMaxDynamicTypes = 32
 const DynamicNullDiscriminator = -1 // The Null index changes as data is being built, use -1 as placeholder for writes.
 
@@ -318,9 +317,7 @@ func (c *Dynamic) decodeHeader(reader *proto.Reader) error {
 		return fmt.Errorf("failed to read dynamic serialization version: %w", err)
 	}
 
-	if dynamicSerializationVersion == DeprecatedSupportedDynamicSerializationVersion {
-		return fmt.Errorf("deprecated dynamic serialization version: %d, enable \"output_format_native_use_flattened_dynamic_and_json_serialization\" in your settings", dynamicSerializationVersion)
-	} else if dynamicSerializationVersion != SupportedDynamicSerializationVersion {
+	if dynamicSerializationVersion != SupportedDynamicSerializationVersion {
 		return fmt.Errorf("unsupported dynamic serialization version: %d", dynamicSerializationVersion)
 	}
 

--- a/lib/column/dynamic_v1.go
+++ b/lib/column/dynamic_v1.go
@@ -1,0 +1,413 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package column
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"github.com/ClickHouse/ch-go/proto"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+const DeprecatedDynamicSerializationVersion = 1
+
+// Dynamic_v1 deprecated. Use Dynamic/JSON serialization version 3.
+type Dynamic_v1 struct {
+	chType Type
+	sc     *ServerContext
+
+	name string
+
+	maxTypes       uint8
+	totalTypes     uint8
+	typeNames      []string
+	typeNamesIndex map[string]int
+
+	variant Variant
+}
+
+func (c *Dynamic_v1) parse(t Type, sc *ServerContext) (_ *Dynamic_v1, err error) {
+	c.chType = t
+	c.sc = sc
+	tStr := string(t)
+
+	// SharedVariant is special, and does not count against totalTypes
+	c.typeNamesIndex = make(map[string]int)
+	c.variant.columnTypeIndex = make(map[string]uint8)
+	sv, _ := Type("SharedVariant").Column("", sc)
+	c.addColumn(sv)
+
+	c.maxTypes = DefaultMaxDynamicTypes
+	c.totalTypes = 0 // Reset to 0 after adding SharedVariant
+
+	if tStr == "Dynamic" {
+		return c, nil
+	}
+
+	if !strings.HasPrefix(tStr, "Dynamic(") || !strings.HasSuffix(tStr, ")") {
+		return nil, &UnsupportedColumnTypeError{t: t}
+	}
+
+	typeParamsStr := strings.TrimPrefix(tStr, "Dynamic(")
+	typeParamsStr = strings.TrimSuffix(typeParamsStr, ")")
+
+	if strings.HasPrefix(typeParamsStr, "max_types=") {
+		v := strings.TrimPrefix(typeParamsStr, "max_types=")
+		if maxTypes, err := strconv.Atoi(v); err == nil {
+			c.maxTypes = uint8(maxTypes)
+		}
+	}
+
+	return c, nil
+}
+
+func (c *Dynamic_v1) addColumn(col Interface) {
+	typeName := string(col.Type())
+	c.typeNames = append(c.typeNames, typeName)
+	c.typeNamesIndex[typeName] = len(c.typeNames) - 1
+	c.totalTypes++
+	c.variant.addColumn(col)
+}
+
+func (c *Dynamic_v1) Name() string {
+	return c.name
+}
+
+func (c *Dynamic_v1) Type() Type {
+	return c.chType
+}
+
+func (c *Dynamic_v1) Rows() int {
+	return c.variant.Rows()
+}
+
+func (c *Dynamic_v1) Row(i int, ptr bool) any {
+	typeIndex := c.variant.discriminators[i]
+	offsetIndex := c.variant.offsets[i]
+	var value any
+	var chType string
+	if typeIndex != NullVariantDiscriminator {
+		value = c.variant.columns[typeIndex].Row(offsetIndex, ptr)
+		chType = string(c.variant.columns[typeIndex].Type())
+	}
+
+	dyn := chcol.NewDynamicWithType(value, chType)
+	if ptr {
+		return &dyn
+	}
+
+	return dyn
+}
+
+func (c *Dynamic_v1) ScanRow(dest any, row int) error {
+	typeIndex := c.variant.discriminators[row]
+	offsetIndex := c.variant.offsets[row]
+	var value any
+	var chType string
+	if typeIndex != NullVariantDiscriminator {
+		value = c.variant.columns[typeIndex].Row(offsetIndex, false)
+		chType = string(c.variant.columns[typeIndex].Type())
+	}
+
+	switch v := dest.(type) {
+	case *chcol.Dynamic:
+		dyn := chcol.NewDynamicWithType(value, chType)
+		*v = dyn
+	case **chcol.Dynamic:
+		dyn := chcol.NewDynamicWithType(value, chType)
+		**v = dyn
+	default:
+		if typeIndex == NullVariantDiscriminator {
+			return nil
+		}
+
+		if err := c.variant.columns[typeIndex].ScanRow(dest, offsetIndex); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Dynamic_v1) Append(v any) (nulls []uint8, err error) {
+	switch vv := v.(type) {
+	case []chcol.Dynamic:
+		for i, dyn := range vv {
+			err := c.AppendRow(dyn)
+			if err != nil {
+				return nil, fmt.Errorf("failed to AppendRow at index %d: %w", i, err)
+			}
+		}
+
+		return nil, nil
+	case []*chcol.Dynamic:
+		for i, dyn := range vv {
+			err := c.AppendRow(dyn)
+			if err != nil {
+				return nil, fmt.Errorf("failed to AppendRow at index %d: %w", i, err)
+			}
+		}
+
+		return nil, nil
+	default:
+		if valuer, ok := v.(driver.Valuer); ok {
+			val, err := valuer.Value()
+			if err != nil {
+				return nil, &ColumnConverterError{
+					Op:   "Append",
+					To:   string(c.chType),
+					From: fmt.Sprintf("%T", v),
+					Hint: "could not get driver.Valuer value",
+				}
+			}
+
+			return c.Append(val)
+		}
+
+		return nil, &ColumnConverterError{
+			Op:   "Append",
+			To:   string(c.chType),
+			From: fmt.Sprintf("%T", v),
+		}
+	}
+}
+
+func (c *Dynamic_v1) AppendRow(v any) error {
+	var requestedType string
+	switch vv := v.(type) {
+	case nil:
+		c.variant.appendNullRow()
+		return nil
+	case chcol.Dynamic:
+		requestedType = vv.Type()
+		v = vv.Any()
+		if vv.Nil() {
+			c.variant.appendNullRow()
+			return nil
+		}
+	case *chcol.Dynamic:
+		requestedType = vv.Type()
+		v = vv.Any()
+		if vv.Nil() {
+			c.variant.appendNullRow()
+			return nil
+		}
+	}
+
+	if requestedType != "" {
+		var col Interface
+		colIndex, ok := c.typeNamesIndex[requestedType]
+		if ok {
+			col = c.variant.columns[colIndex]
+		} else {
+			newCol, err := Type(requestedType).Column("", c.sc)
+			if err != nil {
+				return fmt.Errorf("value \"%v\" cannot be stored in dynamic column %s with requested type %s: unable to append type: %w", v, c.chType, requestedType, err)
+			}
+
+			c.addColumn(newCol)
+			colIndex = int(c.totalTypes)
+			col = newCol
+		}
+
+		if err := col.AppendRow(v); err != nil {
+			return fmt.Errorf("value \"%v\" cannot be stored in dynamic column %s with requested type %s: %w", v, c.chType, requestedType, err)
+		}
+
+		c.variant.appendDiscriminatorRow(uint8(colIndex))
+		return nil
+	}
+
+	// If preferred type wasn't provided, try each column
+	for i, col := range c.variant.columns {
+		if c.typeNames[i] == "SharedVariant" {
+			// Do not try to fit into SharedVariant
+			continue
+		}
+
+		if err := col.AppendRow(v); err == nil {
+			c.variant.appendDiscriminatorRow(uint8(i))
+			return nil
+		}
+	}
+
+	// If no existing columns match, try matching a ClickHouse type from common Go types
+	inferredTypeName := inferClickHouseTypeFromGoType(v)
+	if inferredTypeName != "" {
+		return c.AppendRow(chcol.NewDynamicWithType(v, inferredTypeName))
+	}
+
+	return fmt.Errorf("value \"%v\" cannot be stored in dynamic column: no compatible types. hint: use clickhouse.DynamicWithType to wrap the value", v)
+}
+
+func (c *Dynamic_v1) sortColumnsForEncoding() {
+	previousTypeNames := make([]string, 0, len(c.typeNames))
+	previousTypeNames = append(previousTypeNames, c.typeNames...)
+	slices.Sort(c.typeNames)
+
+	for i, typeName := range c.typeNames {
+		c.typeNamesIndex[typeName] = i
+		c.variant.columnTypeIndex[typeName] = uint8(i)
+	}
+
+	sortedDiscriminatorMap := make([]uint8, len(c.variant.columns))
+	sortedColumns := make([]Interface, len(c.variant.columns))
+	for i, typeName := range previousTypeNames {
+		correctIndex := c.typeNamesIndex[typeName]
+
+		sortedDiscriminatorMap[i] = uint8(correctIndex)
+		sortedColumns[correctIndex] = c.variant.columns[i]
+	}
+	c.variant.columns = sortedColumns
+
+	for i := range c.variant.discriminators {
+		if c.variant.discriminators[i] == NullVariantDiscriminator {
+			continue
+		}
+
+		c.variant.discriminators[i] = sortedDiscriminatorMap[c.variant.discriminators[i]]
+	}
+}
+
+func (c *Dynamic_v1) encodeHeader(buffer *proto.Buffer) error {
+	c.sortColumnsForEncoding()
+
+	buffer.PutUInt64(DeprecatedDynamicSerializationVersion)
+	buffer.PutUVarInt(uint64(c.maxTypes))
+	buffer.PutUVarInt(uint64(c.totalTypes))
+
+	for _, typeName := range c.typeNames {
+		if typeName == "SharedVariant" {
+			// SharedVariant is implicitly present in Dynamic, do not append to type names
+			continue
+		}
+
+		buffer.PutString(typeName)
+	}
+
+	return c.variant.encodeHeader(buffer)
+}
+
+func (c *Dynamic_v1) encodeData(buffer *proto.Buffer) {
+	c.variant.encodeData(buffer)
+}
+
+func (c *Dynamic_v1) WriteStatePrefix(buffer *proto.Buffer) error {
+	return c.encodeHeader(buffer)
+}
+
+func (c *Dynamic_v1) Encode(buffer *proto.Buffer) {
+	c.encodeData(buffer)
+}
+
+func (c *Dynamic_v1) ScanType() reflect.Type {
+	return scanTypeDynamic
+}
+
+func (c *Dynamic_v1) Reset() {
+	c.variant.Reset()
+}
+
+func (c *Dynamic_v1) decodeHeader(reader *proto.Reader) error {
+	dynamicSerializationVersion, err := reader.UInt64()
+	if err != nil {
+		return fmt.Errorf("failed to read dynamic serialization version: %w", err)
+	}
+
+	if dynamicSerializationVersion != DeprecatedDynamicSerializationVersion {
+		return fmt.Errorf("unsupported dynamic serialization version: %d", dynamicSerializationVersion)
+	}
+
+	maxTypes, err := reader.UVarInt()
+	if err != nil {
+		return fmt.Errorf("failed to read max types for dynamic column: %w", err)
+	}
+	c.maxTypes = uint8(maxTypes)
+
+	totalTypes, err := reader.UVarInt()
+	if err != nil {
+		return fmt.Errorf("failed to read total types for dynamic column: %w", err)
+	}
+
+	sortedTypeNames := make([]string, 0, totalTypes+1)
+	for i := uint64(0); i < totalTypes; i++ {
+		typeName, err := reader.Str()
+		if err != nil {
+			return fmt.Errorf("failed to read type name at index %d for dynamic column: %w", i, err)
+		}
+
+		sortedTypeNames = append(sortedTypeNames, typeName)
+	}
+
+	sortedTypeNames = append(sortedTypeNames, "SharedVariant")
+	slices.Sort(sortedTypeNames) // Re-sort after adding SharedVariant
+
+	c.typeNames = make([]string, 0, len(sortedTypeNames))
+	c.typeNamesIndex = make(map[string]int, len(sortedTypeNames))
+	c.variant.columns = make([]Interface, 0, len(sortedTypeNames))
+	c.variant.columnTypeIndex = make(map[string]uint8, len(sortedTypeNames))
+
+	for _, typeName := range sortedTypeNames {
+		col, err := Type(typeName).Column("", c.sc)
+		if err != nil {
+			return fmt.Errorf("failed to add dynamic column with type %s: %w", typeName, err)
+		}
+
+		c.addColumn(col)
+	}
+
+	c.totalTypes = uint8(totalTypes) // Reset to server's totalTypes
+
+	err = c.variant.decodeHeader(reader)
+	if err != nil {
+		return fmt.Errorf("failed to decode variant header: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Dynamic_v1) decodeData(reader *proto.Reader, rows int) error {
+	err := c.variant.decodeData(reader, rows)
+	if err != nil {
+		return fmt.Errorf("failed to decode variant data: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Dynamic_v1) ReadStatePrefix(reader *proto.Reader) error {
+	err := c.decodeHeader(reader)
+	if err != nil {
+		return fmt.Errorf("failed to decode dynamic header: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Dynamic_v1) Decode(reader *proto.Reader, rows int) error {
+	err := c.decodeData(reader, rows)
+	if err != nil {
+		return fmt.Errorf("failed to decode dynamic data: %w", err)
+	}
+
+	return nil
+}

--- a/lib/column/json_v1_reflect.go
+++ b/lib/column/json_v1_reflect.go
@@ -1,0 +1,251 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package column
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+)
+
+// Decoding (Scanning)
+
+// scanIntoStruct will iterate the provided struct and scan JSON data into the matching fields
+func (c *JSON_v1) scanIntoStruct(dest any, row int) error {
+	val := reflect.ValueOf(dest)
+	if val.Kind() != reflect.Pointer {
+		return fmt.Errorf("destination must be a pointer")
+	}
+	val = val.Elem()
+
+	if val.Kind() != reflect.Struct {
+		return fmt.Errorf("destination must be a pointer to struct")
+	}
+
+	return c.fillStruct(val, "", row)
+}
+
+// scanIntoMap converts JSON data into a map
+func (c *JSON_v1) scanIntoMap(dest any, row int) error {
+	val := reflect.ValueOf(dest)
+	if val.Kind() != reflect.Pointer {
+		return fmt.Errorf("destination must be a pointer")
+	}
+	val = val.Elem()
+
+	if val.Kind() != reflect.Map {
+		return fmt.Errorf("destination must be a pointer to map")
+	}
+
+	if val.Type().Key().Kind() != reflect.String {
+		return fmt.Errorf("map key must be string")
+	}
+
+	if val.IsNil() {
+		val.Set(reflect.MakeMap(val.Type()))
+	}
+
+	return c.fillMap(val, "", row)
+}
+
+// fillStruct will iterate the provided struct and scan JSON data into the matching fields recursively
+func (c *JSON_v1) fillStruct(val reflect.Value, prefix string, row int) error {
+	typ := val.Type()
+
+	for i := 0; i < val.NumField(); i++ {
+		field := val.Field(i)
+		fieldType := typ.Field(i)
+
+		if !field.CanSet() {
+			continue
+		}
+
+		name := fieldType.Tag.Get("json")
+		if name == "" || name[0] == ',' {
+			name = fieldType.Name
+		} else {
+			name = strings.Split(name, ",")[0]
+		}
+
+		if name == "-" {
+			continue
+		}
+
+		path := name
+		if prefix != "" {
+			path = prefix + "." + name
+		}
+
+		if c.hasTypedPath(path) {
+			err := c.scanTypedPathToValue(path, row, field)
+			if err != nil {
+				return fmt.Errorf("fillStruct failed to scan typed path: %w", err)
+			}
+
+			continue
+		} else if c.hasDynamicPath(path) {
+			err := c.scanDynamicPathToValue(path, row, field)
+			if err != nil {
+				return fmt.Errorf("fillStruct failed to scan dynamic path: %w", err)
+			}
+
+			continue
+		}
+
+		hasNestedFields := c.pathHasNestedValues(path)
+		if !hasNestedFields {
+			continue
+		}
+
+		switch field.Kind() {
+		case reflect.Pointer:
+			if field.Type().Elem().Kind() == reflect.Struct {
+				if field.IsNil() {
+					field.Set(reflect.New(field.Type().Elem()))
+				}
+
+				if err := c.fillStruct(field.Elem(), path, row); err != nil {
+					return fmt.Errorf("error filling nested struct pointer: %w", err)
+				}
+			}
+		case reflect.Struct:
+			if err := c.fillStruct(field, path, row); err != nil {
+				return fmt.Errorf("error filling nested struct: %w", err)
+			}
+		case reflect.Map:
+			if err := c.fillMap(field, path, row); err != nil {
+				return fmt.Errorf("error filling nested map: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// fillMap will iterate the provided map and scan JSON data in recursively
+func (c *JSON_v1) fillMap(val reflect.Value, prefix string, row int) error {
+	if val.IsNil() {
+		val.Set(reflect.MakeMap(val.Type()))
+	}
+
+	var paths []string
+	for _, path := range c.typedPaths {
+		if strings.HasPrefix(path, prefix) {
+			paths = append(paths, path)
+		}
+	}
+	for _, path := range c.dynamicPaths {
+		if strings.HasPrefix(path, prefix) {
+			paths = append(paths, path)
+		}
+	}
+
+	children := make(map[string][]string)
+	prefixLen := len(prefix)
+	if prefixLen > 0 {
+		prefixLen++ // splitter
+	}
+
+	for _, path := range paths {
+		if prefixLen >= len(path) {
+			continue
+		}
+
+		suffix := path[prefixLen:]
+		nextDot := strings.Index(suffix, ".")
+		var current string
+		if nextDot == -1 {
+			current = suffix
+		} else {
+			current = suffix[:nextDot]
+		}
+		children[current] = append(children[current], path)
+	}
+
+	for key, childPaths := range children {
+		noChildNodes := true
+		for _, path := range childPaths {
+			if strings.Contains(path[prefixLen:], ".") {
+				noChildNodes = false
+				break
+			}
+		}
+
+		if noChildNodes {
+			fullPath := prefix
+			if prefix != "" {
+				fullPath += "."
+			}
+			fullPath += key
+
+			mapValueType := val.Type().Elem()
+			newVal := reflect.New(mapValueType).Elem()
+
+			var err error
+			if _, isTyped := c.typedPathsIndex[fullPath]; isTyped {
+				err = c.scanTypedPathToValue(fullPath, row, newVal)
+			} else {
+				if mapValueType.Kind() == reflect.Interface {
+					value := c.valueAtPath(fullPath, row, false)
+					if dyn, ok := value.(chcol.Dynamic); ok {
+						value = dyn.Any()
+					}
+
+					if value != nil {
+						newVal.Set(reflect.ValueOf(value))
+					}
+				} else {
+					err = c.scanDynamicPathToValue(fullPath, row, newVal)
+				}
+			}
+			if err != nil {
+				return fmt.Errorf("failed to scan value at path \"%s\": %w", fullPath, err)
+			}
+
+			val.SetMapIndex(reflect.ValueOf(key), newVal)
+		} else {
+			newPrefix := prefix
+			if newPrefix != "" {
+				newPrefix += "."
+			}
+			newPrefix += key
+
+			mapValueType := val.Type().Elem()
+			var newMap reflect.Value
+
+			if mapValueType.Kind() == reflect.Interface {
+				newMap = reflect.MakeMap(reflect.TypeOf(map[string]interface{}{}))
+			} else if mapValueType.Kind() == reflect.Map {
+				newMap = reflect.MakeMap(mapValueType)
+			} else {
+				return fmt.Errorf("invalid map value type for nested path \"%s\"", newPrefix)
+			}
+
+			err := c.fillMap(newMap, newPrefix, row)
+			if err != nil {
+				return fmt.Errorf("failed filling nested map at path \"%s\": %w", newPrefix, err)
+			}
+
+			val.SetMapIndex(reflect.ValueOf(key), newMap)
+		}
+	}
+
+	return nil
+}

--- a/lib/column/lowcardinality.go
+++ b/lib/column/lowcardinality.go
@@ -84,10 +84,10 @@ func (col *LowCardinality) Name() string {
 	return col.name
 }
 
-func (col *LowCardinality) parse(t Type, tz *time.Location) (_ *LowCardinality, err error) {
+func (col *LowCardinality) parse(t Type, sc *ServerContext) (_ *LowCardinality, err error) {
 	col.chType = t
 	col.append.index = make(map[any]int)
-	if col.index, err = Type(t.params()).Column(col.name, tz); err != nil {
+	if col.index, err = Type(t.params()).Column(col.name, sc); err != nil {
 		return nil, err
 	}
 	if nullable, ok := col.index.(*Nullable); ok {

--- a/lib/column/map.go
+++ b/lib/column/map.go
@@ -21,11 +21,9 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
 	"strings"
-	"time"
-
-	"github.com/ClickHouse/ch-go/proto"
 )
 
 // https://github.com/ClickHouse/ClickHouse/blob/master/src/Columns/ColumnMap.cpp
@@ -65,7 +63,7 @@ func (col *Map) Name() string {
 	return col.name
 }
 
-func (col *Map) parse(t Type, tz *time.Location) (_ Interface, err error) {
+func (col *Map) parse(t Type, sc *ServerContext) (_ Interface, err error) {
 	col.chType = t
 	types := make([]string, 2, 2)
 	typeParams := t.params()
@@ -78,10 +76,10 @@ func (col *Map) parse(t Type, tz *time.Location) (_ Interface, err error) {
 		types[1] = typeParams[idx+1:]
 	}
 	if types[0] != "" && types[1] != "" {
-		if col.keys, err = Type(strings.TrimSpace(types[0])).Column(col.name, tz); err != nil {
+		if col.keys, err = Type(strings.TrimSpace(types[0])).Column(col.name, sc); err != nil {
 			return nil, err
 		}
-		if col.values, err = Type(strings.TrimSpace(types[1])).Column(col.name, tz); err != nil {
+		if col.values, err = Type(strings.TrimSpace(types[1])).Column(col.name, sc); err != nil {
 			return nil, err
 		}
 

--- a/lib/column/nested.go
+++ b/lib/column/nested.go
@@ -19,10 +19,8 @@ package column
 
 import (
 	"fmt"
-	"strings"
-	"time"
-
 	"github.com/ClickHouse/ch-go/proto"
+	"strings"
 )
 
 type Nested struct {
@@ -42,9 +40,9 @@ func asDDL(cols []namedCol) string {
 	return strings.Join(sCols, ", ")
 }
 
-func (col *Nested) parse(t Type, tz *time.Location) (_ Interface, err error) {
+func (col *Nested) parse(t Type, sc *ServerContext) (_ Interface, err error) {
 	columns := fmt.Sprintf("Array(Tuple(%s))", asDDL(nestedColumns(t.params())))
-	if col.Interface, err = (&Array{name: col.name}).parse(Type(columns), tz); err != nil {
+	if col.Interface, err = (&Array{name: col.name}).parse(Type(columns), sc); err != nil {
 		return nil, err
 	}
 	return col, nil

--- a/lib/column/nullable.go
+++ b/lib/column/nullable.go
@@ -42,9 +42,9 @@ func (col *Nullable) Name() string {
 	return col.name
 }
 
-func (col *Nullable) parse(t Type, tz *time.Location) (_ *Nullable, err error) {
+func (col *Nullable) parse(t Type, sc *ServerContext) (_ *Nullable, err error) {
 	col.enable = true
-	if col.base, err = Type(t.params()).Column(col.name, tz); err != nil {
+	if col.base, err = Type(t.params()).Column(col.name, sc); err != nil {
 		return nil, err
 	}
 	switch base := col.base.ScanType(); {

--- a/lib/column/sharedvariant.go
+++ b/lib/column/sharedvariant.go
@@ -1,0 +1,73 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package column
+
+import (
+	"github.com/ClickHouse/ch-go/proto"
+	"reflect"
+)
+
+// SharedVariant deprecated. Use Dynamic/JSON serialization version 3.
+type SharedVariant struct {
+	name       string
+	stringData String
+}
+
+func (c *SharedVariant) Name() string {
+	return c.name
+}
+
+func (c *SharedVariant) Type() Type {
+	return "SharedVariant"
+}
+
+func (c *SharedVariant) Rows() int {
+	return c.stringData.Rows()
+}
+
+func (c *SharedVariant) Row(i int, ptr bool) any {
+	return c.stringData.Row(i, ptr)
+}
+
+func (c *SharedVariant) ScanRow(dest any, row int) error {
+	return c.stringData.ScanRow(dest, row)
+}
+
+func (c *SharedVariant) Append(v any) (nulls []uint8, err error) {
+	return c.stringData.Append(v)
+}
+
+func (c *SharedVariant) AppendRow(v any) error {
+	return c.stringData.AppendRow(v)
+}
+
+func (c *SharedVariant) Decode(reader *proto.Reader, rows int) error {
+	return c.stringData.Decode(reader, rows)
+}
+
+func (c *SharedVariant) Encode(buffer *proto.Buffer) {
+	c.stringData.Encode(buffer)
+}
+
+func (c *SharedVariant) ScanType() reflect.Type {
+	return c.stringData.ScanType()
+}
+
+func (c *SharedVariant) Reset() {
+	c.stringData.Reset()
+}

--- a/lib/column/simple_aggregate_function.go
+++ b/lib/column/simple_aggregate_function.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
 	"strings"
-	"time"
 )
 
 type SimpleAggregateFunction struct {
@@ -38,10 +37,10 @@ func (col *SimpleAggregateFunction) Name() string {
 	return col.name
 }
 
-func (col *SimpleAggregateFunction) parse(t Type, tz *time.Location) (_ Interface, err error) {
+func (col *SimpleAggregateFunction) parse(t Type, sc *ServerContext) (_ Interface, err error) {
 	col.chType = t
 	base := strings.TrimSpace(strings.SplitN(t.params(), ",", 2)[1])
-	if col.base, err = Type(base).Column(col.name, tz); err == nil {
+	if col.base, err = Type(base).Column(col.name, sc); err == nil {
 		return col, nil
 	}
 	return nil, &UnsupportedColumnTypeError{

--- a/lib/column/tuple.go
+++ b/lib/column/tuple.go
@@ -54,7 +54,7 @@ type namedCol struct {
 	colType Type
 }
 
-func (col *Tuple) parse(t Type, tz *time.Location) (_ Interface, err error) {
+func (col *Tuple) parse(t Type, sc *ServerContext) (_ Interface, err error) {
 	col.chType = t
 	var (
 		element       []rune
@@ -99,7 +99,7 @@ func (col *Tuple) parse(t Type, tz *time.Location) (_ Interface, err error) {
 		if ct.name == "" {
 			isNamed = false
 		}
-		column, err := ct.colType.Column(ct.name, tz)
+		column, err := ct.colType.Column(ct.name, sc)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/column/variant.go
+++ b/lib/column/variant.go
@@ -20,12 +20,10 @@ package column
 import (
 	"database/sql/driver"
 	"fmt"
+	"github.com/ClickHouse/ch-go/proto"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 	"reflect"
 	"strings"
-	"time"
-
-	"github.com/ClickHouse/ch-go/proto"
 )
 
 const SupportedVariantSerializationVersion = 0
@@ -42,7 +40,7 @@ type Variant struct {
 	columnTypeIndex map[string]uint8
 }
 
-func (c *Variant) parse(t Type, tz *time.Location) (_ *Variant, err error) {
+func (c *Variant) parse(t Type, sc *ServerContext) (_ *Variant, err error) {
 	c.chType = t
 	var (
 		element       []rune
@@ -82,7 +80,7 @@ func (c *Variant) parse(t Type, tz *time.Location) (_ *Variant, err error) {
 
 	c.columnTypeIndex = make(map[string]uint8, len(elements))
 	for _, columnType := range elements {
-		column, err := columnType.Column("", tz)
+		column, err := columnType.Column("", sc)
 		if err != nil {
 			return nil, err
 		}

--- a/tests/dynamic_test.go
+++ b/tests/dynamic_test.go
@@ -41,7 +41,7 @@ func setupDynamicTest(t *testing.T, protocol clickhouse.Protocol) driver.Conn {
 	})
 	require.NoError(t, err)
 
-	if !CheckMinServerServerVersion(conn, 25, 6, 0) {
+	if !CheckMinServerServerVersion(conn, 24, 8, 0) {
 		t.Skip("unsupported clickhouse version for Dynamic type")
 	}
 
@@ -214,6 +214,10 @@ func TestDynamicMaxTypes(t *testing.T) {
 func TestDynamicExceededTypes(t *testing.T) {
 	conn := setupDynamicTest(t, clickhouse.Native)
 	ctx := context.Background()
+
+	if !CheckMinServerServerVersion(conn, 25, 6, 0) {
+		t.Skip("Dynamic serialization version 3 required")
+	}
 
 	const ddl = `
 		CREATE TABLE IF NOT EXISTS test_dynamic_exceeded_types (

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -40,7 +40,7 @@ func setupJSONTest(t *testing.T, protocol clickhouse.Protocol) driver.Conn {
 	})
 	require.NoError(t, err)
 
-	if !CheckMinServerServerVersion(conn, 25, 6, 0) {
+	if !CheckMinServerServerVersion(conn, 24, 8, 0) {
 		t.Skip("unsupported clickhouse version for JSON type")
 	}
 
@@ -176,6 +176,10 @@ func TestJSONEmptyArray(t *testing.T) {
 	TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
 		conn := setupJSONTest(t, protocol)
 		ctx := context.Background()
+
+		if !CheckMinServerServerVersion(conn, 24, 9, 0) {
+			t.Skip("Empty Array(JSON) depends on JSON strings for empty payload")
+		}
 
 		const ddl = `
 			CREATE TABLE IF NOT EXISTS test_json_empty_array (
@@ -319,6 +323,10 @@ func TestJSONString(t *testing.T) {
 	TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
 		conn := setupJSONTest(t, protocol)
 		ctx := context.Background()
+
+		if !CheckMinServerServerVersion(conn, 24, 9, 0) {
+			t.Skip("JSON strings not supported")
+		}
 
 		require.NoError(t, conn.Exec(ctx, "SET output_format_native_write_json_as_string=1"))
 		require.NoError(t, conn.Exec(ctx, "SET output_format_json_quote_64bit_integers=0"))


### PR DESCRIPTION
## Summary
#1590 added serialization version 3 for Dynamic and JSON, but this required all users to use ClickHouse v25.6. To prevent breaking newer versions of clickhouse-go for users on versions older than v25.6, I have re-added the old serialization versions.

If you're connecting to a server older than v25.6, it will use the old version of these columns. The old versions are broken. For Dynamic, you likely won't run into the SharedVariant issue, but for JSON you will want to use string encoding if you're on v24.9+. As a full workaround you can always cast your types in the query.

Note that because Native format revision is different in the `revision()` function, an exact version is checked in the code instead of a revision number. There's no revision number for serialization version 3, so the only way we could check is by seeing if the server is `major >=25 && minor >= 6`

Tests have been updated with the correct skip versions. Our GitHub CI's test matrix should be able to test the full range of versions from 24.8 to 25.6+, ensuring full test coverage for these features before and after the serialization version change.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
