### PR TITLE
fix(conn): ensure `ReadTimeout` applies to each `conn.Read`

### DIFF
--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -162,7 +162,9 @@ type Options struct {
 	// Use this instead of Auth.Username and Auth.Password if you're using JWT auth.
 	GetJWT GetJWTFunc
 
-	scheme      string
+	scheme string
+	// ReadTimeout is the maximum duration the client will wait for ClickHouse
+	// to respond to a single Rady call for bytes over the connection.
 	ReadTimeout time.Duration
 }
 

--- a/conn_query.go
+++ b/conn_query.go
@@ -19,7 +19,6 @@ package clickhouse
 
 import (
 	"context"
-	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
@@ -36,15 +35,6 @@ func (c *connect) query(ctx context.Context, release nativeTransportRelease, que
 		c.debugf("[bindQuery] error: %v", err)
 		release(c, err)
 		return nil, err
-	}
-
-	// set a read deadline - alternative to context.Read operation will fail if no data is received after deadline.
-	c.conn.SetReadDeadline(time.Now().Add(c.readTimeout))
-	defer c.conn.SetReadDeadline(time.Time{})
-	// context level deadlines override any read deadline
-	if deadline, ok := ctx.Deadline(); ok {
-		c.conn.SetDeadline(deadline)
-		defer c.conn.SetDeadline(time.Time{})
 	}
 
 	if err = c.sendQuery(body, &options); err != nil {

--- a/conn_test.go
+++ b/conn_test.go
@@ -2,7 +2,6 @@ package clickhouse
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"os"
 	"testing"
@@ -118,20 +117,6 @@ func TestConn_Query_ReadTimeout(t *testing.T) {
 
 	t.Run("second row timeout", func(t *testing.T) {
 		assert.False(t, rows.Next())
-		err := rows.Err()
-		assert.True(t, isDeadlineExceededError(err), "error is not a timeout error: %#v", err)
+		chtesting.AssertIsTimeoutError(t, rows.Err())
 	})
-}
-
-type timeout interface {
-	Timeout() bool
-}
-
-func isDeadlineExceededError(err error) bool {
-	nerr, ok := errors.Unwrap(err).(timeout)
-	if !ok {
-		return false
-	}
-
-	return nerr.Timeout()
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,0 +1,122 @@
+package clickhouse
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	chtesting "github.com/ClickHouse/clickhouse-go/v2/lib/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConn_Query(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(
+		os.Stderr,
+		&slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		},
+	)))
+
+	handlers := chtesting.DefaultHandlers()
+	handlers.OnQuery = func(q *proto.Query, blocks []*proto.Block, c chan<- *proto.Block) error {
+		col := &column.UInt8{}
+		require.NoError(t, col.AppendRow(uint8(1)))
+
+		c <- &proto.Block{
+			Columns: []column.Interface{
+				col,
+			},
+		}
+
+		return nil
+	}
+
+	server, err := chtesting.NewTestServer(":0", handlers)
+	require.NoError(t, err)
+
+	server.Start()
+	t.Cleanup(func() { server.Stop() })
+
+	conn, err := Open(&Options{
+		Addr:         []string{server.Address()},
+		MaxOpenConns: 2,
+	})
+	require.NoError(t, err)
+
+	ctx := context.TODO()
+	require.NoError(t, conn.Ping(ctx))
+
+	rows, err := conn.Query(ctx, "SELECT 1")
+	require.NoError(t, err)
+
+	var num uint8
+	for rows.Next() {
+		err := rows.Scan(&num)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, uint8(1), num)
+	require.NoError(t, rows.Err())
+}
+
+func TestConn_Query_ReadTimeout(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(
+		os.Stderr,
+		&slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		},
+	)))
+
+	handlers := chtesting.DefaultHandlers()
+	handlers.OnQuery = func(q *proto.Query, blocks []*proto.Block, c chan<- *proto.Block) error {
+		col := &column.UInt8{}
+		require.NoError(t, col.AppendRow(uint8(1)))
+
+		// sends first block
+		c <- &proto.Block{
+			Columns: []column.Interface{
+				col,
+			},
+		}
+
+		// then blocks indefinitely
+		select {}
+	}
+
+	server, err := chtesting.NewTestServer(":0", handlers)
+	require.NoError(t, err)
+
+	server.Start()
+	t.Cleanup(func() { server.Stop() })
+
+	conn, err := Open(&Options{
+		Addr:         []string{server.Address()},
+		MaxOpenConns: 2,
+		ReadTimeout:  2 * time.Second,
+	})
+	require.NoError(t, err)
+
+	ctx := context.TODO()
+	require.NoError(t, conn.Ping(ctx))
+
+	rows, err := conn.Query(ctx, "SELECT 1")
+	require.NoError(t, err)
+
+	t.Run("first row is returned", func(t *testing.T) {
+		assert.True(t, rows.Next())
+		var num uint8
+		err = rows.Scan(&num)
+		require.NoError(t, err)
+		assert.Equal(t, uint8(1), num)
+	})
+
+	t.Run("second row timeout", func(t *testing.T) {
+		assert.False(t, rows.Next())
+		assert.ErrorIs(t, rows.Err(), os.ErrDeadlineExceeded)
+	})
+}

--- a/lib/proto/query.go
+++ b/lib/proto/query.go
@@ -20,10 +20,11 @@ package proto
 import (
 	stdbin "encoding/binary"
 	"fmt"
-	chproto "github.com/ClickHouse/ch-go/proto"
-	"go.opentelemetry.io/otel/trace"
 	"os"
 	"strings"
+
+	chproto "github.com/ClickHouse/ch-go/proto"
+	"go.opentelemetry.io/otel/trace"
 )
 
 var (
@@ -139,6 +140,213 @@ func (q *Query) encodeClientInfo(buffer *chproto.Buffer, revision uint64) error 
 	return nil
 }
 
+func (q *Query) Decode(reader *chproto.Reader, revision uint64) error {
+	// Read query ID
+	var err error
+	if q.ID, err = reader.Str(); err != nil {
+		return fmt.Errorf("could not read query ID: %v", err)
+	}
+
+	// Decode client info
+	if err := q.decodeClientInfo(reader, revision); err != nil {
+		return err
+	}
+
+	// Decode settings
+	if err := q.Settings.Decode(reader, revision); err != nil {
+		return err
+	}
+
+	// Read interserver secret (if supported)
+	if revision >= DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET {
+		if _, err := reader.Str(); err != nil {
+			return fmt.Errorf("could not read interserver secret: %v", err)
+		}
+	}
+
+	// Read stage and compression
+	stage, err := reader.ReadByte()
+	if err != nil {
+		return fmt.Errorf("could not read query stage: %v", err)
+	}
+	_ = stage // StateComplete is expected
+
+	if q.Compression, err = reader.Bool(); err != nil {
+		return fmt.Errorf("could not read compression flag: %v", err)
+	}
+
+	// Read query body
+	if q.Body, err = reader.Str(); err != nil {
+		return fmt.Errorf("could not read query body: %v", err)
+	}
+
+	// Read parameters (if supported)
+	if revision >= DBMS_MIN_PROTOCOL_VERSION_WITH_PARAMETERS {
+		if err := q.Parameters.Decode(reader, revision); err != nil {
+			return err
+		}
+
+		// Read empty string marker for end of parameters
+		if _, err := reader.Str(); err != nil {
+			return fmt.Errorf("could not read parameters end marker: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func (q *Query) decodeClientInfo(reader *chproto.Reader, revision uint64) error {
+	// Read client query type
+	queryType, err := reader.ReadByte()
+	if err != nil {
+		return fmt.Errorf("could not read client query type: %v", err)
+	}
+	_ = queryType // ClientQueryInitial is expected
+
+	// Read initial user
+	if q.InitialUser, err = reader.Str(); err != nil {
+		return fmt.Errorf("could not read initial user: %v", err)
+	}
+
+	// Read initial query ID (skip)
+	if _, err := reader.Str(); err != nil {
+		return fmt.Errorf("could not read initial query ID: %v", err)
+	}
+
+	// Read initial address
+	if q.InitialAddress, err = reader.Str(); err != nil {
+		return fmt.Errorf("could not read initial address: %v", err)
+	}
+
+	// Read initial query start time (if supported)
+	if revision >= DBMS_MIN_PROTOCOL_VERSION_WITH_INITIAL_QUERY_START_TIME {
+		_, err := reader.Int64()
+		if err != nil {
+			return fmt.Errorf("could not read initial query start time: %v", err)
+		}
+	}
+
+	// Read interface type
+	if _, err := reader.ReadByte(); err != nil {
+		return fmt.Errorf("could not read interface type: %v", err)
+	}
+
+	// Read OS user (skip)
+
+	if _, err := reader.Str(); err != nil {
+		return fmt.Errorf("could not read OS user: %v", err)
+	}
+
+	// Read hostname (skip)
+	if _, err := reader.Str(); err != nil {
+		return fmt.Errorf("could not read hostname: %v", err)
+	}
+
+	// Read client name
+	if q.ClientName, err = reader.Str(); err != nil {
+		return fmt.Errorf("could not read client name: %v", err)
+	}
+
+	// Read client version
+	if q.ClientVersion.Major, err = reader.UVarInt(); err != nil {
+		return fmt.Errorf("could not read client major version: %v", err)
+	}
+	if q.ClientVersion.Minor, err = reader.UVarInt(); err != nil {
+		return fmt.Errorf("could not read client minor version: %v", err)
+	}
+
+	// Read client TCP protocol version
+	if q.ClientTCPProtocolVersion, err = reader.UVarInt(); err != nil {
+		return fmt.Errorf("could not read client TCP protocol version: %v", err)
+	}
+
+	// Read quota key (if supported)
+	if revision >= DBMS_MIN_REVISION_WITH_QUOTA_KEY_IN_CLIENT_INFO {
+		if q.QuotaKey, err = reader.Str(); err != nil {
+			return fmt.Errorf("could not read quota key: %v", err)
+		}
+	}
+
+	// Read distributed depth (if supported)
+	if revision >= DBMS_MIN_PROTOCOL_VERSION_WITH_DISTRIBUTED_DEPTH {
+		if _, err := reader.UVarInt(); err != nil {
+			return fmt.Errorf("could not read distributed depth: %v", err)
+		}
+	}
+
+	// Read version patch (if supported)
+	if revision >= DBMS_MIN_REVISION_WITH_VERSION_PATCH {
+		q.ClientVersion.Patch, err = reader.UVarInt()
+		if err != nil {
+			return fmt.Errorf("could not read version patch: %v", err)
+		}
+	}
+
+	// Read OpenTelemetry trace info (if supported)
+	if revision >= DBMS_MIN_REVISION_WITH_OPENTELEMETRY {
+		hasTrace, err := reader.ReadByte()
+		if err != nil {
+			return fmt.Errorf("could not read trace flag: %v", err)
+		}
+
+		if hasTrace == 1 {
+			// Read trace ID
+			traceIDBytes := make([]byte, 16)
+			if err := reader.ReadFull(traceIDBytes); err != nil {
+				return fmt.Errorf("could not read trace ID: %v", err)
+			}
+			swap64(traceIDBytes) // Reverse the swap done during encoding
+
+			// Read span ID
+			spanIDBytes := make([]byte, 8)
+			if err := reader.ReadFull(spanIDBytes); err != nil {
+				return fmt.Errorf("could not read span ID: %v", err)
+			}
+			swap64(spanIDBytes) // Reverse the swap done during encoding
+
+			// Read trace state
+			traceState, err := reader.Str()
+			if err != nil {
+				return fmt.Errorf("could not read trace state: %v", err)
+			}
+
+			// Read trace flags
+			traceFlags, err := reader.ReadByte()
+			if err != nil {
+				return fmt.Errorf("could not read trace flags: %v", err)
+			}
+
+			// Reconstruct SpanContext (this is a simplified reconstruction)
+			// In a real implementation, you'd properly reconstruct the trace.SpanContext
+			// For now, we'll store the raw data or skip reconstruction
+			_ = traceIDBytes
+			_ = spanIDBytes
+			_ = traceState
+			_ = traceFlags
+		}
+	}
+
+	// Read parallel replicas info (if supported)
+	if revision >= DBMS_MIN_REVISION_WITH_PARALLEL_REPLICAS {
+		// Read collaborate_with_initiator
+		if _, err := reader.UVarInt(); err != nil {
+			return fmt.Errorf("could not read collaborate_with_initiator: %v", err)
+		}
+
+		// Read count_participating_replicas
+		if _, err := reader.UVarInt(); err != nil {
+			return fmt.Errorf("could not read count_participating_replicas: %v", err)
+		}
+
+		// Read number_of_current_replica
+		if _, err := reader.UVarInt(); err != nil {
+			return fmt.Errorf("could not read number_of_current_replica: %v", err)
+		}
+	}
+
+	return nil
+}
+
 type Settings []Setting
 
 type Setting struct {
@@ -205,6 +413,63 @@ func (s *Setting) encode(buffer *chproto.Buffer, revision uint64) error {
 	return nil
 }
 
+func (s *Settings) Decode(reader *chproto.Reader, revision uint64) error {
+	*s = (*s)[:0] // Clear existing settings
+
+	for {
+		// Read setting key
+		key, err := reader.Str()
+		if err != nil {
+			return fmt.Errorf("could not read setting key: %v", err)
+		}
+
+		// Empty key indicates end of settings
+		if key == "" {
+			break
+		}
+
+		setting := Setting{Key: key}
+
+		if revision <= DBMS_MIN_REVISION_WITH_SETTINGS_SERIALIZED_AS_STRINGS {
+			// Old format: value as UVarInt
+			value, err := reader.UVarInt()
+			if err != nil {
+				return fmt.Errorf("could not read setting value: %v", err)
+			}
+			setting.Value = value
+		} else {
+			// New format: flags + string value
+			flags, err := reader.UVarInt()
+			if err != nil {
+				return fmt.Errorf("could not read setting flags: %v", err)
+			}
+
+			setting.Important = (flags & settingFlagImportant) != 0
+			setting.Custom = (flags & settingFlagCustom) != 0
+
+			valueStr, err := reader.Str()
+			if err != nil {
+				return fmt.Errorf("could not read setting value: %v", err)
+			}
+
+			if setting.Custom {
+				// Decode field dump
+				value, err := decodeFieldDump(valueStr)
+				if err != nil {
+					return fmt.Errorf("could not decode field dump for setting %s: %v", key, err)
+				}
+				setting.Value = value
+			} else {
+				setting.Value = valueStr
+			}
+		}
+
+		*s = append(*s, setting)
+	}
+
+	return nil
+}
+
 type Parameters []Parameter
 
 type Parameter struct {
@@ -235,6 +500,49 @@ func (s *Parameter) encode(buffer *chproto.Buffer, revision uint64) error {
 	return nil
 }
 
+func (p *Parameters) Decode(reader *chproto.Reader, revision uint64) error {
+	*p = (*p)[:0] // Clear existing parameters
+
+	for {
+		// Read parameter key
+		key, err := reader.Str()
+		if err != nil {
+			return fmt.Errorf("could not read parameter key: %v", err)
+		}
+
+		// Empty key indicates end of parameters
+		if key == "" {
+			break
+		}
+
+		// Read flags (should be settingFlagCustom for parameters)
+		if _, err := reader.UVarInt(); err != nil {
+			return fmt.Errorf("could not read parameter flags: %v", err)
+		}
+
+		// Read parameter value
+		valueStr, err := reader.Str()
+		if err != nil {
+			return fmt.Errorf("could not read parameter value: %v", err)
+		}
+
+		// Decode field dump
+		value, err := decodeFieldDump(valueStr)
+		if err != nil {
+			return fmt.Errorf("could not decode field dump for parameter %s: %v", key, err)
+		}
+
+		parameter := Parameter{
+			Key:   key,
+			Value: value,
+		}
+
+		*p = append(*p, parameter)
+	}
+
+	return nil
+}
+
 // encodes a field dump with an appropriate type format
 // implements the same logic as in ClickHouse Field::restoreFromDump (https://github.com/ClickHouse/ClickHouse/blob/master/src/Core/Field.cpp#L312)
 // currently, only string type is supported
@@ -245,4 +553,19 @@ func encodeFieldDump(value any) (string, error) {
 	}
 
 	return "", fmt.Errorf("unsupported field type %T", value)
+}
+
+// decodeFieldDump decodes a field dump string back to its original value
+// This reverses the encodeFieldDump function
+func decodeFieldDump(dump string) (string, error) {
+	// Handle string format: 'value' -> value
+	if len(dump) >= 2 && dump[0] == '\'' && dump[len(dump)-1] == '\'' {
+		// Remove surrounding quotes and unescape
+		value := dump[1 : len(dump)-1]
+		value = strings.ReplaceAll(value, "\\'", "'")
+		return value, nil
+	}
+
+	// If not in string format, return as-is
+	return dump, nil
 }

--- a/lib/testing/errors.go
+++ b/lib/testing/errors.go
@@ -1,0 +1,38 @@
+package testing
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// AssertIsTimeoutError ensures that the error provided is a timeout error
+// It recursively unwraps the provided error and ensures the core error
+// implements the Timeout() method and it returns true.
+// context deadline error, os deadline error and and poll deadline error each
+// implement this and return true.
+func AssertIsTimeoutError(t *testing.T, err error) {
+	assert.True(t, isDeadlineExceededError(err), "error is not a timeout error: %#v", err)
+}
+
+type timeout interface {
+	Timeout() bool
+}
+
+func isDeadlineExceededError(err error) bool {
+	nerr, ok := unwrap(err).(timeout)
+	if !ok {
+		return false
+	}
+
+	return nerr.Timeout()
+}
+
+// unwrap recursively unwraps the error until it gets the core error
+func unwrap(err error) error {
+	if uerr := errors.Unwrap(err); uerr != nil {
+		return unwrap(uerr)
+	}
+	return err
+}

--- a/lib/testing/server.go
+++ b/lib/testing/server.go
@@ -1,0 +1,395 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package proto
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"time"
+
+	chproto "github.com/ClickHouse/ch-go/proto"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+)
+
+// TestServer represents a mock ClickHouse server for testing
+type TestServer struct {
+	listener net.Listener
+	handlers PacketHandlers
+	done     chan struct{}
+}
+
+// PacketHandlers contains handlers for different protocol packets
+type PacketHandlers struct {
+	// OnClientHandshake is called when a client handshake is received
+	OnClientHandshake func(handshake proto.ClientHandshake) (proto.ServerHandshake, error)
+
+	// OnQuery is called when a query packet is received
+	OnQuery func(*proto.Query, []*proto.Block, chan<- *proto.Block) error
+
+	// OnCancel is called when a cancel packet is received
+	OnCancel func() error
+
+	// OnPing is called when a ping packet is received
+	OnPing func() error
+
+	// OnUnknownPacket is called when an unknown packet type is received
+	OnUnknownPacket func(packetType uint64, data []byte) error
+}
+
+// DefaultHandlers returns a set of default handlers that provide basic responses
+func DefaultHandlers() PacketHandlers {
+	return PacketHandlers{
+		OnClientHandshake: func(handshake proto.ClientHandshake) (proto.ServerHandshake, error) {
+			return proto.ServerHandshake{
+				Name:        "ClickHouse",
+				DisplayName: "ClickHouse Test Server",
+				Revision:    proto.DBMS_MIN_REVISION_WITH_VERSION_PATCH,
+				Version:     proto.Version{Major: 25, Minor: 6, Patch: 0},
+				Timezone:    time.UTC,
+			}, nil
+		},
+		OnQuery: func(*proto.Query, []*proto.Block, chan<- *proto.Block) error {
+			// Default: do nothing, just acknowledge
+			return nil
+		},
+		OnCancel: func() error {
+			// Default: do nothing, just acknowledge
+			return nil
+		},
+		OnPing: func() error {
+			// Default: respond with pong
+			return nil
+		},
+		OnUnknownPacket: func(packetType uint64, data []byte) error {
+			return fmt.Errorf("unknown packet type: %d", packetType)
+		},
+	}
+}
+
+// NewTestServer creates a new test server with the given handlers
+func NewTestServer(address string, handlers PacketHandlers) (*TestServer, error) {
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on %s: %v", address, err)
+	}
+
+	return &TestServer{
+		listener: listener,
+		handlers: handlers,
+		done:     make(chan struct{}),
+	}, nil
+}
+
+// Start begins accepting connections and handling requests
+func (ts *TestServer) Start() {
+	go ts.acceptConnections()
+}
+
+// Stop stops the test server
+func (ts *TestServer) Stop() error {
+	close(ts.done)
+	return ts.listener.Close()
+}
+
+// Address returns the address the server is listening on
+func (ts *TestServer) Address() string {
+	return ts.listener.Addr().String()
+}
+
+func (ts *TestServer) acceptConnections() {
+	for {
+		select {
+		case <-ts.done:
+			return
+		default:
+		}
+
+		conn, err := ts.listener.Accept()
+		if err != nil {
+			select {
+			case <-ts.done:
+				return
+			default:
+				continue
+			}
+		}
+
+		go ts.handleConnection(conn)
+	}
+}
+
+// Helper method to get server revision
+func (ts *TestServer) getRevision() uint64 {
+	return proto.DBMS_MIN_REVISION_WITH_VERSION_PATCH
+}
+
+func (ts *TestServer) handleConnection(conn net.Conn) {
+	defer conn.Close()
+
+	reader := chproto.NewReader(conn)
+	writer := chproto.NewWriter(conn, &chproto.Buffer{})
+
+	for {
+		select {
+		case <-ts.done:
+			return
+		default:
+		}
+
+		if err := func() error {
+			// Read packet type
+			packetType, err := reader.UVarInt()
+			if err != nil {
+				return err
+			}
+
+			slog.Debug("Packet type", "type", packetType)
+
+			if err := ts.handlePacket(reader, writer, packetType); err != nil {
+				slog.Error("Handling packet", "error", err)
+				// Send exception packet
+				ts.sendException(writer, err)
+			}
+
+			return nil
+		}(); err != nil {
+			if err != io.EOF {
+				return
+			}
+		}
+	}
+}
+
+func (ts *TestServer) handlePacket(reader *chproto.Reader, writer *chproto.Writer, packetType uint64) error {
+	switch packetType {
+	case proto.ClientHello:
+		return ts.handleClientHandshake(reader, writer)
+	case proto.ClientQuery:
+		return ts.handleQuery(reader, writer)
+	case proto.ClientData:
+		return errors.New("unexpected blocks")
+	case proto.ClientCancel:
+		return ts.handleCancel(reader, writer)
+	case proto.ClientPing:
+		return ts.handlePing(reader, writer)
+	default:
+		// Read remaining packet data
+		data, err := io.ReadAll(reader)
+		if err != nil {
+			return err
+		}
+		return ts.handlers.OnUnknownPacket(packetType, data)
+	}
+}
+
+func (ts *TestServer) handleClientHandshake(reader *chproto.Reader, writer *chproto.Writer) (err error) {
+	var handshake proto.ClientHandshake
+	if err := handshake.Decode(reader); err != nil {
+		return err
+	}
+
+	var auth struct {
+		database string
+		username string
+		password string
+	}
+
+	{
+		if auth.database, err = reader.Str(); err != nil {
+			return err
+		}
+		if auth.username, err = reader.Str(); err != nil {
+			return err
+		}
+		if auth.password, err = reader.Str(); err != nil {
+			return err
+		}
+	}
+
+	slog.Debug("Handling handshake", "handshake", handshake, "auth", auth)
+
+	serverHandshake, err := ts.handlers.OnClientHandshake(handshake)
+	if err != nil {
+		return err
+	}
+
+	// Send server handshake response
+	writer.ChainBuffer(func(b *chproto.Buffer) {
+		b.PutUVarInt(ServerCodeHello)
+		serverHandshake.Encode(b)
+	})
+
+	_, err = writer.Flush()
+	return err
+}
+
+func (ts *TestServer) handleQuery(reader *chproto.Reader, writer *chproto.Writer) (err error) {
+	query := &proto.Query{}
+	if err := query.Decode(reader, proto.DBMS_MIN_REVISION_WITH_VERSION_PATCH); err != nil {
+		return fmt.Errorf("handling query: %w", err)
+	}
+
+	inBlocks, err := ts.readBlocks(reader)
+	if err != nil {
+		return fmt.Errorf("handling query blocks: %w", err)
+	}
+
+	slog.Debug("Handling query", "query", query, "blocks", inBlocks)
+
+	outBlocks := make(chan *proto.Block)
+	go func() {
+		defer close(outBlocks)
+		err = ts.handlers.OnQuery(query, inBlocks, outBlocks)
+	}()
+
+	for block := range outBlocks {
+		writer.ChainBuffer(func(b *chproto.Buffer) {
+			b.PutUVarInt(ServerCodeData)
+			b.PutString("") // is this where TableColumns would be sent?
+			err = block.Encode(b, proto.DBMS_MIN_REVISION_WITH_VERSION_PATCH)
+		})
+		if _, werr := writer.Flush(); werr != nil {
+			return werr
+		}
+		if err != nil {
+			return
+		}
+	}
+
+	if err != nil {
+		return
+	}
+
+	// Send end of stream
+	return ts.sendEndOfStream(writer)
+}
+
+func (ts *TestServer) readBlocks(reader *chproto.Reader) (blocks []*proto.Block, _ error) {
+	for {
+		// Read the next packet type
+		packetType, err := reader.UVarInt()
+		if err != nil {
+			return nil, err
+		}
+
+		switch packetType {
+		case proto.ClientData:
+			// Use ch-go's built-in block decoding
+			var block proto.Block
+			if err := block.Decode(reader, ts.getRevision()); err != nil {
+				return nil, fmt.Errorf("failed to decode data block: %v", err)
+			}
+
+			// If this is an empty block (0 rows), it signals end of data transmission
+			if block.Rows() == 0 {
+				return
+			}
+
+			blocks = append(blocks, &block)
+		case proto.ClientCancel:
+			// Query was cancelled
+			return nil, ts.handlers.OnCancel()
+
+		default:
+			return nil, fmt.Errorf("unexpected packet type %d while reading query data blocks", packetType)
+		}
+	}
+}
+
+func (ts *TestServer) handleCancel(_ *chproto.Reader, _ *chproto.Writer) error {
+	return ts.handlers.OnCancel()
+}
+
+func (ts *TestServer) handlePing(_ *chproto.Reader, writer *chproto.Writer) error {
+	if err := ts.handlers.OnPing(); err != nil {
+		return err
+	}
+
+	// Send pong response
+	writer.ChainBuffer(func(b *chproto.Buffer) {
+		b.PutUVarInt(ServerCodePong)
+	})
+
+	_, err := writer.Flush()
+	return err
+}
+
+func (ts *TestServer) sendEndOfStream(writer *chproto.Writer) error {
+	writer.ChainBuffer(func(b *chproto.Buffer) {
+		b.PutUVarInt(ServerCodeEndOfStream)
+	})
+
+	_, err := writer.Flush()
+	return err
+}
+
+func (ts *TestServer) sendException(writer *chproto.Writer, err error) error {
+	writer.ChainBuffer(func(b *chproto.Buffer) {
+		b.PutUVarInt(ServerCodeException)
+		b.PutUVarInt(1)           // Exception code
+		b.PutString("TestServer") // Exception name
+		b.PutString(err.Error())  // Exception message
+		b.PutString("")           // Stack trace
+		b.PutUVarInt(0)           // Nested exception flag
+	})
+
+	_, err = writer.Flush()
+	return err
+}
+
+// Protocol packet type constants (these would typically be defined elsewhere)
+const (
+	ServerCodeHello                = 0
+	ServerCodeData                 = 1
+	ServerCodeException            = 2
+	ServerCodeProgress             = 3
+	ServerCodePong                 = 4
+	ServerCodeEndOfStream          = 5
+	ServerCodeProfileInfo          = 6
+	ServerCodeTotals               = 7
+	ServerCodeExtremes             = 8
+	ServerCodeTablesStatusResponse = 9
+	ServerCodeLog                  = 10
+	ServerCodeTableColumns         = 11
+)
+
+// Test helper functions
+func (ts *TestServer) SendData(writer *chproto.Writer, data []byte) error {
+	writer.ChainBuffer(func(b *chproto.Buffer) {
+		b.PutUVarInt(ServerCodeData)
+		b.PutRaw(data)
+	})
+
+	_, err := writer.Flush()
+	return err
+}
+
+func (ts *TestServer) SendProgress(writer *chproto.Writer, readRows, readBytes, totalRows uint64) error {
+	writer.ChainBuffer(func(b *chproto.Buffer) {
+		b.PutUVarInt(ServerCodeProgress)
+		b.PutUVarInt(readRows)
+		b.PutUVarInt(readBytes)
+		b.PutUVarInt(totalRows)
+	})
+
+	_, err := writer.Flush()
+	return err
+}

--- a/lib/testing/server.go
+++ b/lib/testing/server.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package proto
+package testing
 
 import (
 	"errors"

--- a/tests/std/context_timeout_test.go
+++ b/tests/std/context_timeout_test.go
@@ -20,14 +20,14 @@ package std
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
-	"net"
-	"net/url"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	chtesting "github.com/ClickHouse/clickhouse-go/v2/lib/testing"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -46,14 +46,7 @@ func TestStdContextStdTimeout(t *testing.T) {
 				if row := connect.QueryRowContext(ctx, "SELECT 1, sleep(3)"); assert.NotNil(t, row) {
 					var a, b int
 					if err := row.Scan(&a, &b); assert.Error(t, err) {
-						switch err := err.(type) {
-						case *net.OpError:
-							assert.Equal(t, "read", err.Op)
-						case *url.Error:
-							assert.Equal(t, context.DeadlineExceeded, err.Err)
-						default:
-							assert.ErrorIs(t, err, context.DeadlineExceeded)
-						}
+						chtesting.AssertIsTimeoutError(t, err)
 					}
 				}
 			}
@@ -67,7 +60,6 @@ func TestStdContextStdTimeout(t *testing.T) {
 					}
 				}
 			}
-
 		})
 	}
 }

--- a/tests/std/context_timeout_test.go
+++ b/tests/std/context_timeout_test.go
@@ -40,7 +40,7 @@ func TestStdContextStdTimeout(t *testing.T) {
 		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			connect, err := GetStdDSNConnection(protocol, useSSL, nil)
 			require.NoError(t, err)
-			{
+			t.Run("query which triggers timeout", func(t *testing.T) {
 				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 				defer cancel()
 				if row := connect.QueryRowContext(ctx, "SELECT 1, sleep(3)"); assert.NotNil(t, row) {
@@ -49,9 +49,9 @@ func TestStdContextStdTimeout(t *testing.T) {
 						chtesting.AssertIsTimeoutError(t, err)
 					}
 				}
-			}
-			{
-				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			})
+			t.Run("query which returns in time", func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 				defer cancel()
 				if row := connect.QueryRowContext(ctx, "SELECT 1, sleep(0.1)"); assert.NotNil(t, row) {
 					var value, value2 int
@@ -59,7 +59,7 @@ func TestStdContextStdTimeout(t *testing.T) {
 						assert.Equal(t, int(1), value)
 					}
 				}
-			}
+			})
 		})
 	}
 }

--- a/tests/std/context_timeout_test.go
+++ b/tests/std/context_timeout_test.go
@@ -40,6 +40,7 @@ func TestStdContextStdTimeout(t *testing.T) {
 		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
 			connect, err := GetStdDSNConnection(protocol, useSSL, nil)
 			require.NoError(t, err)
+
 			t.Run("query which triggers timeout", func(t *testing.T) {
 				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 				defer cancel()
@@ -51,7 +52,7 @@ func TestStdContextStdTimeout(t *testing.T) {
 				}
 			})
 			t.Run("query which returns in time", func(t *testing.T) {
-				ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 				defer cancel()
 				if row := connect.QueryRowContext(ctx, "SELECT 1, sleep(0.1)"); assert.NotNil(t, row) {
 					var value, value2 int


### PR DESCRIPTION
## Summary

Fixes https://github.com/ClickHouse/clickhouse-go/issues/1607

This PR addresses the issue of `ReadTimeout` currently only applying to the first block returned on a query to ClickHouse.

For the Changelog:

```
Fix `ReadTimeout` so that it applies to each call to `conn.Read` not just the first read block
```

The first change in this PR introduces `lib/proto` updates to support some of the missing client encoding and server decoding functions for CH packets.
This was so that I could implement a fake CH server where we can define our own handlers:
https://github.com/GeorgeMac/clickhouse-go/blob/37404af3d6637594d79bf3345a20970ddba01c31/lib/testing/server.go#L57-L85

Then I used this fake server in a couple unit tests. The first a simple happy path `SELECT 1`, mostly to ensure that the fake server was working as expected alongside the client.

The second is the case which demonstrates the problem in the issue.
When the test suite is run with a timeout before the fix in 299fe0c64df939314b043b4b7ddf2a07863c5f7b:

```
=== RUN   TestConn_Query_ReadTimeout
time=2025-07-20T08:48:50.671+01:00 level=DEBUG msg="Packet type" type=0
time=2025-07-20T08:48:50.671+01:00 level=DEBUG msg="Handling handshake" handshake="clickhouse-go/2.37.2 (lv:go/1.24.4; os:darwin) 2.37.0" auth="{database: username:default password:}"
time=2025-07-20T08:48:50.671+01:00 level=DEBUG msg="Packet type" type=4
time=2025-07-20T08:48:50.671+01:00 level=DEBUG msg="Packet type" type=1
time=2025-07-20T08:48:50.671+01:00 level=DEBUG msg="Handling query" query="&{ID: ClientName:clickhouse-go/2.37.2 (lv:go/1.24.4; os:darwin) ClientVersion:2.37.0 ClientTCPProtocolVersion:54460 Span:{traceID:[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] spanID:[0 0 0 0 0 0 0 0] traceFlags:0 traceState:{list:[]} remote:false} Body:SELECT 1 QuotaKey: Settings:[] Parameters:[] Compression:false InitialUser: InitialAddress:[::1]:53128}" blocks=[]
=== RUN   TestConn_Query_ReadTimeout/first_row_is_returned
=== RUN   TestConn_Query_ReadTimeout/second_row_timeout
panic: test timed out after 10s
        running tests:
                TestConn_Query_ReadTimeout (10s)
                TestConn_Query_ReadTimeout/second_row_timeout (10s)
```

Which nicely demonstrates in the panic output where the client blocks on `rows.Next()`:

```
goroutine 5 [select]:
github.com/ClickHouse/clickhouse-go/v2.(*rows).Next(0x1400001e120)
        /Users/georgemacrorie/github/ClickHouse/clickhouse-go/clickhouse_rows.go:52 +0x118
github.com/ClickHouse/clickhouse-go/v2.TestConn_Query_ReadTimeout.func4(0x14000003340)
        /Users/georgemacrorie/github/ClickHouse/clickhouse-go/conn_test.go:119 +0x34
testing.tRunner(0x14000003340, 0x1400000c060)
        /opt/homebrew/Cellar/go/1.24.4/libexec/src/testing/testing.go:1792 +0xe4
created by testing.(*T).Run in goroutine 38
        /opt/homebrew/Cellar/go/1.24.4/libexec/src/testing/testing.go:1851 +0x374
FAIL    github.com/ClickHouse/clickhouse-go/v2  10.349s
FAIL
```

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
