### PR TITLE
feat: add custom http transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # v2.40.3, 2025-09-13 <!-- Release notes generated using configuration in .github/release.yml at main -->
 
 ## What's Changed
+### Enhancements 🎉
+* Add option to set custom http transport @r0bobo in https://github.com/ClickHouse/clickhouse-go/pull/1656
+
 ### Other Changes 🛠
 * bug: deserializing into nullable field by @rbroggi in https://github.com/ClickHouse/clickhouse-go/pull/1649
 * Fixes for #1649 by @SpencerTorres in https://github.com/ClickHouse/clickhouse-go/pull/1654

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -168,6 +168,10 @@ type Options struct {
 	// to respond to a single Read call for bytes over the connection.
 	// Can be overridden with context.WithDeadline.
 	ReadTimeout time.Duration
+
+	// Set a custom transport for the http client.
+	// The default transport configured by the library is passed in as an argument.
+	TransportFunc func(*http.Transport) (http.RoundTripper, error)
 }
 
 func (o *Options) fromDSN(in string) error {

--- a/conn_http_test.go
+++ b/conn_http_test.go
@@ -1,0 +1,39 @@
+// Licensed to ClickHouse, Inc. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. ClickHouse, Inc. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package clickhouse
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestCreateHTTPRoundTripper(t *testing.T) {
+	transportFnCalled := false
+	_, err := createHTTPRoundTripper(&Options{
+		TransportFunc: func(t *http.Transport) (http.RoundTripper, error) {
+			transportFnCalled = true
+			return t, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("can not set up client: %s", err)
+	}
+	if !transportFnCalled {
+		t.Fatal("TransportFn not called")
+	}
+}


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

This makes it possible to set a custom transport for the underlying http client.

## Checklist
Delete items not relevant to your PR:
- [x] A human-readable description of the changes was provided to include in CHANGELOG