### PR TITLE
fix: SimpleAggregateFunction(anyLast, JSON)

### DIFF
--- a/lib/column/simple_aggregate_function.go
+++ b/lib/column/simple_aggregate_function.go
@@ -18,9 +18,11 @@
 package column
 
 import (
-	"github.com/ClickHouse/ch-go/proto"
+	"fmt"
 	"reflect"
 	"strings"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type SimpleAggregateFunction struct {
@@ -76,4 +78,25 @@ func (col *SimpleAggregateFunction) Encode(buffer *proto.Buffer) {
 	col.base.Encode(buffer)
 }
 
+func (col *SimpleAggregateFunction) ReadStatePrefix(reader *proto.Reader) error {
+	if serialize, ok := col.base.(CustomSerialization); ok {
+		if err := serialize.ReadStatePrefix(reader); err != nil {
+			return fmt.Errorf("failed to read prefix for SimpleAggregateFunction base type %s: %w", col.base.Type(), err)
+		}
+	}
+
+	return nil
+}
+
+func (col *SimpleAggregateFunction) WriteStatePrefix(buffer *proto.Buffer) error {
+	if serialize, ok := col.base.(CustomSerialization); ok {
+		if err := serialize.WriteStatePrefix(buffer); err != nil {
+			return fmt.Errorf("failed to write prefix for SimpleAggregateFunction base type %s: %w", col.base.Type(), err)
+		}
+	}
+
+	return nil
+}
+
 var _ Interface = (*SimpleAggregateFunction)(nil)
+var _ CustomSerialization = (*SimpleAggregateFunction)(nil)

--- a/tests/simple_aggregate_function_test.go
+++ b/tests/simple_aggregate_function_test.go
@@ -20,8 +20,9 @@ package tests
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
@@ -29,7 +30,9 @@ import (
 
 func TestSimpleAggregateFunction(t *testing.T) {
 	TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
-		conn, err := GetNativeConnection(t, protocol, nil, nil, &clickhouse.Compression{
+		conn, err := GetNativeConnection(t, protocol, clickhouse.Settings{
+			"allow_experimental_json_type": true,
+		}, nil, &clickhouse.Compression{
 			Method: clickhouse.CompressionLZ4,
 		})
 		ctx := context.Background()
@@ -43,6 +46,7 @@ func TestSimpleAggregateFunction(t *testing.T) {
 			  Col1 UInt64
 			, Col2 SimpleAggregateFunction(sum, Double)
 			, Col3 SimpleAggregateFunction(sumMap, Tuple(Array(Int16), Array(UInt64)))
+			, Col4 SimpleAggregateFunction(anyLast, JSON)
 		) Engine MergeTree() ORDER BY tuple()
 		`
 		defer func() {
@@ -58,18 +62,23 @@ func TestSimpleAggregateFunction(t *testing.T) {
 				[]int16{1, 2, 3, 4, 5},
 				[]uint64{1, 2, 3, 4, 5},
 			}
+			col4Data = map[string]any{
+				"str": "hello world",
+			}
 		)
-		require.NoError(t, batch.Append(col1Data, col2Data, col3Data))
+		require.NoError(t, batch.Append(col1Data, col2Data, col3Data, col4Data))
 		require.Equal(t, 1, batch.Rows())
 		require.NoError(t, batch.Send())
 		var result struct {
 			Col1 uint64
 			Col2 float64
 			Col3 []any
+			Col4 map[string]any
 		}
 		require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_simple_aggregate_function").ScanStruct(&result))
 		assert.Equal(t, col1Data, result.Col1)
 		assert.Equal(t, col2Data, result.Col2)
 		assert.Equal(t, col3Data, result.Col3)
+		assert.Equal(t, col4Data, result.Col4)
 	})
 }


### PR DESCRIPTION
# Why
Attempting to use a `SimpleAggregateFunction(anyLast, JSON)` column type fails through clickhouse-go.

# What
Implement the necessary `CustomSerialization` interface to transmit serialization version information to ClickHouse.

Fixes https://github.com/ClickHouse/clickhouse-go/issues/1644