### PR TITLE
bug: headers map can be nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## What's Changed
 ### Bug fixes 🐛 
 * fix: `database/sql` Nullable(JSON) string scan by @SpencerTorres in https://github.com/ClickHouse/clickhouse-go/pull/1625
+* fix: assignment to entry in nil map with HTTP protocol @r0bobo in https://github.com/ClickHouse/clickhouse-go/pull/1650
 
 
 **Full Changelog**: https://github.com/ClickHouse/clickhouse-go/compare/v2.40.0...v2.40.1

--- a/conn_http.go
+++ b/conn_http.go
@@ -540,6 +540,9 @@ func (h *httpConnect) prepareRequest(ctx context.Context, query string, options 
 }
 
 func (h *httpConnect) createRequestWithExternalTables(ctx context.Context, query string, options *QueryOptions, headers map[string]string) (*http.Request, error) {
+	if headers == nil {
+		headers = map[string]string{}
+	}
 	payload := &bytes.Buffer{}
 	w := multipart.NewWriter(payload)
 	currentUrl := new(url.URL)


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

The `func (h *httpConnect) createRequestWithExternalTables(ctx context.Context, query string, options *QueryOptions, headers map[string]string) (*http.Request, error)` function assumes that the headers map passed into is instantiated. 
When testing the http protocol in our system we get `panic: assignment to entry in nil map`  when doing writes.

This change instantiates the map if it's empty to avoid that.

## Checklist
Delete items not relevant to your PR:
- [x] A human-readable description of the changes was provided to include in CHANGELOG