### PR TITLE
bug: Fix Nullable(JSON) with `nil` map

### DIFF
--- a/lib/column/nullable.go
+++ b/lib/column/nullable.go
@@ -1,4 +1,3 @@
-
 package column
 
 import (
@@ -131,7 +130,7 @@ func (col *Nullable) AppendRow(v any) error {
 		rv = reflect.ValueOf(v)
 	}
 
-	if v == nil || (rv.Kind() == reflect.Pointer && rv.IsNil()) {
+	if v == nil || ((rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Map) && rv.IsNil()) {
 		col.nulls.Append(1)
 		// used to detect sql.Null* types
 	} else if val, ok := v.(driver.Valuer); ok {

--- a/tests/issues/1638_test.go
+++ b/tests/issues/1638_test.go
@@ -1,0 +1,43 @@
+package issues
+
+import (
+	"context"
+	"testing"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue1638_NullableJSON(t *testing.T) {
+	ctx := context.Background()
+
+	conn, err := clickhouse_tests.GetConnectionTCP("issues", nil, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, err, "open clickhouse")
+
+	// Fresh table for the test.
+	_ = conn.Exec(ctx, `DROP TABLE IF EXISTS test_nullable_json`)
+	err = conn.Exec(ctx, `
+		CREATE TABLE test_nullable_json
+		(
+			id Int32,
+			payload Nullable(JSON)
+		)
+		ENGINE = MergeTree
+		ORDER BY (id)
+	`)
+	require.NoError(t, err, "create table")
+
+	batch, err := conn.PrepareBatch(ctx, `INSERT INTO test_nullable_json (id, payload) VALUES (?, ?)`)
+	require.NoError(t, err, "prepare batch")
+	var nilMap map[string]string
+	require.NoError(t, batch.Append(1, nilMap))
+	require.NoError(t, batch.Send(), "batch send")
+
+	var retrievedPayload map[string]string
+	err = conn.QueryRow(ctx, `SELECT payload FROM test_nullable_json WHERE id = 1`, 2).Scan(&retrievedPayload)
+	require.NoError(t, err, "select payload")
+
+	// retrievedPayload should be nil given we inserted NULL value
+	require.Nil(t, retrievedPayload, "payload for id=2 should be NULL (batched insert). Got: %#v", retrievedPayload)
+}


### PR DESCRIPTION
Fixes: #1638

The actual bug is in the `Nullable` [column here.](https://github.com/ClickHouse/clickhouse-go/blob/12088fe6b4a62f27e7cdb43d3bbebbcfccd9a5cb/lib/column/nullable.go?plain=1#L134-L136)

We check if the value is nil only if type is `reflect.Pointer`. In our case, it's `reflect.Map` (which can also be nil).

Following is verification using `clickhouse-client` with and without patch.

```
SELECT *
FROM test_nullable_json

Query id: 485b3606-fe0e-45e9-8719-f7a88e0daaf9

   ┌─id─┬─payload─┐
1. │  2 │ {}      │
   └────┴─────────┘

1 row in set. Elapsed: 0.006 sec.
```

```
SELECT *
FROM test_nullable_json

Query id: f626b8e0-e71e-4ec0-ad29-256903d4a348

   ┌─id─┬─payload─┐
1. │  2 │ ᴺᵁᴸᴸ    │
   └────┴─────────┘

1 row in set. Elapsed: 0.003 sec.
```

Notice how after the patch, the column value is populated correctly as `NULL`.

Also verified with original code in the description. We are able to get back the NULL column correctly as `nil` value. Locked the behavior via integration tests

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [x] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
