### PR TITLE
support `database/sql` scanning json into string/[]byte/json.RawMessage

### DIFF
--- a/examples/std/json_strings.go
+++ b/examples/std/json_strings.go
@@ -32,7 +32,7 @@ func JSONStringExample() error {
 		return err
 	}
 
-	if !CheckMinServerVersion(conn, 24, 9, 0) {
+	if !CheckMinServerVersion(conn, 24, 10, 0) {
 		fmt.Print("unsupported clickhouse version for JSON type")
 		return nil
 	}
@@ -74,7 +74,7 @@ func JSONStringExample() error {
 	if err != nil {
 		return err
 	}
-	
+
 	insertProductString := "{\"created_at\":\"2024-12-19T11:20:04.146Z\",\"id\":\"1234\"," +
 		"\"metadata\":{\"page_count\":\"852\",\"region\":\"us\"},\"name\":\"Book\",\"pricing\":{\"currency\":\"usd\"," +
 		"\"price\":\"750\"},\"tags\":[\"library\",\"fiction\"]}"

--- a/examples/std/json_strings.go
+++ b/examples/std/json_strings.go
@@ -20,6 +20,7 @@ package std
 import (
 	"context"
 	"fmt"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
@@ -73,10 +74,10 @@ func JSONStringExample() error {
 	if err != nil {
 		return err
 	}
-
-	insertProductString := "{\"id\":1234,\"name\":\"Book\",\"tags\":[\"library\",\"fiction\"]," +
-		"\"pricing\":{\"price\":750,\"currency\":\"usd\"},\"metadata\":{\"page_count\":852,\"region\":\"us\"}," +
-		"\"created_at\":\"2024-12-19T11:20:04.146Z\"}"
+	
+	insertProductString := "{\"created_at\":\"2024-12-19T11:20:04.146Z\",\"id\":\"1234\"," +
+		"\"metadata\":{\"page_count\":\"852\",\"region\":\"us\"},\"name\":\"Book\",\"pricing\":{\"currency\":\"usd\"," +
+		"\"price\":\"750\"},\"tags\":[\"library\",\"fiction\"]}"
 
 	if _, err = batch.ExecContext(ctx, insertProductString); err != nil {
 		return err

--- a/lib/column/codegen/column.tpl
+++ b/lib/column/codegen/column.tpl
@@ -202,7 +202,8 @@ var (
 		scanTypeMultiPolygon = reflect.TypeOf(orb.MultiPolygon{})
 		scanTypeVariant = reflect.TypeOf(chcol.Variant{})
 		scanTypeDynamic = reflect.TypeOf(chcol.Dynamic{})
-        scanTypeJSON    = reflect.TypeOf(chcol.JSON{})
+		scanTypeJSON    = reflect.TypeOf(chcol.JSON{})
+		scanTypeJSONString = reflect.TypeOf("")
 	)
 
 {{- range . }}

--- a/lib/column/column_gen.go
+++ b/lib/column/column_gen.go
@@ -267,6 +267,7 @@ var (
 	scanTypeVariant      = reflect.TypeOf(chcol.Variant{})
 	scanTypeDynamic      = reflect.TypeOf(chcol.Dynamic{})
 	scanTypeJSON         = reflect.TypeOf(chcol.JSON{})
+	scanTypeJSONString   = reflect.TypeOf("")
 )
 
 func (col *Float32) Name() string {

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/ClickHouse/ch-go/proto"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/binary"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 )
 
@@ -255,7 +256,14 @@ func (c *JSON) Row(row int, ptr bool) any {
 	case JSONObjectSerializationVersion:
 		return c.rowAsJSON(row)
 	case JSONStringSerializationVersion:
-		return c.jsonStrings.Row(row, ptr)
+		var str string
+		if ptr {
+			str = *c.jsonStrings.Row(row, ptr).(*string)
+		} else {
+			str = c.jsonStrings.Row(row, ptr).(string)
+		}
+
+		return binary.Str2Bytes(str, len(str))
 	default:
 		return nil
 	}
@@ -622,7 +630,14 @@ func (c *JSON) Encode(buffer *proto.Buffer) {
 }
 
 func (c *JSON) ScanType() reflect.Type {
-	return scanTypeJSON
+	switch c.serializationVersion {
+	case JSONObjectSerializationVersion:
+		return scanTypeJSON
+	case JSONStringSerializationVersion:
+		return scanTypeJSONString
+	default:
+		return scanTypeJSON
+	}
 }
 
 func (c *JSON) Reset() {

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -324,7 +324,7 @@ func TestJSONString(t *testing.T) {
 		conn := setupJSONTest(t, protocol)
 		ctx := context.Background()
 
-		if !CheckMinServerServerVersion(conn, 24, 9, 0) {
+		if !CheckMinServerServerVersion(conn, 24, 10, 0) {
 			t.Skip("JSON strings not supported")
 		}
 

--- a/tests/std/json_test.go
+++ b/tests/std/json_test.go
@@ -270,6 +270,10 @@ func TestJSONString(t *testing.T) {
 	ctx := context.Background()
 	conn := setupJSONTest(t)
 
+	if !CheckMinServerVersion(conn, 24, 10, 0) {
+		t.Skip("JSON strings not supported")
+	}
+
 	_, err := conn.ExecContext(ctx, "SET output_format_native_write_json_as_string = 1")
 	require.NoError(t, err)
 	_, err = conn.ExecContext(ctx, "SET output_format_json_quote_64bit_integers = 0")
@@ -355,6 +359,10 @@ func TestJSONString(t *testing.T) {
 func TestJSONStringScanTypes(t *testing.T) {
 	ctx := context.Background()
 	conn := setupJSONTest(t)
+
+	if !CheckMinServerVersion(conn, 24, 10, 0) {
+		t.Skip("JSON strings not supported")
+	}
 
 	_, err := conn.ExecContext(ctx, "SET output_format_native_write_json_as_string = 1")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
The `database/sql` interface now supports scanning JSON strings into `string`, `[]byte` and `json.RawMessage`.
The String type was also updated to support new cases for scanning and appending `[]byte`.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
