### PR TITLE
bug: Fix `formatTime` escaping

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -252,10 +252,14 @@ func formatTime(tz *time.Location, scale TimeUnit, value time.Time) (string, err
 		}
 		return fmt.Sprintf("toDateTime64('%s', %d)", value.Format(fmt.Sprintf("2006-01-02 15:04:05.%0*d", int(scale*3), 0)), int(scale*3)), nil
 	}
+
+	// Escape the timezone string (timezone may contain malicious SQL query)
+	escapedTimezone := stringQuoteReplacer.Replace(value.Location().String())
+	// escapedTimezone := value.Location().String()
 	if scale == Seconds {
-		return fmt.Sprintf("toDateTime('%s', '%s')", value.Format("2006-01-02 15:04:05"), value.Location().String()), nil
+		return fmt.Sprintf("toDateTime('%s', '%s')", value.Format("2006-01-02 15:04:05"), escapedTimezone), nil
 	}
-	return fmt.Sprintf("toDateTime64('%s', %d, '%s')", value.Format(fmt.Sprintf("2006-01-02 15:04:05.%0*d", int(scale*3), 0)), int(scale*3), value.Location().String()), nil
+	return fmt.Sprintf("toDateTime64('%s', %d, '%s')", value.Format(fmt.Sprintf("2006-01-02 15:04:05.%0*d", int(scale*3), 0)), int(scale*3), escapedTimezone), nil
 }
 
 var stringQuoteReplacer = strings.NewReplacer(`\`, `\\`, `'`, `\'`)

--- a/bind_test.go
+++ b/bind_test.go
@@ -330,6 +330,66 @@ func TestFormatMap(t *testing.T) {
 	assert.Equal(t, "map('a', 1)", val)
 }
 
+func TestTimezoneSQLEscaping(t *testing.T) {
+	t.Run("prevent SQL injection via timezone name", func(t *testing.T) {
+		maliciousLoc := time.FixedZone("UTC') UNION ALL SELECT 1,2,3 --", 0)
+		maliciousTime := time.Now().In(maliciousLoc)
+
+		val, err := format(time.UTC, Seconds, maliciousTime)
+		require.NoError(t, err)
+
+		// The single quote should be escaped with backslash
+		// Expected format: toDateTime('...', 'UTC\') UNION ALL SELECT 1,2,3 --')
+		// The \' makes it part of the string literal, not SQL code
+		expectedEscaped := `'UTC\') UNION ALL SELECT 1,2,3 --'`
+		assert.Contains(t, val, expectedEscaped, "Single quotes in timezone name should be escaped with backslash")
+
+		// Verify it's in a toDateTime function call
+		assert.Contains(t, val, "toDateTime(")
+	})
+
+	t.Run("prevent SQL injection via timezone name with milliseconds", func(t *testing.T) {
+		maliciousLoc := time.FixedZone("America/New_York'); DROP TABLE users; --", 0)
+		maliciousTime := time.Now().In(maliciousLoc)
+
+		val, err := format(time.UTC, MilliSeconds, maliciousTime)
+		require.NoError(t, err)
+
+		// Should be properly escaped: 'America/New_York\'); DROP TABLE users; --'
+		expectedEscaped := `'America/New_York\'); DROP TABLE users; --'`
+		assert.Contains(t, val, expectedEscaped, "Single quotes should be escaped")
+
+		// Verify it's in a toDateTime64 function call
+		assert.Contains(t, val, "toDateTime64(")
+	})
+
+	t.Run("prevent SQL injection via timezone with backslashes", func(t *testing.T) {
+		maliciousLoc := time.FixedZone(`UTC\' OR 1=1 --`, 0)
+		maliciousTime := time.Now().In(maliciousLoc)
+
+		val, err := format(time.UTC, Seconds, maliciousTime)
+		require.NoError(t, err)
+
+		// Backslashes should be escaped to \\ and quotes to \'
+		// Expected: 'UTC\\\' OR 1=1 --'
+		expectedEscaped := `'UTC\\\' OR 1=1 --'`
+		assert.Contains(t, val, expectedEscaped, "Backslashes and quotes should both be escaped")
+	})
+
+	t.Run("normal timezone names remain unaffected", func(t *testing.T) {
+		// Test that normal, safe timezone names still work correctly
+		normalLoc := time.FixedZone("America/New_York", -5*3600)
+		normalTime := time.Now().In(normalLoc)
+
+		val, err := format(time.UTC, Seconds, normalTime)
+		require.NoError(t, err)
+
+		// Should contain the timezone name without any escaping
+		assert.Contains(t, val, "'America/New_York'")
+		assert.NotContains(t, val, `\'`, "Normal timezone names should not have escaped quotes")
+	})
+}
+
 // a simple (non thread safe) ordered map, implementing the column.OrderedMap interface
 type OrderedMap struct {
 	keys   []any


### PR DESCRIPTION


## Summary
<!-- A short description of the changes with a link to an open issue. -->
Currently formatTime do not properly escape the timezone info passed to it. Meaning timezone info can contain malicious SQL.

This PR makes sure it's properly escaped

Fixes: #1713 

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
