### PR TITLE
chore: migrate to maintained YAML library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,8 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.38.0
 	go.opentelemetry.io/otel/trace v1.38.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/net v0.44.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require go.opentelemetry.io/otel v1.38.0 // indirect
@@ -74,4 +74,5 @@ require (
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	golang.org/x/crypto v0.42.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,8 @@ go.opentelemetry.io/otel/trace v1.38.0 h1:Fxk5bKrDZJUH+AMyyIXGcFAPah0oRcT+LuNtJr
 go.opentelemetry.io/otel/trace v1.38.0/go.mod h1:j1P9ivuFsTceSWe1oY+EeW3sc+Pp42sO++GHkg4wwhs=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/lib/proto/handshake.go
+++ b/lib/proto/handshake.go
@@ -20,7 +20,7 @@ package proto
 import (
 	"fmt"
 	chproto "github.com/ClickHouse/ch-go/proto"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"strconv"
 	"strings"
 	"time"

--- a/resources/meta.go
+++ b/resources/meta.go
@@ -20,7 +20,7 @@ package resources
 import (
 	_ "embed"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"strings"
 )
 


### PR DESCRIPTION
## Summary

The library `gopkg.in/yaml.v3` is unmaintained since 2025-04-01:

https://github.com/go-yaml/yaml#this-project-is-unmaintained

There's an official fork of the YAML project at https://github.com/yaml/go-yaml which works as a drop-in replacement and where the development will continue.

This change set replaces the old `gopkg.in/yaml.v3` with the new `go.yaml.in/yaml/v3`.

Please note that `gopkg.in/yaml.v3` is still being used in tests as an indirect dependency via `github.com/stretchr/testify/assert/yaml`.

```
❯ go mod why gopkg.in/yaml.v3
github.com/ClickHouse/clickhouse-go/v2/tests
github.com/stretchr/testify/assert
github.com/stretchr/testify/assert/yaml
gopkg.in/yaml.v3
```

See https://github.com/stretchr/testify/issues/1724 for the respective GitHub issue.

For the CHANGELOG (Other Changes):

> Replace unmaintained `gopkg.in/yaml.v3` with `go.yaml.in/yaml/v3`.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added (existing tests work without a change due to `go.yaml.in/yaml/v3` being a drop-in replacement)
- [x] A human-readable description of the changes was provided to include in CHANGELOG
