### PR TITLE
Implement Unwrap() on BlockError

### DIFF
--- a/lib/proto/block.go
+++ b/lib/proto/block.go
@@ -291,3 +291,7 @@ func (e *BlockError) Error() string {
 	}
 	return fmt.Sprintf("clickhouse [%s]: %s %s", e.Op, e.ColumnName, e.Err)
 }
+
+func (e *BlockError) Unwrap() error {
+	return e.Err
+}


### PR DESCRIPTION
## Summary
Implement `Unwrap()` on `BlockError` to allow for `errors.Is()` traversal
Fixes #1740 

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
