### PR TITLE
fix: `database/sql` Nullable(JSON) string scan

### DIFF
--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -256,14 +256,13 @@ func (c *JSON) Row(row int, ptr bool) any {
 	case JSONObjectSerializationVersion:
 		return c.rowAsJSON(row)
 	case JSONStringSerializationVersion:
-		var str string
+		str := c.jsonStrings.Row(row, false).(string)
+		strBytes := binary.Str2Bytes(str, len(str))
 		if ptr {
-			str = *c.jsonStrings.Row(row, ptr).(*string)
-		} else {
-			str = c.jsonStrings.Row(row, ptr).(string)
+			return &strBytes
 		}
 
-		return binary.Str2Bytes(str, len(str))
+		return strBytes
 	default:
 		return nil
 	}


### PR DESCRIPTION
## Summary
The `ptr` boolean was being ignored in `JSON`'s `Row` function, which meant that `Nullable(JSON)` would fail to scan when using string serialization with `database/sql` interface. Very specific conditions, but it's fixed now.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added