### PR TITLE
fix: json v1 encoding/decoding for prefixed types

### DIFF
--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -488,3 +488,26 @@ func TestJSONArrayVariant(t *testing.T) {
 		require.NoError(t, rows.Err())
 	})
 }
+
+func TestJSONLowCardinalityNullableString(t *testing.T) {
+	TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
+		conn := setupJSONTest(t, protocol)
+		ctx := context.Background()
+
+		rows, err := conn.Query(ctx, `SELECT '{"x": "test"}'::JSON(x LowCardinality(Nullable(String)))`)
+		require.NoError(t, err)
+
+		require.True(t, rows.Next())
+
+		var row clickhouse.JSON
+		err = rows.Scan(&row)
+		require.NoError(t, err)
+
+		xStr, ok := clickhouse.ExtractJSONPathAs[*string](&row, "x")
+		require.True(t, ok)
+		require.Equal(t, "test", *xStr)
+
+		require.NoError(t, rows.Close())
+		require.NoError(t, rows.Err())
+	})
+}


### PR DESCRIPTION
## Summary
Fixes deprecated JSON serialization version `0` for `LowCardinality(Nullable(String))` and similar types.

LowCardinality is a type that has a prefix in the Native format, so this fix applies to similar columns that implement a prefix.

This is not an issue for serialization version `3` from #1590, only this older version.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
