### PR TITLE
chore: Improve EOF error messages.

### DIFF
--- a/conn_error_context_test.go
+++ b/conn_error_context_test.go
@@ -1,0 +1,308 @@
+package clickhouse
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/ch-go/compress"
+	chproto "github.com/ClickHouse/ch-go/proto"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockNetConn is a mock net.Conn that can be configured to return specific errors
+type mockNetConn struct {
+	net.Conn
+	readErr  error
+	writeErr error
+	closed   bool
+}
+
+func (m *mockNetConn) Read(b []byte) (n int, err error) {
+	if m.readErr != nil {
+		return 0, m.readErr
+	}
+	return 0, io.EOF
+}
+
+func (m *mockNetConn) Write(b []byte) (n int, err error) {
+	if m.writeErr != nil {
+		return 0, m.writeErr
+	}
+	return len(b), nil
+}
+
+func (m *mockNetConn) Close() error {
+	m.closed = true
+	return nil
+}
+
+func (m *mockNetConn) LocalAddr() net.Addr {
+	return &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345}
+}
+
+func (m *mockNetConn) RemoteAddr() net.Addr {
+	return &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 9000}
+}
+
+func (m *mockNetConn) SetDeadline(t time.Time) error      { return nil }
+func (m *mockNetConn) SetReadDeadline(t time.Time) error  { return nil }
+func (m *mockNetConn) SetWriteDeadline(t time.Time) error { return nil }
+
+// createMockConnect creates a connect instance with mock components for testing
+func createMockConnect(mockConn *mockNetConn) *connect {
+	reader := chproto.NewReader(mockConn)
+	buffer := new(chproto.Buffer)
+	compressor := &compress.Writer{}
+
+	return &connect{
+		id:                   1,
+		conn:                 mockConn,
+		buffer:               buffer,
+		reader:               reader,
+		connectedAt:          time.Now().Add(-5 * time.Minute),
+		readTimeout:          10 * time.Second,
+		compression:          CompressionLZ4,
+		compressor:           compressor,
+		maxCompressionBuffer: 1024 * 1024,
+		debugfFunc:           func(format string, v ...any) {},
+		opt:                  &Options{},
+		revision:             ClientTCPProtocolVersion,
+	}
+}
+
+// TestHandshakeErrorContext tests that handshake errors include server address and connection info
+func TestHandshakeErrorContext(t *testing.T) {
+	mockConn := &mockNetConn{readErr: io.EOF}
+	conn := createMockConnect(mockConn)
+
+	err := conn.handshake(Auth{
+		Database: "default",
+		Username: "default",
+		Password: "",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "handshake")
+	assert.Contains(t, err.Error(), "127.0.0.1:9000", "should contain server address")
+	assert.Contains(t, err.Error(), "conn_id=1", "should contain connection ID")
+	assert.Contains(t, err.Error(), "auth_db=default", "should contain database name")
+	assert.True(t, errors.Is(err, io.EOF), "should wrap io.EOF")
+}
+
+// TestQueryProcessingErrorContext tests that query processing errors include connection info
+func TestQueryProcessingErrorContext(t *testing.T) {
+	mockConn := &mockNetConn{readErr: io.EOF}
+	conn := createMockConnect(mockConn)
+
+	_, err := conn.firstBlockImpl(context.Background(), &onProcess{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query processing")
+	assert.Contains(t, err.Error(), "127.0.0.1:9000", "should contain server address")
+	assert.Contains(t, err.Error(), "conn_id=1", "should contain connection ID")
+	assert.True(t, errors.Is(err, io.EOF), "should wrap io.EOF")
+}
+
+// TestPingErrorContext tests that ping errors include connection age and connection info
+func TestPingErrorContext(t *testing.T) {
+	mockConn := &mockNetConn{readErr: io.EOF}
+	conn := createMockConnect(mockConn)
+
+	// First flush succeeds (mocked Write), then read fails
+	mockConn.writeErr = nil // Allow flush to succeed
+	err := conn.ping(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ping")
+	assert.Contains(t, err.Error(), "127.0.0.1:9000", "should contain server address")
+	assert.Contains(t, err.Error(), "conn_id=1", "should contain connection ID")
+	assert.Contains(t, err.Error(), "age=", "should contain connection age")
+	assert.True(t, errors.Is(err, io.EOF), "should wrap io.EOF")
+}
+
+// TestReadDataErrorContext tests that read data errors include connection and compression info
+func TestReadDataErrorContext(t *testing.T) {
+	mockConn := &mockNetConn{readErr: io.EOF}
+	conn := createMockConnect(mockConn)
+
+	_, err := conn.readData(context.Background(), proto.ServerData, false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read data")
+	assert.Contains(t, err.Error(), "127.0.0.1:9000", "should contain server address")
+	assert.Contains(t, err.Error(), "conn_id=1", "should contain connection ID")
+	assert.True(t, errors.Is(err, io.EOF), "should wrap io.EOF")
+}
+
+// TestSendDataErrorContext tests that send data errors include block information
+func TestSendDataErrorContext(t *testing.T) {
+	mockConn := &mockNetConn{writeErr: io.EOF}
+	conn := createMockConnect(mockConn)
+
+	// Create a simple block with columns for testing
+	block := proto.NewBlock()
+	_ = block.AddColumn("col1", "UInt64")
+	_ = block.AddColumn("col2", "String")
+
+	err := conn.sendData(block, "test")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "send data")
+	assert.Contains(t, err.Error(), "127.0.0.1:9000", "should contain server address")
+	assert.Contains(t, err.Error(), "conn_id=1", "should contain connection ID")
+	assert.Contains(t, err.Error(), "block_cols=2", "should contain block column count")
+	assert.Contains(t, err.Error(), "block_rows=", "should contain block row count")
+	assert.True(t, errors.Is(err, io.EOF), "should wrap io.EOF")
+}
+
+// TestErrorContextPreservesEOF tests that all error wrappers preserve io.EOF for errors.Is
+func TestErrorContextPreservesEOF(t *testing.T) {
+	testCases := []struct {
+		name     string
+		testFunc func(*connect) error
+	}{
+		{
+			name: "handshake",
+			testFunc: func(c *connect) error {
+				return c.handshake(Auth{Database: "default"})
+			},
+		},
+		{
+			name: "ping",
+			testFunc: func(c *connect) error {
+				return c.ping(context.Background())
+			},
+		},
+		{
+			name: "firstBlock",
+			testFunc: func(c *connect) error {
+				_, err := c.firstBlockImpl(context.Background(), &onProcess{})
+				return err
+			},
+		},
+		{
+			name: "readData",
+			testFunc: func(c *connect) error {
+				_, err := c.readData(context.Background(), proto.ServerData, false)
+				return err
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockConn := &mockNetConn{readErr: io.EOF}
+			conn := createMockConnect(mockConn)
+
+			err := tc.testFunc(conn)
+
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, io.EOF),
+				"error from %s should preserve io.EOF for errors.Is check", tc.name)
+
+			// Also verify the error is not bare io.EOF
+			assert.NotEqual(t, io.EOF, err,
+				"error from %s should be wrapped, not bare io.EOF", tc.name)
+
+			// Verify error message has context
+			assert.NotEqual(t, "EOF", err.Error(),
+				"error from %s should have context beyond just 'EOF'", tc.name)
+		})
+	}
+}
+
+// TestErrorContextDistinguishesOperations tests that different operations produce distinguishable errors
+func TestErrorContextDistinguishesOperations(t *testing.T) {
+	mockConn := &mockNetConn{readErr: io.EOF}
+
+	operations := map[string]func(*connect) error{
+		"handshake": func(c *connect) error {
+			return c.handshake(Auth{Database: "default"})
+		},
+		"ping": func(c *connect) error {
+			return c.ping(context.Background())
+		},
+		"query processing": func(c *connect) error {
+			_, err := c.firstBlockImpl(context.Background(), &onProcess{})
+			return err
+		},
+		"read data": func(c *connect) error {
+			_, err := c.readData(context.Background(), proto.ServerData, false)
+			return err
+		},
+	}
+
+	errorMessages := make(map[string]string)
+
+	for opName, opFunc := range operations {
+		conn := createMockConnect(mockConn)
+		err := opFunc(conn)
+		require.Error(t, err, "operation %s should return error", opName)
+		errorMessages[opName] = err.Error()
+	}
+
+	// Verify all error messages are unique and contain the operation name
+	for opName, errMsg := range errorMessages {
+		assert.Contains(t, strings.ToLower(errMsg), strings.ToLower(opName),
+			"error message should identify the operation: %s", opName)
+
+		// Verify this error is different from all others
+		for otherOp, otherMsg := range errorMessages {
+			if opName != otherOp {
+				assert.NotEqual(t, errMsg, otherMsg,
+					"error messages for %s and %s should be different", opName, otherOp)
+			}
+		}
+	}
+}
+
+// TestIsConnBrokenErrorDetectsEOF tests that isConnBrokenError still detects EOF errors
+func TestIsConnBrokenErrorDetectsEOF(t *testing.T) {
+	mockConn := &mockNetConn{readErr: io.EOF}
+	conn := createMockConnect(mockConn)
+
+	// Test various wrapped EOF errors
+	testCases := []struct {
+		name     string
+		getError func(*connect) error
+	}{
+		{
+			name: "handshake EOF",
+			getError: func(c *connect) error {
+				return c.handshake(Auth{Database: "default"})
+			},
+		},
+		{
+			name: "ping EOF",
+			getError: func(c *connect) error {
+				return c.ping(context.Background())
+			},
+		},
+		{
+			name: "query processing EOF",
+			getError: func(c *connect) error {
+				_, err := c.firstBlockImpl(context.Background(), &onProcess{})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.getError(conn)
+			require.Error(t, err)
+
+			// Verify that isConnBrokenError correctly identifies these as connection errors
+			isBroken := isConnBrokenError(err)
+			assert.True(t, isBroken,
+				"isConnBrokenError should detect wrapped EOF from %s", tc.name)
+		})
+	}
+}

--- a/conn_handshake.go
+++ b/conn_handshake.go
@@ -31,20 +31,23 @@ func (c *connect) handshake(auth Auth) error {
 			c.buffer.PutString(auth.Password)
 		}
 		if err := c.flush(); err != nil {
-			return err
+			return fmt.Errorf("handshake: failed to send hello to %s (conn_id=%d): %w",
+				c.conn.RemoteAddr(), c.id, err)
 		}
 	}
 	{
 		packet, err := c.reader.ReadByte()
 		if err != nil {
-			return err
+			return fmt.Errorf("handshake: failed to read packet from %s (conn_id=%d, auth_db=%s): %w",
+				c.conn.RemoteAddr(), c.id, auth.Database, err)
 		}
 		switch packet {
 		case proto.ServerException:
 			return c.exception()
 		case proto.ServerHello:
 			if err := c.server.Decode(c.reader); err != nil {
-				return err
+				return fmt.Errorf("handshake: failed to decode server hello from %s (conn_id=%d): %w",
+					c.conn.RemoteAddr(), c.id, err)
 			}
 		case proto.ServerEndOfStream:
 			c.debugf("[handshake] <- end of stream")

--- a/conn_ping.go
+++ b/conn_ping.go
@@ -22,13 +22,15 @@ func (c *connect) ping(ctx context.Context) (err error) {
 	c.debugf("[ping] -> ping")
 	c.buffer.PutByte(proto.ClientPing)
 	if err := c.flush(); err != nil {
-		return err
+		return fmt.Errorf("ping: failed to send ping to %s (conn_id=%d): %w",
+			c.conn.RemoteAddr(), c.id, err)
 	}
 
 	var packet byte
 	for {
 		if packet, err = c.reader.ReadByte(); err != nil {
-			return err
+			return fmt.Errorf("ping: failed to read packet from %s (conn_id=%d, age=%s): %w",
+				c.conn.RemoteAddr(), c.id, time.Since(c.connectedAt).Round(time.Second), err)
 		}
 		switch packet {
 		case proto.ServerException:

--- a/conn_process.go
+++ b/conn_process.go
@@ -67,7 +67,8 @@ func (c *connect) firstBlockImpl(ctx context.Context, on *onProcess) (*proto.Blo
 
 		packet, err := c.reader.ReadByte()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("query processing: failed to read first block packet from %s (conn_id=%d): %w",
+				c.conn.RemoteAddr(), c.id, err)
 		}
 
 		switch packet {
@@ -140,7 +141,8 @@ func (c *connect) processImpl(ctx context.Context, on *onProcess) error {
 
 		packet, err := c.reader.ReadByte()
 		if err != nil {
-			return err
+			return fmt.Errorf("query processing: failed to read packet from %s (conn_id=%d): %w",
+				c.conn.RemoteAddr(), c.id, err)
 		}
 
 		switch packet {


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
**Before:** most of the exit points in this PR returns either `EOF`  or `read: EOF` without much context

**After:** These errors are written with more context. e.g: handsake failure, ping failure, reading block failure, etc. Along with more info like connection-id, remote-address, etc.

```
"send data: connection broken (EPIPE) to 127.0.0.1 (conn_id=3, block_cols=45, block_rows=77): read: EOF"

"handshake: failed to send hello to 127.0.0.1 (conn_id=5): read: EOF",

"ping: failed to send ping to 127.0.0.1 (conn_id=8): read: EOF"
```

We also make sure, we wrap the original error `io.EOF` so that consumer can still use helpers like errors.Is(err, io.EOF) without any problem.

**Although one caveat is if any users where trying to use the actual error message like `err.Error() == "read: EOF"` that would fail now.**

Related: #1464 
## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
