### PR TITLE
Add context option to append more ClientInfo to the system.query_log

### DIFF
--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -203,7 +203,7 @@ func (std *stdDriver) Open(dsn string) (_ driver.Conn, err error) {
 	if o.Debug {
 		debugf = log.New(os.Stdout, "[clickhouse-std][opener] ", 0).Printf
 	}
-	o.ClientInfo.comment = []string{"database/sql"}
+	o.ClientInfo.Comment = []string{"database/sql"}
 	return (&stdConnOpener{opt: o, debugf: debugf}).Connect(context.Background())
 }
 

--- a/client_info.go
+++ b/client_info.go
@@ -2,10 +2,11 @@ package clickhouse
 
 import (
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"runtime"
 	"sort"
 	"strings"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
 const ClientName = "clickhouse-go"
@@ -23,7 +24,34 @@ type ClientInfo struct {
 		Version string
 	}
 
-	comment []string
+	Comment []string
+}
+
+// Append returns a new copy of the combined ClientInfo structs
+func (a ClientInfo) Append(b ClientInfo) ClientInfo {
+	c := ClientInfo{
+		Products: make([]struct {
+			Name    string
+			Version string
+		}, 0, len(a.Products)+len(b.Products)),
+		Comment: make([]string, 0, len(a.Comment)+len(b.Comment)),
+	}
+
+	for _, p := range a.Products {
+		c.Products = append(c.Products, p)
+	}
+	for _, p := range b.Products {
+		c.Products = append(c.Products, p)
+	}
+
+	for _, cm := range a.Comment {
+		c.Comment = append(c.Comment, cm)
+	}
+	for _, cm := range b.Comment {
+		c.Comment = append(c.Comment, cm)
+	}
+
+	return c
 }
 
 func (o ClientInfo) String() string {
@@ -45,7 +73,9 @@ func (o ClientInfo) String() string {
 	lvMeta := "lv:go/" + runtime.Version()[2:]
 	osMeta := "os:" + runtime.GOOS
 
-	chunks := append(info.comment, lvMeta, osMeta) // nolint:gocritic
+	chunks := make([]string, 0, len(info.Comment) + 2)
+	chunks = append(chunks, info.Comment...)
+	chunks = append(chunks, lvMeta, osMeta)
 
 	s.WriteByte(' ')
 	s.WriteByte('(')

--- a/client_info_test.go
+++ b/client_info_test.go
@@ -2,10 +2,68 @@ package clickhouse
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestClientInfoAppend(t *testing.T) {
+	a := ClientInfo{
+		Products: []struct {
+			Name    string
+			Version string
+		}{
+			{
+				Name:    "product",
+				Version: "1.0.0",
+			},
+		},
+		Comment: []string{"comment_a"},
+	}
+
+	b := ClientInfo{
+		Products: []struct {
+			Name    string
+			Version string
+		}{
+			{
+				Name:    "product2",
+				Version: "2.0.0",
+			},
+		},
+		Comment: []string{"comment_b"},
+	}
+
+	c := a.Append(b)
+
+	// Check first ClientInfo unchanged
+	require.Len(t, a.Products, 1)
+	require.Equal(t, "product", a.Products[0].Name)
+	require.Equal(t, "1.0.0", a.Products[0].Version)
+	require.Len(t, a.Comment, 1)
+	require.Equal(t, "comment_a", a.Comment[0])
+
+	// Check second ClientInfo unchanged
+	require.Len(t, b.Products, 1)
+	require.Equal(t, "product2", b.Products[0].Name)
+	require.Equal(t, "2.0.0", b.Products[0].Version)
+	require.Len(t, b.Comment, 1)
+	require.Equal(t, "comment_b", b.Comment[0])
+
+	// Verify third ClientInfo is merged correctly
+	require.Len(t, c.Products, 2)
+	require.Equal(t, "product", c.Products[0].Name)
+	require.Equal(t, "1.0.0", c.Products[0].Version)
+	require.Equal(t, "product2", c.Products[1].Name)
+	require.Equal(t, "2.0.0", c.Products[1].Version)
+
+	require.Len(t, c.Comment, 2)
+	require.Equal(t, "comment_a", c.Comment[0])
+	require.Equal(t, "comment_b", c.Comment[1])
+
+}
 
 func TestClientInfoString(t *testing.T) {
 	// e.g. clickhouse-go/2.5.1
@@ -25,7 +83,7 @@ func TestClientInfoString(t *testing.T) {
 		},
 		"client with comment": {
 			ClientInfo{
-				comment: []string{"database/sql"},
+				Comment: []string{"database/sql"},
 			},
 			// e.g. clickhouse-go/2.5.1 (database/sql; lv:go/1.19.5; os:darwin)
 			fmt.Sprintf("%s (database/sql; %s)", expectedClientProduct, expectedDefaultMeta),
@@ -51,7 +109,7 @@ func TestClientInfoString(t *testing.T) {
 					{Name: "grafana", Version: "6.1"},
 					{Name: "grafana-datasource", Version: "0.1.1"},
 				},
-				comment: []string{"database/sql"},
+				Comment: []string{"database/sql"},
 			},
 			// e.g. grafana/6.1 grafana-datasource/0.1.1 clickhouse-go/2.5.1 (database/sql; lv:go/1.19.5; os:darwin)
 			fmt.Sprintf("grafana/6.1 grafana-datasource/0.1.1 %s (database/sql; %s)", expectedClientProduct, expectedDefaultMeta),

--- a/conn_http.go
+++ b/conn_http.go
@@ -103,7 +103,9 @@ func (rw *HTTPReaderWriter) reset(pw *io.PipeWriter) io.WriteCloser {
 
 // applyOptionsToRequest applies the client Options (such as auth, headers, client info) to the given http.Request
 func applyOptionsToRequest(ctx context.Context, req *http.Request, opt *Options) error {
-	jwt := queryOptionsJWT(ctx)
+	queryOpt := queryOptions(ctx)
+
+	jwt := queryOpt.jwt
 	useJWT := jwt != "" || useJWTAuth(opt)
 
 	if opt.TLS != nil && useJWT {
@@ -133,7 +135,7 @@ func applyOptionsToRequest(ctx context.Context, req *http.Request, opt *Options)
 		}
 	}
 
-	req.Header.Set("User-Agent", opt.ClientInfo.String())
+	req.Header.Set("User-Agent", opt.ClientInfo.Append(queryOpt.clientInfo).String())
 
 	for k, v := range opt.HttpHeaders {
 		req.Header.Set(k, v)

--- a/conn_send_query.go
+++ b/conn_send_query.go
@@ -11,7 +11,7 @@ func (c *connect) sendQuery(body string, o *QueryOptions) error {
 	c.buffer.PutByte(proto.ClientQuery)
 	q := proto.Query{
 		ClientTCPProtocolVersion: ClientTCPProtocolVersion,
-		ClientName:               c.opt.ClientInfo.String(),
+		ClientName:               c.opt.ClientInfo.Append(o.clientInfo).String(),
 		ClientVersion:            proto.Version{ClientVersionMajor, ClientVersionMinor, ClientVersionPatch}, //nolint:govet
 		ID:                       o.queryID,
 		Body:                     body,

--- a/tests/client_info_test.go
+++ b/tests/client_info_test.go
@@ -25,16 +25,19 @@ func TestClientInfo(t *testing.T) {
 
 	testCases := map[string]struct {
 		expectedClientInfo string
+		ctx                context.Context
 		clientInfo         clickhouse.ClientInfo
 	}{
 		"no additional products": {
 			// e.g. clickhouse-go/2.5.1 (database/sql; lv:go/1.19.3; os:darwin)
 			expectedClientProduct,
+			context.Background(),
 			clickhouse.ClientInfo{},
 		},
 		"one additional product": {
 			// e.g. tests/dev clickhouse-go/2.5.1 (database/sql; lv:go/1.19.3; os:darwin)
 			fmt.Sprintf("tests/dev %s", expectedClientProduct),
+			context.Background(),
 			clickhouse.ClientInfo{
 				Products: []struct {
 					Name    string
@@ -50,6 +53,7 @@ func TestClientInfo(t *testing.T) {
 		"two additional products": {
 			// e.g. product/version tests/dev clickhouse-go/2.5.1 (database/sql; lv:go/1.19.3; os:darwin)
 			fmt.Sprintf("product/version tests/dev %s", expectedClientProduct),
+			context.Background(),
 			clickhouse.ClientInfo{
 				Products: []struct {
 					Name    string
@@ -66,6 +70,31 @@ func TestClientInfo(t *testing.T) {
 				},
 			},
 		},
+		"additional product from context": {
+			// e.g. ctxProduct/1.2.3 clickhouse-go/2.41.0 (ctxComment; lv:go/1.25.5; os:linux)
+			fmt.Sprintf(
+				"ctxProduct/1.2.3 %s/%d.%d.%d (ctxComment; lv:go/%s; os:%s)",
+				clickhouse.ClientName,
+				clickhouse.ClientVersionMajor,
+				clickhouse.ClientVersionMinor,
+				clickhouse.ClientVersionPatch,
+				runtime.Version()[2:],
+				runtime.GOOS,
+			),
+			clickhouse.Context(context.Background(), clickhouse.WithClientInfo(clickhouse.ClientInfo{
+				Products: []struct {
+					Name    string
+					Version string
+				}{
+					{
+						Name:    "ctxProduct",
+						Version: "1.2.3",
+					},
+				},
+				Comment: []string{"ctxComment"},
+			})),
+			clickhouse.ClientInfo{},
+		},
 	}
 
 	env, err := GetTestEnvironment(testSet)
@@ -79,23 +108,23 @@ func TestClientInfo(t *testing.T) {
 			conn, err := clickhouse.Open(&opts)
 			require.NoError(t, err)
 
-			actualClientInfo := getConnectedClientInfo(t, conn)
+			actualClientInfo := getConnectedClientInfo(t, conn, testCase.ctx)
 			assert.Equal(t, testCase.expectedClientInfo, actualClientInfo)
 		})
 	}
 }
 
-func getConnectedClientInfo(t *testing.T, conn driver.Conn) string {
+func getConnectedClientInfo(t *testing.T, conn driver.Conn, ctx context.Context) string {
 	var queryID string
-	row := conn.QueryRow(context.TODO(), "SELECT queryID()")
+	row := conn.QueryRow(ctx, "SELECT queryID()")
 	require.NoError(t, row.Err())
 	require.NoError(t, row.Scan(&queryID))
 
-	err := conn.Exec(context.TODO(), "SYSTEM FLUSH LOGS")
+	err := conn.Exec(ctx, "SYSTEM FLUSH LOGS")
 	require.NoError(t, err)
 
 	var clientName string
-	row = conn.QueryRow(context.TODO(), fmt.Sprintf("SELECT IF(interface = 2, http_user_agent, client_name) as client_name FROM system.query_log WHERE query_id = '%s'", queryID))
+	row = conn.QueryRow(ctx, fmt.Sprintf("SELECT IF(interface = 2, http_user_agent, client_name) as client_name FROM system.query_log WHERE query_id = '%s'", queryID))
 	require.NoError(t, row.Err())
 	require.NoError(t, row.Scan(&clientName))
 

--- a/tests/std/client_info_test.go
+++ b/tests/std/client_info_test.go
@@ -1,16 +1,18 @@
 package std
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net/url"
 	"runtime"
 	"strconv"
 	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClientInfo(t *testing.T) {
@@ -26,16 +28,19 @@ func TestClientInfo(t *testing.T) {
 
 	testCases := map[string]struct {
 		expectedClientInfo string
+		ctx                context.Context
 		additionalOpts     url.Values
 	}{
 		"no additional products": {
 			// e.g. clickhouse-go/2.5.1 (database/sql; lv:go/1.19.3; os:darwin)
 			expectedClientProduct,
+			context.Background(),
 			nil,
 		},
 		"one additional product": {
 			// e.g. tests/dev clickhouse-go/2.5.1 (database/sql; lv:go/1.19.3; os:darwin)
 			fmt.Sprintf("tests/dev %s", expectedClientProduct),
+			context.Background(),
 			url.Values{
 				"client_info_product": []string{"tests/dev"},
 			},
@@ -43,9 +48,35 @@ func TestClientInfo(t *testing.T) {
 		"two additional products": {
 			// e.g. product/version tests/dev clickhouse-go/2.5.1 (database/sql; lv:go/1.19.3; os:darwin)
 			fmt.Sprintf("product/version tests/dev %s", expectedClientProduct),
+			context.Background(),
 			url.Values{
 				"client_info_product": []string{"product/version,tests/dev"},
 			},
+		},
+		"additional product from context": {
+			// e.g. ctxProduct/1.2.3 clickhouse-go/2.41.0 (database/sql; ctxComment; lv:go/1.25.5 X:nodwarf5; os:linux)
+			fmt.Sprintf(
+				"ctxProduct/1.2.3 %s/%d.%d.%d (database/sql; ctxComment; lv:go/%s; os:%s)",
+				clickhouse.ClientName,
+				clickhouse.ClientVersionMajor,
+				clickhouse.ClientVersionMinor,
+				clickhouse.ClientVersionPatch,
+				runtime.Version()[2:],
+				runtime.GOOS,
+			),
+			clickhouse.Context(context.Background(), clickhouse.WithClientInfo(clickhouse.ClientInfo{
+				Products: []struct {
+					Name    string
+					Version string
+				}{
+					{
+						Name:    "ctxProduct",
+						Version: "1.2.3",
+					},
+				},
+				Comment: []string{"ctxComment"},
+			})),
+			nil,
 		},
 	}
 
@@ -59,7 +90,7 @@ func TestClientInfo(t *testing.T) {
 					conn, err := GetStdDSNConnection(protocol, useSSL, testCase.additionalOpts)
 					require.NoError(t, err)
 
-					actualClientInfo := getConnectedClientInfo(t, conn)
+					actualClientInfo := getConnectedClientInfo(t, conn, testCase.ctx)
 					assert.Equal(t, testCase.expectedClientInfo, actualClientInfo)
 				})
 			}
@@ -67,17 +98,17 @@ func TestClientInfo(t *testing.T) {
 	}
 }
 
-func getConnectedClientInfo(t *testing.T, conn *sql.DB) string {
+func getConnectedClientInfo(t *testing.T, conn *sql.DB, ctx context.Context) string {
 	var queryID string
-	row := conn.QueryRow("SELECT queryID()")
+	row := conn.QueryRowContext(ctx, "SELECT queryID()")
 	require.NoError(t, row.Err())
 	require.NoError(t, row.Scan(&queryID))
 
-	_, err := conn.Exec("SYSTEM FLUSH LOGS")
+	_, err := conn.ExecContext(ctx, "SYSTEM FLUSH LOGS")
 	require.NoError(t, err)
 
 	var clientName string
-	row = conn.QueryRow(fmt.Sprintf("SELECT IF(interface = 2, http_user_agent, client_name) as client_name FROM system.query_log WHERE query_id = '%s'", queryID))
+	row = conn.QueryRowContext(ctx, fmt.Sprintf("SELECT IF(interface = 2, http_user_agent, client_name) as client_name FROM system.query_log WHERE query_id = '%s'", queryID))
 	require.NoError(t, row.Err())
 	require.NoError(t, row.Scan(&clientName))
 


### PR DESCRIPTION
## Summary
ClientInfo is appended per-query, but it can only be set upon connection.

This PR allows users to append to it per-query. The original ClientInfo from the initial connection is unaffected, it's append-only.

Changes:
- Add `WithClientInfo` function for usage with `clickhouse.Context`
- Made `Comment` public on `ClientInfo` so users can append to it in their `clickhouse.Options` config
- Updated TCP and HTTP usage. ClientInfo is merged from connection options and query options.
- Updated unit + integration tests

## Usage

```go
// This data will be appended to the existing ClientInfo from clickhouse.Options
queryCtx := clickhouse.Context(ctx, clickhouse.WithClientInfo(clickhouse.ClientInfo{
	Products: []struct {
		Name    string
		Version string
	}{
		{ Name:    "ctxProduct", Version: "1.2.3" },
	},
	Comment: []string{"ctxComment"},
}))

// The system.query_log table will include the additional ClientInfo from the queryCtx
row := conn.QueryRow(queryCtx, "SELECT 1")
```

## Checklist
- [X] Unit and integration tests covering the common scenarios were added
