### PR TITLE
chore: Async inserts docs and example updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,16 +321,17 @@ Usage examples for [native API](examples/clickhouse_api/client_info.go) and [dat
 
 ## Async insert
 
-[Asynchronous insert](https://clickhouse.com/docs/en/optimize/asynchronous-inserts#enabling-asynchronous-inserts) is supported via dedicated `AsyncInsert` method. This allows to insert data with a non-blocking call.
-Effectively, it controls a `async_insert` setting for the query. 
+[Async insert](https://clickhouse.com/docs/optimize/asynchronous-inserts) is supported via `WithAsync()` helper on both Native and HTTP protocols. You can use it for both Go standard interface `OpenDB` and also ClickHouse interface `Open()`.
 
-### Using with batch API
+**NOTE**: You can use `WithSettings()` manually to add any async related settings. `WithAsync()` is just a simple wrapper that does that for you.
 
-Using native protocol, asynchronous insert does not support batching. It means, only inline query data is supported. Please see an example [here](examples/std/async.go).
+We have following examples to show Async Insert in action.
+1. [Native with OpenDB](examples/clickhouse_api/async_native.go)
+1. [HTTP with OpenDB](examples/clickhouse_api/async_http.go)
+1. [Native with Open](examples/std/async_native.go)
+1. [HTTP with Open](examples/std/async_http.go)
 
-HTTP protocol supports batching. It can be enabled by setting `async_insert` when using standard `Prepare` method.
-
-For more details please see [asynchronous inserts](https://clickhouse.com/docs/en/optimize/asynchronous-inserts#enabling-asynchronous-inserts) documentation.
+**NOTE**: The old `AsyncInsert()` api is deprecated and will be removed in future versions. We highly recommend to use `WithAsync()` api for all the Async Insert use cases.
 
 ## PrepareBatch options
 

--- a/benchmark/v2/write-async/main.go
+++ b/benchmark/v2/write-async/main.go
@@ -1,4 +1,3 @@
-
 package main
 
 import (
@@ -22,8 +21,10 @@ CREATE TABLE benchmark_async (
 func benchmark(conn clickhouse.Conn) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+
+	ctx = clickhouse.Context(ctx, clickhouse.WithAsync(true))
 	for i := 0; i < 10_000; i++ {
-		err := conn.AsyncInsert(ctx, fmt.Sprintf(`INSERT INTO benchmark_async VALUES (
+		err := conn.Exec(ctx, fmt.Sprintf(`INSERT INTO benchmark_async VALUES (
 			%d, '%s', [1, 2, 3, 4, 5, 6, 7, 8, 9], now()
 		)`, i, "Golang SQL database driver"), false)
 		if err != nil {

--- a/conn_async_insert.go
+++ b/conn_async_insert.go
@@ -1,8 +1,8 @@
-
 package clickhouse
 
 import (
 	"context"
+
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 

--- a/context.go
+++ b/context.go
@@ -1,4 +1,3 @@
-
 package clickhouse
 
 import (
@@ -157,6 +156,14 @@ func WithExternalTable(t ...*ext.Table) QueryOption {
 	}
 }
 
+func WithAsync(wait bool) QueryOption {
+	return func(o *QueryOptions) error {
+		o.async.ok, o.async.wait = true, wait
+		return nil
+	}
+}
+
+// Deprecated: use `WithAsync` instead.
 func WithStdAsync(wait bool) QueryOption {
 	return func(o *QueryOptions) error {
 		o.async.ok, o.async.wait = true, wait

--- a/examples/clickhouse_api/async_native.go
+++ b/examples/clickhouse_api/async_native.go
@@ -1,0 +1,48 @@
+package clickhouse_api
+
+import (
+	"context"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+)
+
+func AsyncInsertNative() error {
+	conn, err := GetNativeConnection(nil, nil, nil)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	if !clickhouse_tests.CheckMinServerServerVersion(conn, 21, 12, 0) {
+		return nil
+	}
+	defer func() {
+		conn.Exec(ctx, "DROP TABLE example")
+	}()
+	conn.Exec(ctx, `DROP TABLE IF EXISTS example`)
+	const ddl = `
+		CREATE TABLE example (
+			  Col1 UInt64
+			, Col2 String
+			, Col3 Array(UInt8)
+			, Col4 DateTime
+		) ENGINE = Memory
+	`
+
+	if err := conn.Exec(ctx, ddl); err != nil {
+		return err
+	}
+
+	ctx = clickhouse.Context(ctx, clickhouse.WithAsync(false))
+	{
+		for i := 0; i < 100; i++ {
+			err := conn.Exec(ctx, `INSERT INTO example VALUES (
+				?, ?, ?, now()
+			)`, i, "Golang SQL database driver", []uint8{1, 2, 3, 4, 5, 6, 7, 8, 9})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/examples/clickhouse_api/main_test.go
+++ b/examples/clickhouse_api/main_test.go
@@ -1,4 +1,3 @@
-
 package clickhouse_api
 
 import (
@@ -57,7 +56,8 @@ func TestArrayInsertRead(t *testing.T) {
 }
 
 func TestAsyncInsert(t *testing.T) {
-	require.NoError(t, AsyncInsert())
+	require.NoError(t, AsyncInsertNative())
+	require.NoError(t, AsyncInsertHTTP())
 }
 
 func TestBatchInsert(t *testing.T) {

--- a/examples/clickhouse_api/utils.go
+++ b/examples/clickhouse_api/utils.go
@@ -1,19 +1,23 @@
-
 package clickhouse_api
 
 import (
 	"crypto/tls"
+	"math/rand"
+	"time"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"math/rand"
-	"time"
 )
 
 const TestSet string = "examples_clickhouse_api"
 
 func GetNativeConnection(settings clickhouse.Settings, tlsConfig *tls.Config, compression *clickhouse.Compression) (driver.Conn, error) {
 	return clickhouse_tests.GetConnectionTCP(TestSet, settings, tlsConfig, compression)
+}
+
+func GetHTTPConnection(sessionName string, settings clickhouse.Settings, tlsConfig *tls.Config, compression *clickhouse.Compression) (driver.Conn, error) {
+	return clickhouse_tests.GetConnectionHTTP(TestSet, sessionName, settings, tlsConfig, compression)
 }
 
 func GetNativeTestEnvironment() (clickhouse_tests.ClickHouseTestEnvironment, error) {

--- a/examples/std/async_http.go
+++ b/examples/std/async_http.go
@@ -1,0 +1,39 @@
+package std
+
+import (
+	"context"
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+func AsyncInsertHTTP() error {
+	conn, err := GetStdOpenDBConnection(clickhouse.HTTP, nil, nil, nil)
+	if err != nil {
+		return err
+	}
+	if _, err := conn.Exec(`DROP TABLE IF EXISTS example`); err != nil {
+		return err
+	}
+	const ddl = `
+		CREATE TABLE example (
+			  Col1 UInt64
+			, Col2 String
+			, Col3 Array(UInt8)
+			, Col4 DateTime
+		) ENGINE = Memory
+		`
+	if _, err := conn.Exec(ddl); err != nil {
+		return err
+	}
+	ctx := clickhouse.Context(context.Background(), clickhouse.WithAsync(false))
+	{
+		for i := 0; i < 100; i++ {
+			_, err := conn.ExecContext(ctx, `INSERT INTO example VALUES (
+				?, ?, ?, now()
+			)`, i, "Golang SQL database driver", []uint8{1, 2, 3, 4, 5, 6, 7, 8, 9})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/examples/std/async_http.go
+++ b/examples/std/async_http.go
@@ -2,6 +2,8 @@ package std
 
 import (
 	"context"
+	"time"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
@@ -33,6 +35,41 @@ func AsyncInsertHTTP() error {
 			if err != nil {
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+func AsyncInsertHTTP_WithPrepare() error {
+	conn, err := GetStdOpenDBConnection(clickhouse.HTTP, nil, nil, nil)
+	if err != nil {
+		return err
+	}
+	if _, err := conn.Exec(`DROP TABLE IF EXISTS example`); err != nil {
+		return err
+	}
+	const ddl = `
+		CREATE TABLE example (
+			  Col1 UInt64
+			, Col2 String
+			, Col3 Array(UInt8)
+			, Col4 DateTime
+		) ENGINE = Memory
+		`
+	if _, err := conn.Exec(ddl); err != nil {
+		return err
+	}
+	ctx := clickhouse.Context(context.Background(), clickhouse.WithAsync(false))
+
+	s, err := conn.PrepareContext(ctx, `INSERT INTO example VALUES (?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < 100; i++ {
+		_, err := s.ExecContext(ctx, i, "Golang SQL database driver", []uint8{1, 2, 3, 4, 5, 6, 7, 8, 9}, time.Now())
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/examples/std/async_native.go
+++ b/examples/std/async_native.go
@@ -2,6 +2,8 @@ package std
 
 import (
 	"context"
+	"time"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
@@ -30,6 +32,43 @@ func AsyncInsertNative() error {
 			_, err := conn.ExecContext(ctx, `INSERT INTO example VALUES (
 				?, ?, ?, now()
 			)`, i, "Golang SQL database driver", []uint8{1, 2, 3, 4, 5, 6, 7, 8, 9})
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func AsyncInsertNative_WithPrepare() error {
+	conn, err := GetStdOpenDBConnection(clickhouse.Native, nil, nil, nil)
+	if err != nil {
+		return err
+	}
+	if _, err := conn.Exec(`DROP TABLE IF EXISTS example`); err != nil {
+		return err
+	}
+	const ddl = `
+		CREATE TABLE example (
+			  Col1 UInt64
+			, Col2 String
+			, Col3 Array(UInt8)
+			, Col4 DateTime
+		) ENGINE = Memory
+		`
+	if _, err := conn.Exec(ddl); err != nil {
+		return err
+	}
+
+	s, err := conn.Prepare(`INSERT INTO example VALUES (?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+
+	ctx := clickhouse.Context(context.Background(), clickhouse.WithAsync(false))
+	{
+		for i := 0; i < 100; i++ {
+			_, err := s.ExecContext(ctx, i, "Golang SQL database driver", []uint8{1, 2, 3, 4, 5, 6, 7, 8, 9}, time.Now())
 			if err != nil {
 				return err
 			}

--- a/examples/std/async_native.go
+++ b/examples/std/async_native.go
@@ -1,4 +1,3 @@
-
 package std
 
 import (
@@ -6,7 +5,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
-func AsyncInsert() error {
+func AsyncInsertNative() error {
 	conn, err := GetStdOpenDBConnection(clickhouse.Native, nil, nil, nil)
 	if err != nil {
 		return err
@@ -25,7 +24,7 @@ func AsyncInsert() error {
 	if _, err := conn.Exec(ddl); err != nil {
 		return err
 	}
-	ctx := clickhouse.Context(context.Background(), clickhouse.WithStdAsync(false))
+	ctx := clickhouse.Context(context.Background(), clickhouse.WithAsync(false))
 	{
 		for i := 0; i < 100; i++ {
 			_, err := conn.ExecContext(ctx, `INSERT INTO example VALUES (

--- a/examples/std/main_test.go
+++ b/examples/std/main_test.go
@@ -89,7 +89,9 @@ func TestStdQueryWithParameters(t *testing.T) {
 
 func TestStdAsyncInsert(t *testing.T) {
 	require.NoError(t, AsyncInsertNative())
+	require.NoError(t, AsyncInsertNative_WithPrepare())
 	require.NoError(t, AsyncInsertHTTP())
+	require.NoError(t, AsyncInsertHTTP_WithPrepare())
 }
 
 func TestStdMapInsertRead(t *testing.T) {

--- a/examples/std/main_test.go
+++ b/examples/std/main_test.go
@@ -1,4 +1,3 @@
-
 package std
 
 import (
@@ -89,7 +88,8 @@ func TestStdQueryWithParameters(t *testing.T) {
 }
 
 func TestStdAsyncInsert(t *testing.T) {
-	require.NoError(t, AsyncInsert())
+	require.NoError(t, AsyncInsertNative())
+	require.NoError(t, AsyncInsertHTTP())
 }
 
 func TestStdMapInsertRead(t *testing.T) {

--- a/lib/driver/driver.go
+++ b/lib/driver/driver.go
@@ -1,4 +1,3 @@
-
 package driver
 
 import (
@@ -41,6 +40,8 @@ type (
 		QueryRow(ctx context.Context, query string, args ...any) Row
 		PrepareBatch(ctx context.Context, query string, opts ...PrepareBatchOption) (Batch, error)
 		Exec(ctx context.Context, query string, args ...any) error
+
+		// Deprecated: use context aware `WithAsync()` for any async operations
 		AsyncInsert(ctx context.Context, query string, wait bool, args ...any) error
 		Ping(context.Context) error
 		Stats() Stats


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Previously it was confusing (1) how to use async inserts (2) what kind of interfaces supports async inserts.

This PR address both. Changes
1. Deprecate `WithStdAsync` and prefer new `WithAsync`
2. Deprecate `AsyncInsert()` api and prefer new `WithAsync`
3. Add more examples for all possible cases
4. Update README

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
