### PR TITLE
fix: Nullable base types with prefix

### DIFF
--- a/lib/column/nullable.go
+++ b/lib/column/nullable.go
@@ -20,9 +20,11 @@ package column
 import (
 	"database/sql"
 	"database/sql/driver"
-	"github.com/ClickHouse/ch-go/proto"
+	"fmt"
 	"reflect"
 	"time"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type Nullable struct {
@@ -181,6 +183,26 @@ func (col *Nullable) Encode(buffer *proto.Buffer) {
 		col.nulls.EncodeColumn(buffer)
 	}
 	col.base.Encode(buffer)
+}
+
+func (col *Nullable) ReadStatePrefix(reader *proto.Reader) error {
+	if serialize, ok := col.base.(CustomSerialization); ok {
+		if err := serialize.ReadStatePrefix(reader); err != nil {
+			return fmt.Errorf("failed to read prefix for Nullable base type %s: %w", col.base.Type(), err)
+		}
+	}
+
+	return nil
+}
+
+func (col *Nullable) WriteStatePrefix(buffer *proto.Buffer) error {
+	if serialize, ok := col.base.(CustomSerialization); ok {
+		if err := serialize.WriteStatePrefix(buffer); err != nil {
+			return fmt.Errorf("failed to write prefix for Nullable base type %s: %w", col.base.Type(), err)
+		}
+	}
+
+	return nil
 }
 
 var _ Interface = (*Nullable)(nil)

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -515,8 +515,12 @@ func TestJSONLowCardinalityNullableString(t *testing.T) {
 func TestJSONNullable(t *testing.T) {
 	TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
 		conn := setupJSONTest(t, protocol)
-		ctx := context.Background()
 
+		if !CheckMinServerServerVersion(conn, 25, 2, 0) {
+			t.Skip("Nullable(JSON) unsupported")
+		}
+
+		ctx := context.Background()
 		rows, err := conn.Query(ctx, `SELECT '{"x": "test"}'::Nullable(JSON)`)
 		require.NoError(t, err)
 

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -511,3 +511,26 @@ func TestJSONLowCardinalityNullableString(t *testing.T) {
 		require.NoError(t, rows.Err())
 	})
 }
+
+func TestJSONNullable(t *testing.T) {
+	TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
+		conn := setupJSONTest(t, protocol)
+		ctx := context.Background()
+
+		rows, err := conn.Query(ctx, `SELECT '{"x": "test"}'::Nullable(JSON)`)
+		require.NoError(t, err)
+
+		require.True(t, rows.Next())
+
+		var row clickhouse.JSON
+		err = rows.Scan(&row)
+		require.NoError(t, err)
+
+		xStr, ok := clickhouse.ExtractJSONPathAs[string](&row, "x")
+		require.True(t, ok)
+		require.Equal(t, "test", xStr)
+
+		require.NoError(t, rows.Close())
+		require.NoError(t, rows.Err())
+	})
+}


### PR DESCRIPTION
## Summary
Fixes `Nullable` for types with a prefix. Previously this was uncommon since things like `Nullable(LowCardinality(String))` are not possible, this is usually written as `LowCardinality(Nullable(String))`.

`Nullable(JSON)` is possible however, and this change fixes parsing for this type and similar types with a prefix.

Support added in https://github.com/ClickHouse/ClickHouse/pull/73556, available in ClickHouse v25.2

## Checklist
- [x] Unit and integration tests covering the common scenarios were added