### PR TITLE
Division by zero panic fix

### DIFF
--- a/lib/column/fixed_string.go
+++ b/lib/column/fixed_string.go
@@ -178,7 +178,11 @@ func (col *FixedString) Append(v any) (nulls []uint8, err error) {
 			return nil, err
 		}
 
-		nulls = make([]uint8, len(data)/col.col.Size)
+		if col.col.Size == 0 {
+			nulls = make([]uint8, 0)
+		} else {
+			nulls = make([]uint8, len(data)/col.col.Size)
+		}
 	case [][]byte:
 		nulls = make([]uint8, len(v))
 		for i, v := range v {


### PR DESCRIPTION
The Svace static analyzer (https://www.ispras.ru/en/technologies/svace/) flagged this code as suspicious: it could lead to a panic (division by zero) when data is empty.
