### PR TITLE
fix(conn): ensure `ReadTimeout` applies to each `conn.Read` (edited)

### DIFF
--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -162,7 +162,11 @@ type Options struct {
 	// Use this instead of Auth.Username and Auth.Password if you're using JWT auth.
 	GetJWT GetJWTFunc
 
-	scheme      string
+	scheme string
+
+	// ReadTimeout is the maximum duration the client will wait for ClickHouse
+	// to respond to a single Read call for bytes over the connection.
+	// Can be overridden with context.WithDeadline.
 	ReadTimeout time.Duration
 }
 

--- a/conn_process.go
+++ b/conn_process.go
@@ -74,6 +74,9 @@ func (c *connect) firstBlockImpl(ctx context.Context, on *onProcess) (*proto.Blo
 	c.readerMutex.Lock()
 	defer c.readerMutex.Unlock()
 
+	c.startReadWriteTimeout(ctx)
+	defer c.clearReadWriteTimeout(ctx)
+
 	for {
 		if c.reader == nil {
 			return nil, errors.New("unexpected state: c.reader is nil")
@@ -143,6 +146,9 @@ func (c *connect) process(ctx context.Context, on *onProcess) error {
 func (c *connect) processImpl(ctx context.Context, on *onProcess) error {
 	c.readerMutex.Lock()
 	defer c.readerMutex.Unlock()
+
+	c.startReadWriteTimeout(ctx)
+	defer c.clearReadWriteTimeout(ctx)
 
 	for {
 		if c.reader == nil {

--- a/conn_query.go
+++ b/conn_query.go
@@ -19,8 +19,6 @@ package clickhouse
 
 import (
 	"context"
-	"time"
-
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
@@ -36,15 +34,6 @@ func (c *connect) query(ctx context.Context, release nativeTransportRelease, que
 		c.debugf("[bindQuery] error: %v", err)
 		release(c, err)
 		return nil, err
-	}
-
-	// set a read deadline - alternative to context.Read operation will fail if no data is received after deadline.
-	c.conn.SetReadDeadline(time.Now().Add(c.readTimeout))
-	defer c.conn.SetReadDeadline(time.Time{})
-	// context level deadlines override any read deadline
-	if deadline, ok := ctx.Deadline(); ok {
-		c.conn.SetDeadline(deadline)
-		defer c.conn.SetDeadline(time.Time{})
 	}
 
 	if err = c.sendQuery(body, &options); err != nil {


### PR DESCRIPTION
## Summary
Original PR https://github.com/ClickHouse/clickhouse-go/pull/1612

Added functions, fixed typo, removed test server from original PR. See original PR for notes