### PR TITLE
chore: Upgrade Go toolchain to 1.25.x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/ClickHouse/clickhouse-go/v2
 
-go 1.24.0
-
-toolchain go1.24.1
+go 1.25.3
 
 require (
 	github.com/ClickHouse/ch-go v0.69.0


### PR DESCRIPTION

## Summary
<!-- A short description of the changes with a link to an open issue. -->
Main goal is to be able to use `synctest` package to capture some goroutine leaks bugs

It is experemental in v1.24 and becomes part of standard library in v1.25.
https://go.dev/blog/synctest

So that we remove build tags from this these tests.
https://github.com/ClickHouse/clickhouse-go/pull/1688/files#r2435808409

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
