### PR TITLE
Set HttpUrlPath from DSN to resolve missing path in HTTP requests

### DIFF
--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -1,4 +1,3 @@
-
 package clickhouse
 
 import (
@@ -319,6 +318,12 @@ func (o *Options) fromDSN(in string) error {
 				return fmt.Errorf("clickhouse [dsn parse]: http_proxy: %s", err)
 			}
 			o.HTTPProxyURL = proxyURL
+		case "http_path":
+			path := params.Get(v)
+			if path != "" && !strings.HasPrefix(path, "/") {
+				path = "/" + path
+			}
+			o.HttpUrlPath = path
 		default:
 			switch p := strings.ToLower(params.Get(v)); p {
 			case "true":

--- a/clickhouse_options_test.go
+++ b/clickhouse_options_test.go
@@ -1,4 +1,3 @@
-
 package clickhouse
 
 import (
@@ -478,6 +477,24 @@ func TestParseDSN(t *testing.T) {
 					Database: `bla`,
 				},
 				scheme: "tcp",
+			},
+			"",
+		},
+		{
+			"http protocol with custom http_path",
+			"https://127.0.0.1/clickhouse?secure=true&skip_verify=true&http_path=/clickhouse",
+			&Options{
+				Protocol: HTTP,
+				TLS: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+				Addr:     []string{"127.0.0.1"},
+				Settings: Settings{},
+				Auth: Auth{
+					Database: "clickhouse",
+				},
+				HttpUrlPath: "/clickhouse",
+				scheme:      "https",
 			},
 			"",
 		},


### PR DESCRIPTION
## Summary
This PR fixes an issue where HttpUrlPath was not set from the DSN, which caused problems when using ClickHouse behind a reverse proxy.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
