### PR TITLE
chore: Update contributing guide and docker compose stack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,8 @@
 
 The easiest way to run tests is to use Docker Compose:
 
-```
-docker-compose up
-make
+```bash
+make up
+make test
+make down
 ```

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CLICKHOUSE_TEST_TIMEOUT ?= 240s
 CLICKHOUSE_QUORUM_INSERT ?= 1
 
 up:
-	@docker compose up -d
+	@docker compose up --wait
 down:
 	@docker compose down
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
----
-version: '3.9'
 services:
   clickhouse:
     environment:
@@ -12,5 +10,18 @@ services:
       - 127.0.0.1:8123:8123
       - 127.0.0.1:9000:9000
       - 127.0.0.1:9009:9009
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:8123/ping",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 networks:
   clickhouse: null


### PR DESCRIPTION
## Summary

Updated the contributing docs to make it easier to contribute. `docker-compose` is v1, and you should use `docker compose` as in the makefile. Also added a health check to the compose stack and removed the deprecated `version` property
