### PR TITLE
feat: support BFloat16 datatype

### DIFF
--- a/examples/clickhouse_api/bfloat16.go
+++ b/examples/clickhouse_api/bfloat16.go
@@ -1,0 +1,58 @@
+package clickhouse_api
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+func BFloat16() error {
+	conn, err := GetNativeConnection(clickhouse.Settings{}, nil, nil)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	conn.Exec(ctx, "DROP TABLE IF EXISTS example")
+
+	const ddl = `
+		CREATE TABLE example (
+			  Col1 BFloat16,
+			  Col2 Nullable(BFloat16)
+		) Engine MergeTree() ORDER BY tuple()
+		`
+
+	if err := conn.Exec(ctx, ddl); err != nil {
+		return nil
+	}
+	fmt.Println("Table created")
+
+	batch, err := conn.PrepareBatch(ctx, "INSERT INTO example")
+	if err != nil {
+		return err
+	}
+	batch.Append(float32(33.125), sql.NullFloat64{
+		Float64: 34.25,
+		Valid:   true,
+	})
+
+	fmt.Println("Rows to be inserted", batch.Rows())
+	if err := batch.Send(); err != nil {
+		return err
+	}
+
+	fmt.Printf("Inserted %d rows\n", batch.Rows())
+	var (
+		col1 float32
+		col2 sql.NullFloat64
+	)
+
+	if err := conn.QueryRow(ctx, "SELECT * FROM example").Scan(&col1, &col2); err != nil {
+		return nil
+	}
+
+	fmt.Printf("Col1: %v, Col2: %v\n", col1, col2)
+
+	return nil
+}

--- a/examples/clickhouse_api/main_test.go
+++ b/examples/clickhouse_api/main_test.go
@@ -238,3 +238,7 @@ func TestJSONStringExample(t *testing.T) {
 	clickhouse_tests.SkipOnCloud(t, "cannot modify JSON settings on cloud")
 	require.NoError(t, JSONStringExample())
 }
+
+func TestBFloat16(t *testing.T) {
+	require.NoError(t, BFloat16())
+}

--- a/examples/std/bfloat16.go
+++ b/examples/std/bfloat16.go
@@ -1,0 +1,70 @@
+package std
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+func BFloat16() error {
+	conn, err := GetStdOpenDBConnection(clickhouse.Native, nil, nil, nil)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	_, err = conn.ExecContext(ctx, "DROP TABLE IF EXISTS example")
+	if err != nil {
+		return nil
+	}
+
+	const ddl = `
+		CREATE TABLE example (
+			  Col1 BFloat16,
+			  Col2 Nullable(BFloat16)
+		) Engine MergeTree() ORDER BY tuple()
+		`
+
+	if _, err := conn.ExecContext(ctx, ddl); err != nil {
+		return nil
+	}
+	fmt.Println("Table created")
+
+	scope, err := conn.Begin()
+	if err != nil {
+		return err
+	}
+
+	batch, err := scope.PrepareContext(ctx, "INSERT INTO example")
+	if err != nil {
+		return err
+	}
+
+	_, err = batch.ExecContext(ctx, float32(33.125), sql.NullFloat64{
+		Float64: 34.25,
+		Valid:   true,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := scope.Commit(); err != nil {
+		return err
+	}
+
+	fmt.Println("Values inserted")
+
+	var (
+		col1 float32
+		col2 sql.NullFloat64
+	)
+
+	if err := conn.QueryRowContext(ctx, "SELECT * FROM example").Scan(&col1, &col2); err != nil {
+		return nil
+	}
+
+	fmt.Printf("Col1: %v, Col2: %v\n", col1, col2)
+
+	return nil
+}

--- a/examples/std/main_test.go
+++ b/examples/std/main_test.go
@@ -163,3 +163,7 @@ func TestJSONStringExample(t *testing.T) {
 func TestStdGeoInsertRead(t *testing.T) {
 	require.NoError(t, GeoInsertRead())
 }
+
+func TestStdBFloat16(t *testing.T) {
+	require.NoError(t, BFloat16())
+}

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/ClickHouse/clickhouse-go/v2
 
-go 1.24.0
+go 1.24.1
 
 toolchain go1.25.4
 
 require (
-	github.com/ClickHouse/ch-go v0.69.1-0.20260120130256-d5ac1c0ec8d4
+	github.com/ClickHouse/ch-go v0.70.0
 	github.com/andybalholm/brotli v1.2.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-units v0.5.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.25.4
 
 require (
-	github.com/ClickHouse/ch-go v0.69.0
+	github.com/ClickHouse/ch-go v0.69.1-0.20260120130256-d5ac1c0ec8d4
 	github.com/andybalholm/brotli v1.2.0
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-units v0.5.0
@@ -44,7 +44,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
-	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/klauspost/compress v1.18.3 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -57,7 +57,7 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/pierrec/lz4/v4 v4.1.22 // indirect
+	github.com/pierrec/lz4/v4 v4.1.25 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8af
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/ClickHouse/ch-go v0.69.0 h1:nO0OJkpxOlN/eaXFj0KzjTz5p7vwP1/y3GN4qc5z/iM=
-github.com/ClickHouse/ch-go v0.69.0/go.mod h1:9XeZpSAT4S0kVjOpaJ5186b7PY/NH/hhF8R6u0WIjwg=
+github.com/ClickHouse/ch-go v0.69.1-0.20260120130256-d5ac1c0ec8d4 h1:YmU6TbQeus35rmC9mm8ARpQa5Y7a60Nxf50vIE/17H8=
+github.com/ClickHouse/ch-go v0.69.1-0.20260120130256-d5ac1c0ec8d4/go.mod h1:gk6B9UqB7UtvTNVruztrh6k85SlrIZiCCSfQFIxKU3s=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
@@ -73,8 +73,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9K
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
-github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
-github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/klauspost/compress v1.18.3 h1:9PJRvfbmTabkOX8moIpXPbMMbYN60bWImDDU7L+/6zw=
+github.com/klauspost/compress v1.18.3/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
@@ -114,8 +114,8 @@ github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgr
 github.com/paulmach/orb v0.12.0 h1:z+zOwjmG3MyEEqzv92UN49Lg1JFYx0L9GpGKNVDKk1s=
 github.com/paulmach/orb v0.12.0/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=
 github.com/paulmach/protoscan v0.2.1/go.mod h1:SpcSwydNLrxUGSDvXvO0P7g7AuhJ7lcKfDlhJCDw2gY=
-github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
-github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pierrec/lz4/v4 v4.1.25 h1:kocOqRffaIbU5djlIBr7Wh+cx82C0vtFb0fOurZHqD0=
+github.com/pierrec/lz4/v4 v4.1.25/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -174,8 +174,8 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.19.0 h1:IeMey
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.19.0/go.mod h1:oVdCUtjq9MK9BlS7TtucsQwUcXcymNiEDjgDD2jMtZU=
 go.opentelemetry.io/otel/metric v1.39.0 h1:d1UzonvEZriVfpNKEVmHXbdf909uGTOQjA0HF0Ls5Q0=
 go.opentelemetry.io/otel/metric v1.39.0/go.mod h1:jrZSWL33sD7bBxg1xjrqyDjnuzTUB0x1nBERXd7Ftcs=
-go.opentelemetry.io/otel/sdk v1.38.0 h1:l48sr5YbNf2hpCUj/FoGhW9yDkl+Ma+LrVl8qaM5b+E=
-go.opentelemetry.io/otel/sdk v1.38.0/go.mod h1:ghmNdGlVemJI3+ZB5iDEuk4bWA3GkTpW+DOoZMYBVVg=
+go.opentelemetry.io/otel/sdk v1.39.0 h1:nMLYcjVsvdui1B/4FRkwjzoRVsMK8uL/cj0OyhKzt18=
+go.opentelemetry.io/otel/sdk v1.39.0/go.mod h1:vDojkC4/jsTJsE+kh+LXYQlbL8CgrEcwmt1ENZszdJE=
 go.opentelemetry.io/otel/trace v1.39.0 h1:2d2vfpEDmCJ5zVYz7ijaJdOF59xLomrvj7bjt6/qCJI=
 go.opentelemetry.io/otel/trace v1.39.0/go.mod h1:88w4/PnZSazkGzz/w84VHpQafiU4EtqqlVdxWy+rNOA=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8af
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/ClickHouse/ch-go v0.69.1-0.20260120130256-d5ac1c0ec8d4 h1:YmU6TbQeus35rmC9mm8ARpQa5Y7a60Nxf50vIE/17H8=
-github.com/ClickHouse/ch-go v0.69.1-0.20260120130256-d5ac1c0ec8d4/go.mod h1:gk6B9UqB7UtvTNVruztrh6k85SlrIZiCCSfQFIxKU3s=
+github.com/ClickHouse/ch-go v0.70.0 h1:/0lJpiSXxg/7IaJi7TOkKAOHrx0z0OiSMU475EJNAwM=
+github.com/ClickHouse/ch-go v0.70.0/go.mod h1:gk6B9UqB7UtvTNVruztrh6k85SlrIZiCCSfQFIxKU3s=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=

--- a/lib/column/codegen/main.go
+++ b/lib/column/codegen/main.go
@@ -26,6 +26,10 @@ var (
 	dynamicTypes     []_type
 )
 
+const (
+	typeBFloat16 = "BFloat16"
+)
+
 type _type struct {
 	Size int
 
@@ -54,11 +58,22 @@ func init() {
 			GoType: fmt.Sprintf("float%d", size),
 		})
 	}
+	// BFloat16 - Brain Floating Point 16
+	types = append(types, _type{
+		Size:      16,
+		ChType:    typeBFloat16,
+		GoType:    "float32", // BFloat16 uses float32 in user-facing apis.
+		SkipArray: true,
+	})
 	sort.Slice(types, func(i, j int) bool {
 		return sequenceKey(types[i].ChType) < sequenceKey(types[j].ChType)
 	})
 
 	for _, typ := range types {
+		// Skip BFloat16 from supportedGoTypes to avoid conflict with float32
+		if typ.ChType == typeBFloat16 {
+			continue
+		}
 		supportedGoTypes = append(supportedGoTypes, typ.GoType)
 	}
 
@@ -80,6 +95,12 @@ func init() {
 			// Prevent conflict with []byte and []uint8
 			typ.SkipArray = true
 			dynamicTypes = append(dynamicTypes, typ)
+			continue
+		}
+
+		if typ.ChType == typeBFloat16 {
+			// Skip BFloat16 from dynamic types to prevent conflict with Float32.
+			// Both Float32 and BFloat16 uses float32 Go type.
 			continue
 		}
 

--- a/tests/bfloat16_test.go
+++ b/tests/bfloat16_test.go
@@ -1,0 +1,322 @@
+package tests
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSimpleBFloat16(t *testing.T) {
+	TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
+		conn, err := GetNativeConnection(t, protocol, nil, nil, &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		})
+		ctx := context.Background()
+		require.NoError(t, err)
+		if !CheckMinServerServerVersion(conn, 24, 11, 0) {
+			t.Skip(fmt.Errorf("BFloat16 requires ClickHouse 24.11+"))
+			return
+		}
+		const ddl = `
+		CREATE TABLE test_bfloat16 (
+			  Col1 BFloat16,
+			  Col2 Nullable(BFloat16)
+		) Engine MergeTree() ORDER BY tuple()
+		`
+		defer func() {
+			conn.Exec(ctx, "DROP TABLE IF EXISTS test_bfloat16")
+		}()
+		require.NoError(t, conn.Exec(ctx, ddl))
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_bfloat16")
+		require.NoError(t, err)
+		require.NoError(t, batch.Append(float32(33.125), sql.NullFloat64{
+			Float64: 34.25,
+			Valid:   true,
+		}))
+		require.Equal(t, 1, batch.Rows())
+		assert.NoError(t, batch.Send())
+
+		// BFloat16 may have precision loss, so check with tolerance
+		// BFloat16 has 7-bit for mantissa compared to 23-bit mantissa for Float32.
+		// which makes it loose 3-4 digits of precision.
+		relativeError := 0.004 // 0.4%
+		var (
+			col1 float32
+			col2 sql.NullFloat64
+		)
+		require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_bfloat16").Scan(&col1, &col2))
+		// BFloat16 has limited precision, so use tolerance of 0.04% of the original number
+		require.InDelta(t, float32(33.125), col1, (33.125)*relativeError)
+		require.True(t, col2.Valid)
+		require.InDelta(t, 34.25, col2.Float64, (34.25)*relativeError)
+	})
+}
+
+type customBFloat16 float32
+
+func (f *customBFloat16) Scan(src any) error {
+	if t, ok := src.(float32); ok {
+		*f = customBFloat16(t)
+		return nil
+	}
+	return fmt.Errorf("cannot scan %T into customBFloat16", src)
+}
+
+func TestCustomBFloat16(t *testing.T) {
+	TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
+		conn, err := GetNativeConnection(t, protocol, nil, nil, nil)
+		ctx := context.Background()
+		require.NoError(t, err)
+		if !CheckMinServerServerVersion(conn, 24, 11, 0) {
+			t.Skip(fmt.Errorf("BFloat16 requires ClickHouse 24.11+"))
+			return
+		}
+		const ddl = `
+		CREATE TABLE test_bfloat16_custom (
+			  Col1 BFloat16
+		) Engine MergeTree() ORDER BY tuple()
+		`
+		defer func() {
+			conn.Exec(ctx, "DROP TABLE IF EXISTS test_bfloat16_custom")
+		}()
+		require.NoError(t, conn.Exec(ctx, ddl))
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_bfloat16_custom")
+		require.NoError(t, err)
+		require.NoError(t, batch.Append(float32(123.456)))
+		require.NoError(t, batch.Send())
+
+		var col1 customBFloat16
+		require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_bfloat16_custom").Scan(&col1))
+		require.InDelta(t, float32(123.456), float32(col1), 1.0)
+	})
+}
+
+func TestBFloat16Flush(t *testing.T) {
+	TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
+		SkipOnHTTP(t, protocol, "Flush")
+		conn, err := GetNativeConnection(t, protocol, nil, nil, nil)
+		ctx := context.Background()
+		require.NoError(t, err)
+		if !CheckMinServerServerVersion(conn, 24, 11, 0) {
+			t.Skip(fmt.Errorf("BFloat16 requires ClickHouse 24.11+"))
+			return
+		}
+		const ddl = `
+		CREATE TABLE test_bfloat16_flush (
+			  Col1 BFloat16
+		) Engine MergeTree() ORDER BY tuple()
+		`
+		defer func() {
+			conn.Exec(ctx, "DROP TABLE IF EXISTS test_bfloat16_flush")
+		}()
+		require.NoError(t, conn.Exec(ctx, ddl))
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_bfloat16_flush")
+		require.NoError(t, err)
+		vals := [1000]float32{}
+		for i := range 1000 {
+			vals[i] = rand.Float32() * 1000
+			require.NoError(t, batch.Append(vals[i]))
+			if (i+1)%100 == 0 {
+				require.NoError(t, batch.Flush())
+			}
+		}
+		require.NoError(t, batch.Send())
+
+		rows, err := conn.Query(ctx, "SELECT * FROM test_bfloat16_flush")
+		require.NoError(t, err)
+
+		// BFloat16 may have precision loss, so check with tolerance
+		// BFloat16 has 7-bit for mantissa compared to 23-bit mantissa for Float32.
+		// which makes it loose 3-4 digits of precision.
+		relativeError := 0.004 // 0.4%
+
+		i := 0
+		for rows.Next() {
+			var col1 float32
+			require.NoError(t, rows.Scan(&col1))
+
+			maxDelta := float64(vals[i]) * relativeError
+			require.InDelta(t, vals[i], col1, float64(maxDelta)) // BFloat16 precision
+			i++
+		}
+		require.Equal(t, 1000, i)
+	})
+}
+
+func TestBFloat16EdgeCases(t *testing.T) {
+	TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
+		conn, err := GetNativeConnection(t, protocol, nil, nil, nil)
+		ctx := context.Background()
+		require.NoError(t, err)
+		if !CheckMinServerServerVersion(conn, 24, 11, 0) {
+			t.Skip(fmt.Errorf("BFloat16 requires ClickHouse 24.11+"))
+			return
+		}
+		const ddl = `
+		CREATE TABLE test_bfloat16_edge (
+			  Col1 BFloat16
+		) Engine MergeTree() ORDER BY tuple()
+		`
+		defer func() {
+			conn.Exec(ctx, "DROP TABLE IF EXISTS test_bfloat16_edge")
+		}()
+		require.NoError(t, conn.Exec(ctx, ddl))
+
+		testCases := []struct {
+			name  string
+			value float32
+		}{
+			{"zero", 0.0},
+			{"negative_zero", float32(math.Copysign(0, -1))},
+			{"positive", 3.14},
+			{"negative", -3.14},
+			{"small_positive", 0.00001},
+			{"small_negative", -0.00001},
+			{"large_positive", 10000.0},
+			{"large_negative", -10000.0},
+			{"positive_infinity", float32(math.Inf(1))},
+			{"negative_infinity", float32(math.Inf(-1))},
+			{"nan", float32(math.NaN())},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				batch, _ := conn.PrepareBatch(ctx, "INSERT INTO test_bfloat16_edge")
+				batch.Append(tc.value)
+				batch.Send()
+				var result float32
+				conn.QueryRow(ctx, "SELECT * FROM test_bfloat16_edge ORDER BY Col1 DESC LIMIT 1").Scan(&result)
+
+				if math.IsNaN(float64(tc.value)) {
+					require.True(t, math.IsNaN(float64(result)), "expected NaN")
+				} else if math.IsInf(float64(tc.value), 0) {
+					require.True(t, math.IsInf(float64(result), int(math.Copysign(1, float64(tc.value)))), "expected infinity with same sign")
+				} else {
+					require.InDelta(t, tc.value, result, math.Max(0.01*math.Abs(float64(tc.value)), 0.001))
+				}
+
+				conn.Exec(ctx, "TRUNCATE TABLE test_bfloat16_edge")
+			})
+		}
+	})
+}
+
+func TestBFloat16Precision(t *testing.T) {
+	TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
+		conn, err := GetNativeConnection(t, protocol, nil, nil, nil)
+		ctx := context.Background()
+		require.NoError(t, err)
+		if !CheckMinServerServerVersion(conn, 24, 11, 0) {
+			t.Skip(fmt.Errorf("BFloat16 requires ClickHouse 24.11+"))
+			return
+		}
+		const ddl = `
+		CREATE TABLE test_bfloat16_precision (
+			  Col1 BFloat16
+		) Engine MergeTree() ORDER BY tuple()
+		`
+		defer func() {
+			conn.Exec(ctx, "DROP TABLE IF EXISTS test_bfloat16_precision")
+		}()
+		require.NoError(t, conn.Exec(ctx, ddl))
+
+		// Test that BFloat16 has limited precision (~7 bits mantissa)
+		testCases := []struct {
+			input    float32
+			expected float32
+			delta    float64
+		}{
+			{1.0, 1.0, 0.0},
+			{2.0, 2.0, 0.0},
+			{3.14159, 3.140625, 0.002},
+			{100.5, 100.5, 0.5},
+		}
+
+		for _, tc := range testCases {
+			batch, _ := conn.PrepareBatch(ctx, "INSERT INTO test_bfloat16_precision")
+			batch.Append(tc.input)
+			batch.Send()
+			var result float32
+			conn.QueryRow(ctx, "SELECT * FROM test_bfloat16_precision ORDER BY Col1 DESC LIMIT 1").Scan(&result)
+			require.InDelta(t, tc.expected, result, tc.delta, "input=%v", tc.input)
+			conn.Exec(ctx, "TRUNCATE TABLE test_bfloat16_precision")
+		}
+	})
+}
+
+func TestBFloat16Array(t *testing.T) {
+	TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
+		conn, err := GetNativeConnection(t, protocol, nil, nil, nil)
+		ctx := context.Background()
+		require.NoError(t, err)
+		if !CheckMinServerServerVersion(conn, 24, 11, 0) {
+			t.Skip(fmt.Errorf("BFloat16 requires ClickHouse 24.11+"))
+			return
+		}
+		const ddl = `
+		CREATE TABLE test_bfloat16_array (
+			  Col1 Array(BFloat16)
+		) Engine MergeTree() ORDER BY tuple()
+		`
+		defer func() {
+			conn.Exec(ctx, "DROP TABLE IF EXISTS test_bfloat16_array")
+		}()
+		require.NoError(t, conn.Exec(ctx, ddl))
+
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_bfloat16_array")
+		require.NoError(t, err)
+
+		expected := []float32{1.5, 2.5, 3.5, 4.5}
+		require.NoError(t, batch.Append(expected))
+		require.NoError(t, batch.Send())
+
+		var result []float32
+		require.NoError(t, conn.QueryRow(ctx, "SELECT * FROM test_bfloat16_array").Scan(&result))
+		require.Equal(t, len(expected), len(result))
+		for i := range expected {
+			require.InDelta(t, expected[i], result[i], 0.01)
+		}
+	})
+}
+
+func BenchmarkBFloat16(b *testing.B) {
+	conn, err := GetNativeConnectionTCP(nil, nil, &clickhouse.Compression{
+		Method: clickhouse.CompressionLZ4,
+	})
+	ctx := context.Background()
+	if err != nil {
+		b.Fatal(err)
+	}
+	if !CheckMinServerServerVersion(conn, 24, 11, 0) {
+		b.Skip("BFloat16 requires ClickHouse 24.11+")
+		return
+	}
+	defer conn.Exec(ctx, "DROP TABLE IF EXISTS benchmark_bfloat16")
+
+	conn.Exec(ctx, `CREATE TABLE benchmark_bfloat16 (Col1 BFloat16) ENGINE = Null`)
+
+	const rowsInBlock = 10_000_000
+
+	for b.Loop() {
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO benchmark_bfloat16 VALUES")
+		if err != nil {
+			b.Fatal(err)
+		}
+		for range rowsInBlock {
+			if err := batch.Append(float32(122.112)); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err = batch.Send(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
The implementation is simple wrapper on top of ch-go's BFloat16 type

Merge ch-go support before merging this PR
https://github.com/ClickHouse/ch-go/pull/1127

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
