### PR TITLE
bug: Fixes some correctness bug with ContextWatchdog

### DIFF
--- a/context_watchdog.go
+++ b/context_watchdog.go
@@ -1,10 +1,9 @@
-
 package clickhouse
 
 import "context"
 
 // contextWatchdog is a helper function to run a callback when the context is done.
-// it has a cancellation function to prevent the callback from running.
+// It has a cancellation function to prevent the callback from running.
 // Useful for interrupting some logic when the context is done,
 // but you want to not bother about context cancellation if your logic is already done.
 // Example:
@@ -15,17 +14,16 @@ func contextWatchdog(ctx context.Context, callback func()) (cancel func()) {
 	exit := make(chan struct{})
 
 	go func() {
-		for {
-			select {
-			case <-exit:
-				return
-			case <-ctx.Done():
-				callback()
-			}
+		select {
+		case <-exit:
+			return
+		case <-ctx.Done():
+			callback()
+			return
 		}
 	}()
 
 	return func() {
-		exit <- struct{}{}
+		close(exit)
 	}
 }

--- a/context_watchdog_test.go
+++ b/context_watchdog_test.go
@@ -1,3 +1,5 @@
+//go:build go1.25
+
 package clickhouse
 
 import (
@@ -48,10 +50,6 @@ func TestContextWatchdog(t *testing.T) {
 	})
 
 	t.Run("No goroutines should be left out after stopping ContextWatchdog", func(t *testing.T) {
-		if isGo124OrLess(t) {
-			t.Skipf("Skipping test as it involves incompatible Go version %s to use `synctest` package", runtime.Version())
-		}
-
 		synctest.Test(t, func(t *testing.T) {
 			// when context is cancelled
 			called := atomic.Int32{}
@@ -91,26 +89,4 @@ func TestContextWatchdog(t *testing.T) {
 			synctest.Wait()
 		})
 	})
-}
-
-func isGo124OrLess(t *testing.T) bool {
-	t.Helper()
-
-	// always in "go1.[minor]" format.
-	v := runtime.Version()
-	parts := strings.FieldsFunc(v, func(r rune) bool {
-		return r == '.'
-	})
-
-	if len(parts) != 2 {
-		return false
-	}
-
-	minor, err := strconv.Atoi(parts[0])
-	assert.NoError(t, err)
-	if minor <= 24 {
-		return true
-	}
-
-	return false
 }

--- a/context_watchdog_test.go
+++ b/context_watchdog_test.go
@@ -1,0 +1,89 @@
+package clickhouse
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContextWatchdog(t *testing.T) {
+	t.Run("callback should be called once", func(t *testing.T) {
+		called := atomic.Int32{}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		stopCW := contextWatchdog(ctx, func() {
+			called.Add(1)
+		})
+
+		<-ctx.Done()
+
+		// Give it some more time to make sure watch dog has enough time to
+		// call callback multiple times
+		time.Sleep(100 * time.Millisecond)
+		assert.Equal(t, int32(1), called.Load(), "callback should be called only once")
+
+		stopCW()
+		assert.Equal(t, int32(1), called.Load(), "callback should be called only once even after stopping watchdog")
+	})
+
+	t.Run("callback should not be called during normal exit before context cancellation", func(t *testing.T) {
+		called := atomic.Int32{}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		stopCW := contextWatchdog(ctx, func() {
+			called.Add(1)
+		})
+		stopCW() // normal exit
+
+		assert.Equal(t, int32(0), called.Load(), "callback should not be called during normal exit")
+	})
+
+	t.Run("No goroutines should be left out after stopping ContextWatchdog", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			// when context is cancelled
+			called := atomic.Int32{}
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+			defer cancel()
+
+			stopCW := contextWatchdog(ctx, func() {
+				called.Add(1)
+			})
+
+			<-ctx.Done()
+
+			// Give it some more time to make sure watch dog has enough time to
+			// call callback multiple times
+			time.Sleep(100 * time.Millisecond)
+			assert.Equal(t, int32(1), called.Load(), "callback should be called only once")
+
+			stopCW()
+			assert.Equal(t, int32(1), called.Load(), "callback should be called only once even after stopping watchdog")
+
+			synctest.Wait()
+		})
+
+		synctest.Test(t, func(t *testing.T) {
+			// during normal exit
+			called := atomic.Int32{}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			stopCW := contextWatchdog(ctx, func() {
+				called.Add(1)
+			})
+			stopCW() // normal exit
+
+			assert.Equal(t, int32(0), called.Load(), "callback should not be called during normal exit")
+
+			synctest.Wait()
+		})
+	})
+
+	// No goroutines should be left out after stopping context watch dog
+}

--- a/context_watchdog_test.go
+++ b/context_watchdog_test.go
@@ -2,6 +2,9 @@ package clickhouse
 
 import (
 	"context"
+	"runtime"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
@@ -45,6 +48,10 @@ func TestContextWatchdog(t *testing.T) {
 	})
 
 	t.Run("No goroutines should be left out after stopping ContextWatchdog", func(t *testing.T) {
+		if isGo124OrLess(t) {
+			t.Skipf("Skipping test as it involves incompatible Go version %s to use `synctest` package", runtime.Version())
+		}
+
 		synctest.Test(t, func(t *testing.T) {
 			// when context is cancelled
 			called := atomic.Int32{}
@@ -84,6 +91,26 @@ func TestContextWatchdog(t *testing.T) {
 			synctest.Wait()
 		})
 	})
+}
 
-	// No goroutines should be left out after stopping context watch dog
+func isGo124OrLess(t *testing.T) bool {
+	t.Helper()
+
+	// always in "go1.[minor]" format.
+	v := runtime.Version()
+	parts := strings.FieldsFunc(v, func(r rune) bool {
+		return r == '.'
+	})
+
+	if len(parts) != 2 {
+		return false
+	}
+
+	minor, err := strconv.Atoi(parts[0])
+	assert.NoError(t, err)
+	if minor <= 24 {
+		return true
+	}
+
+	return false
 }

--- a/context_watchdog_test.go
+++ b/context_watchdog_test.go
@@ -4,9 +4,6 @@ package clickhouse
 
 import (
 	"context"
-	"runtime"
-	"strconv"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
1. We don't need infinite for loop to call the callback once context timeout
2. Currently callback will be called multiple times even after context is cancelled. This PR fixes and block the behavior with tests to make sure callback is called only once.
3. Make sure the goroutine started by watchdog exits at all cases without any leaking

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
