### PR TITLE
fix(batch): nested column name parsing #1587

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -48,7 +48,7 @@ func extractNormalizedInsertQueryAndColumns(query string) (normalizedQuery strin
 		for i := range columns {
 			// refers to https://clickhouse.com/docs/en/sql-reference/syntax#identifiers
 			// we can use identifiers with double quotes or backticks, for example: "id", `id`, but not both, like `"id"`.
-			columns[i] = strings.Trim(strings.Trim(strings.TrimSpace(columns[i]), "\""), "`")
+			columns[i] = strings.ReplaceAll(strings.Trim(strings.TrimSpace(columns[i]), "\""), "`", "")
 		}
 	}
 

--- a/batch_test.go
+++ b/batch_test.go
@@ -201,6 +201,14 @@ func TestExtractNormalizedInsertQueryAndColumns(t *testing.T) {
 			query:         "SELECT * FROM table_name",
 			expectedError: true,
 		},
+		{
+			name:                    "Insert with backtick quoted table name and nested columns",
+			query:                   "INSERT INTO `table_name` (`col1`.`nested1`, `col1`.`nested2`) VALUES ((1, 2), (1, 2))",
+			expectedNormalizedQuery: "INSERT INTO `table_name` (`col1`.`nested1`, `col1`.`nested2`) FORMAT Native",
+			expectedTableName:       "`table_name`",
+			expectedColumns:         []string{"col1.nested1", "col1.nested2"},
+			expectedError:           false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary
Column name parsing improved within batch insert.

## Checklist
- [ ] Unit and integration tests covering the common scenarios were added

