### PR TITLE
fix: Fixes the failure againt HEAD of CH server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,12 @@ up:
 down:
 	@docker compose down
 
+up-cluster:
+	@docker compose -f docker-compose.cluster.yml up
+
+down-cluster:
+	@docker compose -f docker-compose.cluster.yml down
+
 cli:
 	docker run -it --rm --net clickhouse-go_clickhouse --link clickhouse:clickhouse-server --host clickhouse-server
 

--- a/examples/clickhouse_api/main_test.go
+++ b/examples/clickhouse_api/main_test.go
@@ -56,6 +56,12 @@ func TestArrayInsertRead(t *testing.T) {
 }
 
 func TestAsyncInsert(t *testing.T) {
+	// Rationale: ClickHouser server added a validation that
+	// "insert_quoram" and "async_insert" setting cannot be used together.
+	// https://github.com/ClickHouse/ClickHouse/pull/89140/changes#diff-ff8ad4aed4cf07fe29cb5344d2ab79bc24efd97d054aa112c3a05b5ab853cc44R1558-R1562
+	// NOTE: using t.Setenv also cleanups and restore old value after end of the test. So no need
+	// to manually unset the envs.
+	t.Setenv("CLICKHOUSE_QUORUM_INSERT", "0")
 	require.NoError(t, AsyncInsertNative())
 	require.NoError(t, AsyncInsertHTTP())
 }

--- a/lib/column/dynamic.go
+++ b/lib/column/dynamic.go
@@ -19,7 +19,7 @@ const DefaultMaxDynamicTypes = 32
 
 func supportsFlatDynamicJSON(sc *ServerContext) bool {
 	// Any CH version more than 25.6
-	return sc.VersionMajor >= 25 || (sc.VersionMajor == 25 && sc.VersionMinor >= 6)
+	return sc.VersionMajor > 25 || (sc.VersionMajor == 25 && sc.VersionMinor >= 6)
 }
 
 type Dynamic struct {

--- a/lib/column/dynamic.go
+++ b/lib/column/dynamic.go
@@ -18,7 +18,8 @@ const DynamicNullDiscriminator = -1 // The Null index changes as data is being b
 const DefaultMaxDynamicTypes = 32
 
 func supportsFlatDynamicJSON(sc *ServerContext) bool {
-	return sc.VersionMajor >= 25 && sc.VersionMinor >= 6
+	// Any CH version more than 25.6
+	return sc.VersionMajor >= 25 || (sc.VersionMajor == 25 && sc.VersionMinor >= 6)
 }
 
 type Dynamic struct {

--- a/tests/dynamic_test.go
+++ b/tests/dynamic_test.go
@@ -231,7 +231,8 @@ func TestDynamicExceededTypes(t *testing.T) {
 	}
 
 	t.Run("less than UInt8", testTypeCount(16))
-	t.Run("UInt8 bounds", testTypeCount(254))
+	t.Run("UInt8 bounds", testTypeCount(255))
+	t.Run("UInt16 range", testTypeCount(300))
 }
 
 func TestDynamicArray(t *testing.T) {

--- a/tests/dynamic_test.go
+++ b/tests/dynamic_test.go
@@ -193,7 +193,6 @@ func TestDynamicMaxTypes(t *testing.T) {
 }
 
 // Discriminator precision must grow dynamically depending on the number of types within the Dynamic.
-// This test confirms that we can go beyond UInt8/255 types.
 func TestDynamicExceededTypes(t *testing.T) {
 	conn := setupDynamicTest(t, clickhouse.Native)
 	ctx := context.Background()
@@ -217,7 +216,7 @@ func TestDynamicExceededTypes(t *testing.T) {
 			batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_dynamic_exceeded_types (c)")
 			require.NoError(t, err)
 
-			for i := 0; i < typeCount; i++ {
+			for i := range typeCount {
 				typeName := fmt.Sprintf("Tuple(\"%d\" Int64)", i)
 				require.NoError(t, batch.Append(clickhouse.NewDynamicWithType([]int64{int64(i)}, typeName)))
 			}
@@ -232,8 +231,7 @@ func TestDynamicExceededTypes(t *testing.T) {
 	}
 
 	t.Run("less than UInt8", testTypeCount(16))
-	t.Run("UInt8 bounds", testTypeCount(255))
-	t.Run("UInt16 range", testTypeCount(300))
+	t.Run("UInt8 bounds", testTypeCount(254))
 }
 
 func TestDynamicArray(t *testing.T) {


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

Two changes:
1. We cannot use async_insert and quorum_insert settings together in latest CH
2. Then version check for `supportsFlatDynamicJSON` was buggy. Causing it to return false for version26.1 (major >=25, but minor <6) (Thanks @Avogar for catching the bug :bow: )

Related PRs on core
1. https://github.com/ClickHouse/ClickHouse/pull/89140/changes#diff-ff8ad4aed4cf07fe29cb5344d2ab79bc24efd97d054aa112c3a05b5ab853cc44R1558-R1562

Should fix the periodic tests running against current CH head (after 25.12)
1. https://github.com/ClickHouse/clickhouse-go/actions/runs/20904405013/job/60055340690#step:4:2227
2. https://github.com/ClickHouse/clickhouse-go/actions/runs/20904405013/job/60055340690#step:4:470


### Before
```
$ CLICKHOUSE_VERSION=head go test ./tests/... -run TestDynamicExceededTypes -count=1
using random seed 1768407595883362685 for native tests
Using Docker for integration tests
ClickHouse 26.1.1 ready: Container=62d1298a6bf1 Host=127.0.0.1 TCP=33119 HTTP=33117 SSL=33120 HTTPS=33118
--- FAIL: TestDynamicExceededTypes (0.04s)
    --- FAIL: TestDynamicExceededTypes/UInt8_bounds (0.01s)
        dynamic_test.go:224:
            	Error Trace:	/home/kavi/src/clickhouse-go/tests/dynamic_test.go:224
            	Error:      	Received unexpected error:
            	            	code: 36, message: Variant type with more than 255 nested types is not allowed
            	Test:       	TestDynamicExceededTypes/UInt8_bounds
    --- FAIL: TestDynamicExceededTypes/UInt16_range (0.01s)
        dynamic_test.go:224:
            	Error Trace:	/home/kavi/src/clickhouse-go/tests/dynamic_test.go:224
            	Error:      	Received unexpected error:
            	            	code: 36, message: Variant type with more than 255 nested types is not allowed
            	Test:       	TestDynamicExceededTypes/UInt16_range
FAIL
FAIL	github.com/ClickHouse/clickhouse-go/v2/tests	6.456s
ok  	github.com/ClickHouse/clickhouse-go/v2/tests/issues	6.319s [no tests to run]
?   	github.com/ClickHouse/clickhouse-go/v2/tests/issues/209	[no test files]
?   	github.com/ClickHouse/clickhouse-go/v2/tests/issues/360	[no test files]
?   	github.com/ClickHouse/clickhouse-go/v2/tests/issues/470	[no test files]
?   	github.com/ClickHouse/clickhouse-go/v2/tests/issues/476	[no test files]
?   	github.com/ClickHouse/clickhouse-go/v2/tests/issues/484	[no test files]
?   	github.com/ClickHouse/clickhouse-go/v2/tests/issues/485	[no test files]
ok  	github.com/ClickHouse/clickhouse-go/v2/tests/std	6.178s [no tests to run]
?   	github.com/ClickHouse/clickhouse-go/v2/tests/stress	[no test files]
FAIL
$ CLICKHOUSE_VERSION=head go test ./examples/... -run TestAsyncInsert -count=1
using random seed 1768407605293614881 for examples_clickhouse_api tests
Using Docker for integration tests
ClickHouse 26.1.1 ready: Container=811cae9b564b Host=127.0.0.1 TCP=33132 HTTP=33130 SSL=33133 HTTPS=33131
--- FAIL: TestAsyncInsert (0.01s)
    main_test.go:59:
        	Error Trace:	/home/kavi/src/clickhouse-go/examples/clickhouse_api/main_test.go:59
        	Error:      	Received unexpected error:
        	            	code: 344, message: Insert quorum cannot be used together with async inserts. Please disable either `insert_quorum` or `async_insert` setting.
        	Test:       	TestAsyncInsert
FAIL
FAIL	github.com/ClickHouse/clickhouse-go/v2/examples/clickhouse_api	1.370s
ok  	github.com/ClickHouse/clickhouse-go/v2/examples/std	1.260s [no tests to run]
FAIL
$

```

### After
```
$ CLICKHOUSE_VERSION=head go test ./tests/... -run TestDynamicExceededTypes -count=1
ok  	github.com/ClickHouse/clickhouse-go/v2/tests	6.507s
ok  	github.com/ClickHouse/clickhouse-go/v2/tests/issues	6.336s [no tests to run]
?   	github.com/ClickHouse/clickhouse-go/v2/tests/issues/209	[no test files]
?   	github.com/ClickHouse/clickhouse-go/v2/tests/issues/360	[no test files]
?   	github.com/ClickHouse/clickhouse-go/v2/tests/issues/470	[no test files]
?   	github.com/ClickHouse/clickhouse-go/v2/tests/issues/476	[no test files]
?   	github.com/ClickHouse/clickhouse-go/v2/tests/issues/484	[no test files]
?   	github.com/ClickHouse/clickhouse-go/v2/tests/issues/485	[no test files]
ok  	github.com/ClickHouse/clickhouse-go/v2/tests/std	6.189s [no tests to run]
?   	github.com/ClickHouse/clickhouse-go/v2/tests/stress	[no test files]
$ CLICKHOUSE_VERSION=head go test ./examples/... -run TestAsyncInsert -count=1
ok  	github.com/ClickHouse/clickhouse-go/v2/examples/clickhouse_api	1.562s
ok  	github.com/ClickHouse/clickhouse-go/v2/examples/std	1.323s [no tests to run]
$

```

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
