### PR TITLE
feat(slog): add support for structured and leveled logger

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -94,7 +95,7 @@ type nativeTransport interface {
 	connectedAtTime() time.Time
 	isReleased() bool
 	setReleased(released bool)
-	debugf(format string, v ...any)
+	getLogger() *slog.Logger
 	// freeBuffer is called if Options.FreeBufOnConnRelease is set
 	freeBuffer()
 	close() error
@@ -139,7 +140,7 @@ func (ch *clickhouse) Query(ctx context.Context, query string, args ...any) (row
 	if err != nil {
 		return nil, err
 	}
-	conn.debugf("[query] \"%s\"", query)
+	conn.getLogger().Info("executing query", slog.String("sql", query))
 	return conn.query(ctx, ch.release, query, args...)
 }
 
@@ -151,7 +152,7 @@ func (ch *clickhouse) QueryRow(ctx context.Context, query string, args ...any) d
 		}
 	}
 
-	conn.debugf("[query row] \"%s\"", query)
+	conn.getLogger().Info("executing query row", slog.String("sql", query))
 	return conn.queryRow(ctx, ch.release, query, args...)
 }
 
@@ -160,7 +161,7 @@ func (ch *clickhouse) Exec(ctx context.Context, query string, args ...any) error
 	if err != nil {
 		return err
 	}
-	conn.debugf("[exec] \"%s\"", query)
+	conn.getLogger().Info("executing statement", slog.String("sql", query))
 
 	if asyncOpt := queryOptionsAsync(ctx); asyncOpt.ok {
 		err = conn.asyncInsert(ctx, query, asyncOpt.wait, args...)
@@ -182,7 +183,7 @@ func (ch *clickhouse) PrepareBatch(ctx context.Context, query string, opts ...dr
 	if err != nil {
 		return nil, err
 	}
-	conn.debugf("[prepare batch] \"%s\"", query)
+	conn.getLogger().Info("preparing batch", slog.String("sql", query))
 	batch, err := conn.prepareBatch(ctx, ch.release, ch.acquire, query, getPrepareBatchOptions(opts...))
 	if err != nil {
 		return nil, err
@@ -206,7 +207,7 @@ func (ch *clickhouse) AsyncInsert(ctx context.Context, query string, wait bool, 
 	if err != nil {
 		return err
 	}
-	conn.debugf("[async insert] \"%s\"", query)
+	conn.getLogger().Info("async insert", slog.String("sql", query), slog.Bool("wait", wait))
 	if err := conn.asyncInsert(ctx, query, wait, args...); err != nil {
 		ch.release(conn, err)
 		return err
@@ -220,7 +221,7 @@ func (ch *clickhouse) Ping(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	conn.debugf("[ping]")
+	conn.getLogger().Debug("ping")
 	if err := conn.ping(ctx); err != nil {
 		ch.release(conn, err)
 		return err
@@ -318,7 +319,7 @@ func (ch *clickhouse) acquire(ctx context.Context) (conn nativeTransport, err er
 	if err == nil && conn != nil {
 		if !conn.isBad() {
 			conn.setReleased(false)
-			conn.debugf("[acquired from pool]")
+			conn.getLogger().Debug("connection acquired from pool")
 			return conn, nil
 		}
 
@@ -334,7 +335,7 @@ func (ch *clickhouse) acquire(ctx context.Context) (conn nativeTransport, err er
 		return nil, err
 	}
 
-	conn.debugf("[acquired new]")
+	conn.getLogger().Debug("new connection established")
 	return conn, nil
 
 }
@@ -346,9 +347,9 @@ func (ch *clickhouse) release(conn nativeTransport, err error) {
 	conn.setReleased(true)
 
 	if err != nil {
-		conn.debugf("[released with error]")
+		conn.getLogger().Debug("connection released with error", slog.Any("error", err))
 	} else {
-		conn.debugf("[released]")
+		conn.getLogger().Debug("connection released to pool")
 	}
 
 	select {
@@ -357,17 +358,19 @@ func (ch *clickhouse) release(conn nativeTransport, err error) {
 	}
 
 	if err != nil {
-		conn.debugf("[close: error] %s", err.Error())
+		conn.getLogger().Info("connection closed due to error", slog.Any("error", err))
 		conn.close()
 		return
 	} else if time.Since(conn.connectedAtTime()) >= ch.opt.ConnMaxLifetime {
-		conn.debugf("[close: lifetime expired]")
+		conn.getLogger().Debug("connection closed: lifetime expired",
+			slog.Duration("age", time.Since(conn.connectedAtTime())),
+			slog.Duration("max_lifetime", ch.opt.ConnMaxLifetime))
 		conn.close()
 		return
 	}
 
 	if ch.opt.FreeBufOnConnRelease {
-		conn.debugf("[free buffer]")
+		conn.getLogger().Debug("freeing connection buffer")
 		conn.freeBuffer()
 	}
 

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -140,7 +140,7 @@ func (ch *clickhouse) Query(ctx context.Context, query string, args ...any) (row
 	if err != nil {
 		return nil, err
 	}
-	conn.getLogger().Info("executing query", slog.String("sql", query))
+	conn.getLogger().Debug("executing query", slog.String("sql", query))
 	return conn.query(ctx, ch.release, query, args...)
 }
 
@@ -152,7 +152,7 @@ func (ch *clickhouse) QueryRow(ctx context.Context, query string, args ...any) d
 		}
 	}
 
-	conn.getLogger().Info("executing query row", slog.String("sql", query))
+	conn.getLogger().Debug("executing query row", slog.String("sql", query))
 	return conn.queryRow(ctx, ch.release, query, args...)
 }
 
@@ -161,7 +161,7 @@ func (ch *clickhouse) Exec(ctx context.Context, query string, args ...any) error
 	if err != nil {
 		return err
 	}
-	conn.getLogger().Info("executing statement", slog.String("sql", query))
+	conn.getLogger().Debug("executing statement", slog.String("sql", query))
 
 	if asyncOpt := queryOptionsAsync(ctx); asyncOpt.ok {
 		err = conn.asyncInsert(ctx, query, asyncOpt.wait, args...)
@@ -183,7 +183,7 @@ func (ch *clickhouse) PrepareBatch(ctx context.Context, query string, opts ...dr
 	if err != nil {
 		return nil, err
 	}
-	conn.getLogger().Info("preparing batch", slog.String("sql", query))
+	conn.getLogger().Debug("preparing batch", slog.String("sql", query))
 	batch, err := conn.prepareBatch(ctx, ch.release, ch.acquire, query, getPrepareBatchOptions(opts...))
 	if err != nil {
 		return nil, err
@@ -207,7 +207,7 @@ func (ch *clickhouse) AsyncInsert(ctx context.Context, query string, wait bool, 
 	if err != nil {
 		return err
 	}
-	conn.getLogger().Info("async insert", slog.String("sql", query), slog.Bool("wait", wait))
+	conn.getLogger().Debug("async insert", slog.String("sql", query), slog.Bool("wait", wait))
 	if err := conn.asyncInsert(ctx, query, wait, args...); err != nil {
 		ch.release(conn, err)
 		return err
@@ -358,7 +358,7 @@ func (ch *clickhouse) release(conn nativeTransport, err error) {
 	}
 
 	if err != nil {
-		conn.getLogger().Info("connection closed due to error", slog.Any("error", err))
+		conn.getLogger().Debug("connection closed due to error", slog.Any("error", err))
 		conn.close()
 		return
 	} else if time.Since(conn.connectedAtTime()) >= ch.opt.ConnMaxLifetime {

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -348,7 +348,6 @@ func (s *stdBatch) Exec(args []driver.Value) (driver.Result, error) {
 		values = append(values, v)
 	}
 	if err := s.batch.Append(values...); err != nil {
-		s.logger.Error("batch append error", slog.Any("error", err))
 		return nil, err
 	}
 	return driver.RowsAffected(0), nil

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -7,10 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"math/rand"
 	"net"
-	"os"
 	"reflect"
 	"sync/atomic"
 	"syscall"
@@ -24,27 +23,19 @@ var globalConnID int64
 type stdConnOpener struct {
 	err    error
 	opt    *Options
-	debugf func(format string, v ...any)
+	logger *slog.Logger
 }
 
 func (o *stdConnOpener) Driver() driver.Driver {
-	var debugf = func(format string, v ...any) {}
-	if o.opt.Debug {
-		if o.opt.Debugf != nil {
-			debugf = o.opt.Debugf
-		} else {
-			debugf = log.New(os.Stdout, "[clickhouse-std] ", 0).Printf
-		}
-	}
 	return &stdDriver{
 		opt:    o.opt,
-		debugf: debugf,
+		logger: o.logger,
 	}
 }
 
 func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) {
 	if o.err != nil {
-		o.debugf("[connect] opener error: %v\n", o.err)
+		o.logger.Error("opener error", slog.Any("error", o.err))
 		return nil, o.err
 	}
 	var (
@@ -80,20 +71,20 @@ func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) 
 			num = (random + i) % len(o.opt.Addr)
 		}
 		if conn, err = dialFunc(ctx, o.opt.Addr[num], connID, o.opt); err == nil {
-			var debugf = func(format string, v ...any) {}
-			if o.opt.Debug {
-				if o.opt.Debugf != nil {
-					debugf = o.opt.Debugf
-				} else {
-					debugf = log.New(os.Stdout, fmt.Sprintf("[clickhouse-std][conn=%d][%s] ", num, o.opt.Addr[num]), 0).Printf
-				}
-			}
+			// Create a logger with connection-specific context
+			connLogger := o.logger.With(
+				slog.Int("conn_num", num),
+				slog.String("addr", o.opt.Addr[num]),
+			)
 			return &stdDriver{
 				conn:   conn,
-				debugf: debugf,
+				logger: connLogger,
 			}, nil
 		} else {
-			o.debugf("[connect] error connecting to %s on connection %d: %v\n", o.opt.Addr[num], connID, err)
+			o.logger.Error("connection error",
+				slog.String("addr", o.opt.Addr[num]),
+				slog.Int("conn_id", connID),
+				slog.Any("error", err))
 		}
 	}
 
@@ -103,8 +94,7 @@ func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) 
 var _ driver.Connector = (*stdConnOpener)(nil)
 
 func init() {
-	var debugf = func(format string, v ...any) {}
-	sql.Register("clickhouse", &stdDriver{debugf: debugf})
+	sql.Register("clickhouse", &stdDriver{logger: newNoopLogger()})
 }
 
 // isConnBrokenError returns true if the error class indicates that the
@@ -125,31 +115,25 @@ func Connector(opt *Options) driver.Connector {
 	}
 
 	o := opt.setDefaults()
+	logger := o.logger().With(slog.String("component", "std-driver"))
 
-	var debugf = func(format string, v ...any) {}
-	if o.Debug {
-		if o.Debugf != nil {
-			debugf = o.Debugf
-		} else {
-			debugf = log.New(os.Stdout, "[clickhouse-std][opener] ", 0).Printf
-		}
-	}
 	return &stdConnOpener{
 		opt:    o,
-		debugf: debugf,
+		logger: logger,
 	}
 }
 
 func OpenDB(opt *Options) *sql.DB {
-	var debugf = func(format string, v ...any) {}
 	if opt == nil {
 		opt = &Options{}
 	}
 
 	o := opt.setDefaults()
+	logger := o.logger().With(slog.String("component", "std-driver"))
+
 	db := sql.OpenDB(&stdConnOpener{
 		opt:    o,
-		debugf: debugf,
+		logger: logger,
 	})
 
 	// Ok to set these configs irrespective of values in opt.
@@ -158,13 +142,6 @@ func OpenDB(opt *Options) *sql.DB {
 	db.SetMaxIdleConns(o.MaxIdleConns)
 	db.SetMaxOpenConns(o.MaxOpenConns)
 	db.SetConnMaxLifetime(o.ConnMaxLifetime)
-	if o.Debug {
-		if o.Debugf != nil {
-			debugf = o.Debugf
-		} else {
-			debugf = log.New(os.Stdout, "[clickhouse-std][opener] ", 0).Printf
-		}
-	}
 
 	return db
 }
@@ -183,7 +160,7 @@ type stdDriver struct {
 	opt    *Options
 	conn   stdConnect
 	commit func() error
-	debugf func(format string, v ...any)
+	logger *slog.Logger
 }
 
 var _ driver.Conn = (*stdDriver)(nil)
@@ -195,23 +172,20 @@ var _ driver.ConnPrepareContext = (*stdDriver)(nil)
 func (std *stdDriver) Open(dsn string) (_ driver.Conn, err error) {
 	var opt Options
 	if err := opt.fromDSN(dsn); err != nil {
-		std.debugf("Open dsn error: %v\n", err)
+		std.logger.Error("dsn parsing error", slog.Any("error", err))
 		return nil, err
 	}
 	o := opt.setDefaults()
-	var debugf = func(format string, v ...any) {}
-	if o.Debug {
-		debugf = log.New(os.Stdout, "[clickhouse-std][opener] ", 0).Printf
-	}
+	logger := o.logger().With(slog.String("component", "std-driver"))
 	o.ClientInfo.Comment = []string{"database/sql"}
-	return (&stdConnOpener{opt: o, debugf: debugf}).Connect(context.Background())
+	return (&stdConnOpener{opt: o, logger: logger}).Connect(context.Background())
 }
 
 var _ driver.Driver = (*stdDriver)(nil)
 
 func (std *stdDriver) ResetSession(ctx context.Context) error {
 	if std.conn.isBad() {
-		std.debugf("Resetting session because connection is bad")
+		std.logger.Debug("resetting session because connection is bad")
 		return driver.ErrBadConn
 	}
 	return nil
@@ -221,7 +195,7 @@ var _ driver.SessionResetter = (*stdDriver)(nil)
 
 func (std *stdDriver) Ping(ctx context.Context) error {
 	if std.conn.isBad() {
-		std.debugf("Ping: connection is bad")
+		std.logger.Debug("ping: connection is bad")
 		return driver.ErrBadConn
 	}
 
@@ -232,7 +206,7 @@ var _ driver.Pinger = (*stdDriver)(nil)
 
 func (std *stdDriver) Begin() (driver.Tx, error) {
 	if std.conn.isBad() {
-		std.debugf("Begin: connection is bad")
+		std.logger.Debug("begin: connection is bad")
 		return nil, driver.ErrBadConn
 	}
 
@@ -241,7 +215,7 @@ func (std *stdDriver) Begin() (driver.Tx, error) {
 
 func (std *stdDriver) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
 	if std.conn.isBad() {
-		std.debugf("BeginTx: connection is bad")
+		std.logger.Debug("begin tx: connection is bad")
 		return nil, driver.ErrBadConn
 	}
 
@@ -258,10 +232,10 @@ func (std *stdDriver) Commit() error {
 
 	if err := std.commit(); err != nil {
 		if isConnBrokenError(err) {
-			std.debugf("Commit got EOF error: resetting connection")
+			std.logger.Debug("commit got EOF error: resetting connection")
 			return driver.ErrBadConn
 		}
-		std.debugf("Commit error: %v\n", err)
+		std.logger.Error("commit error", slog.Any("error", err))
 		return err
 	}
 	return nil
@@ -281,7 +255,7 @@ var _ driver.NamedValueChecker = (*stdDriver)(nil)
 
 func (std *stdDriver) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 	if std.conn.isBad() {
-		std.debugf("ExecContext: connection is bad")
+		std.logger.Debug("exec context: connection is bad")
 		return nil, driver.ErrBadConn
 	}
 
@@ -294,10 +268,10 @@ func (std *stdDriver) ExecContext(ctx context.Context, query string, args []driv
 
 	if err != nil {
 		if isConnBrokenError(err) {
-			std.debugf("ExecContext got a fatal error, resetting connection: %v\n", err)
+			std.logger.Error("exec context got a fatal error, resetting connection", slog.Any("error", err))
 			return nil, driver.ErrBadConn
 		}
-		std.debugf("ExecContext error: %v\n", err)
+		std.logger.Error("exec context error", slog.Any("error", err))
 		return nil, err
 	}
 	return driver.RowsAffected(0), nil
@@ -305,22 +279,22 @@ func (std *stdDriver) ExecContext(ctx context.Context, query string, args []driv
 
 func (std *stdDriver) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 	if std.conn.isBad() {
-		std.debugf("QueryContext: connection is bad")
+		std.logger.Debug("query context: connection is bad")
 		return nil, driver.ErrBadConn
 	}
 
 	r, err := std.conn.query(ctx, func(nativeTransport, error) {}, query, rebind(args)...)
 	if isConnBrokenError(err) {
-		std.debugf("QueryContext got a fatal error, resetting connection: %v\n", err)
+		std.logger.Error("query context got a fatal error, resetting connection", slog.Any("error", err))
 		return nil, driver.ErrBadConn
 	}
 	if err != nil {
-		std.debugf("QueryContext error: %v\n", err)
+		std.logger.Error("query context error", slog.Any("error", err))
 		return nil, err
 	}
 	return &stdRows{
 		rows:   r,
-		debugf: std.debugf,
+		logger: std.logger,
 	}, nil
 }
 
@@ -330,23 +304,23 @@ func (std *stdDriver) Prepare(query string) (driver.Stmt, error) {
 
 func (std *stdDriver) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
 	if std.conn.isBad() {
-		std.debugf("PrepareContext: connection is bad")
+		std.logger.Debug("prepare context: connection is bad")
 		return nil, driver.ErrBadConn
 	}
 
 	batch, err := std.conn.prepareBatch(ctx, func(nativeTransport, error) {}, func(context.Context) (nativeTransport, error) { return nil, nil }, query, chdriver.PrepareBatchOptions{})
 	if err != nil {
 		if isConnBrokenError(err) {
-			std.debugf("PrepareContext got a fatal error, resetting connection: %v\n", err)
+			std.logger.Error("prepare context got a fatal error, resetting connection", slog.Any("error", err))
 			return nil, driver.ErrBadConn
 		}
-		std.debugf("PrepareContext error: %v\n", err)
+		std.logger.Error("prepare context error", slog.Any("error", err))
 		return nil, err
 	}
 	std.commit = batch.Send
 	return &stdBatch{
 		batch:  batch,
-		debugf: std.debugf,
+		logger: std.logger,
 	}, nil
 }
 
@@ -354,17 +328,17 @@ func (std *stdDriver) Close() error {
 	err := std.conn.close()
 	if err != nil {
 		if isConnBrokenError(err) {
-			std.debugf("Close got a fatal error, resetting connection: %v\n", err)
+			std.logger.Error("close got a fatal error, resetting connection", slog.Any("error", err))
 			return driver.ErrBadConn
 		}
-		std.debugf("Close error: %v\n", err)
+		std.logger.Error("close error", slog.Any("error", err))
 	}
 	return err
 }
 
 type stdBatch struct {
 	batch  chdriver.Batch
-	debugf func(format string, v ...any)
+	logger *slog.Logger
 }
 
 func (s *stdBatch) NumInput() int { return -1 }
@@ -374,7 +348,7 @@ func (s *stdBatch) Exec(args []driver.Value) (driver.Result, error) {
 		values = append(values, v)
 	}
 	if err := s.batch.Append(values...); err != nil {
-		s.debugf("[batch][exec] append error: %v", err)
+		s.logger.Error("batch append error", slog.Any("error", err))
 		return nil, err
 	}
 	return driver.RowsAffected(0), nil
@@ -399,7 +373,7 @@ func (s *stdBatch) Close() error { return nil }
 
 type stdRows struct {
 	rows   *rows
-	debugf func(format string, v ...any)
+	logger *slog.Logger
 }
 
 func (r *stdRows) Columns() []string {
@@ -449,7 +423,7 @@ var _ driver.RowsColumnTypePrecisionScale = (*stdRows)(nil)
 func (r *stdRows) Next(dest []driver.Value) error {
 	if len(r.rows.block.Columns) != len(dest) {
 		err := fmt.Errorf("expected %d destination arguments in Next, not %d", len(r.rows.block.Columns), len(dest))
-		r.debugf("Next length error: %v\n", err)
+		r.logger.Error("next length error", slog.Any("error", err))
 		return &OpError{
 			Op:  "Next",
 			Err: err,
@@ -462,7 +436,7 @@ func (r *stdRows) Next(dest []driver.Value) error {
 			case driver.Valuer:
 				v, err := value.Value()
 				if err != nil {
-					r.debugf("Next row error: %v\n", err)
+					r.logger.Error("next row error", slog.Any("error", err))
 					return err
 				}
 				dest[i] = v
@@ -488,7 +462,7 @@ func (r *stdRows) Next(dest []driver.Value) error {
 		return nil
 	}
 	if err := r.rows.Err(); err != nil {
-		r.debugf("Next rows error: %v\n", err)
+		r.logger.Error("next rows error", slog.Any("error", err))
 		return err
 	}
 	return io.EOF
@@ -514,7 +488,7 @@ var _ driver.RowsNextResultSet = (*stdRows)(nil)
 func (r *stdRows) Close() error {
 	err := r.rows.Close()
 	if err != nil {
-		r.debugf("Rows Close error: %v\n", err)
+		r.logger.Error("rows close error", slog.Any("error", err))
 	}
 	return err
 }

--- a/conn.go
+++ b/conn.go
@@ -137,12 +137,12 @@ type connect struct {
 	closeMutex           sync.Mutex
 }
 
-func (c *connect) debugf(format string, v ...any) {
-	c.logger.Debug(fmt.Sprintf(format, v...))
-}
-
 func (c *connect) connID() int {
 	return c.id
+}
+
+func (c *connect) getLogger() *slog.Logger {
+	return c.logger
 }
 
 func (c *connect) connectedAtTime() time.Time {
@@ -248,7 +248,10 @@ func (c *connect) progress() (*Progress, error) {
 		return nil, err
 	}
 
-	c.debugf("[progress] %s", &progress)
+	c.logger.Debug("query progress",
+		slog.Uint64("rows", progress.Rows),
+		slog.Uint64("bytes", progress.Bytes),
+		slog.Uint64("total_rows", progress.TotalRows))
 	return &progress, nil
 }
 
@@ -258,7 +261,9 @@ func (c *connect) exception() error {
 		return err
 	}
 
-	c.debugf("[exception] %s", e.Error())
+	c.logger.Warn("server exception received",
+		slog.String("error", e.Error()),
+		slog.Int("code", int(e.Code)))
 	return &e
 }
 
@@ -276,11 +281,14 @@ func (c *connect) compressBuffer(start int) error {
 func (c *connect) sendData(block *proto.Block, name string) error {
 	if c.isClosed() {
 		err := errors.New("attempted sending on closed connection")
-		c.debugf("[send data] err: %v", err)
+		c.logger.Error("send data failed: connection closed", slog.Any("error", err))
 		return err
 	}
 
-	c.debugf("[send data] compression=%q", c.compression)
+	c.logger.Debug("sending data block",
+		slog.String("compression", c.compression.String()),
+		slog.Int("columns", len(block.Columns)),
+		slog.Int("rows", block.Rows()))
 	c.buffer.PutByte(proto.ClientData)
 	c.buffer.PutString(name)
 
@@ -298,7 +306,8 @@ func (c *connect) sendData(block *proto.Block, name string) error {
 			if err := c.compressBuffer(compressionOffset); err != nil {
 				return err
 			}
-			c.debugf("[buff compress] buffer size: %d", len(c.buffer.Buf))
+			c.logger.Debug("buffer compressed",
+				slog.Int("buffer_bytes", len(c.buffer.Buf)))
 			if err := c.flush(); err != nil {
 				return fmt.Errorf("send data: failed to flush partial block (conn_id=%d, col=%d): %w", c.id, i, err)
 			}
@@ -313,17 +322,26 @@ func (c *connect) sendData(block *proto.Block, name string) error {
 	if err := c.flush(); err != nil {
 		switch {
 		case errors.Is(err, syscall.EPIPE):
-			c.debugf("[send data] pipe is broken, closing connection")
+			c.logger.Error("connection broken: pipe error",
+				slog.Any("error", err),
+				slog.Int("block_columns", len(block.Columns)),
+				slog.Int("block_rows", block.Rows()))
 			c.setClosed()
 			return fmt.Errorf("send data: connection broken (EPIPE) to %s (conn_id=%d, block_cols=%d, block_rows=%d): %w",
 				c.conn.RemoteAddr(), c.id, len(block.Columns), block.Rows(), err)
 		case errors.Is(err, io.EOF):
-			c.debugf("[send data] unexpected EOF, closing connection")
+			c.logger.Error("connection closed unexpectedly",
+				slog.Any("error", err),
+				slog.Int("block_columns", len(block.Columns)),
+				slog.Int("block_rows", block.Rows()))
 			c.setClosed()
 			return fmt.Errorf("send data: unexpected EOF to %s (conn_id=%d, block_cols=%d, block_rows=%d): %w",
 				c.conn.RemoteAddr(), c.id, len(block.Columns), block.Rows(), err)
 		default:
-			c.debugf("[send data] unexpected error: %v", err)
+			c.logger.Error("send data failed",
+				slog.Any("error", err),
+				slog.Int("block_columns", len(block.Columns)),
+				slog.Int("block_rows", block.Rows()))
 			return fmt.Errorf("send data: write error to %s (conn_id=%d, block_cols=%d, block_rows=%d): %w",
 				c.conn.RemoteAddr(), c.id, len(block.Columns), block.Rows(), err)
 		}
@@ -349,18 +367,18 @@ func serverVersionToContext(v ServerVersion) column.ServerContext {
 func (c *connect) readData(ctx context.Context, packet byte, compressible bool) (*proto.Block, error) {
 	if c.isClosed() {
 		err := errors.New("attempted reading on closed connection")
-		c.debugf("[read data] err: %v", err)
+		c.logger.Error("read data failed: connection closed", slog.Any("error", err))
 		return nil, err
 	}
 
 	if c.reader == nil {
 		err := errors.New("attempted reading on nil reader")
-		c.debugf("[read data] err: %v", err)
+		c.logger.Error("read data failed: nil reader", slog.Any("error", err))
 		return nil, err
 	}
 
 	if _, err := c.reader.Str(); err != nil {
-		c.debugf("[read data] str error: %v", err)
+		c.logger.Error("read data failed: cannot read block name", slog.Any("error", err))
 		return nil, fmt.Errorf("read data: failed to read block name from %s (conn_id=%d): %w",
 			c.conn.RemoteAddr(), c.id, err)
 	}
@@ -380,13 +398,18 @@ func (c *connect) readData(ctx context.Context, packet byte, compressible bool) 
 	serverContext.Timezone = location
 	block := proto.Block{ServerContext: &serverContext}
 	if err := block.Decode(c.reader, c.revision); err != nil {
-		c.debugf("[read data] decode error: %v", err)
+		c.logger.Error("read data failed: decode error",
+			slog.Any("error", err),
+			slog.String("compression", c.compression.String()))
 		return nil, fmt.Errorf("read data: failed to decode block from %s (conn_id=%d, compression=%s): %w",
 			c.conn.RemoteAddr(), c.id, c.compression, err)
 	}
 
 	block.Packet = packet
-	c.debugf("[read data] compression=%q. block: columns=%d, rows=%d", c.compression, len(block.Columns), block.Rows())
+	c.logger.Debug("data block received",
+		slog.String("compression", c.compression.String()),
+		slog.Int("columns", len(block.Columns)),
+		slog.Int("rows", block.Rows()))
 	return &block, nil
 }
 

--- a/conn_batch.go
+++ b/conn_batch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"regexp"
 	"slices"
@@ -140,7 +141,7 @@ func (b *batch) appendRowsBlocks(r *rows) error {
 
 	for r.Next() {
 		if lastReadLock == nil { // make sure the first block is logged
-			b.conn.debugf("[batch.appendRowsBlocks] blockNum = %d", blockNum)
+			b.conn.logger.Debug("batch: appending rows block", slog.Int("block_num", blockNum))
 		}
 
 		// rows.Next() will read the next block from the server only if the current block is empty
@@ -151,7 +152,7 @@ func (b *batch) appendRowsBlocks(r *rows) error {
 				return err
 			}
 			blockNum++
-			b.conn.debugf("[batch.appendRowsBlocks] blockNum = %d", blockNum)
+			b.conn.logger.Debug("batch: appending rows block", slog.Int("block_num", blockNum))
 		}
 
 		b.block = r.block

--- a/conn_error_context_test.go
+++ b/conn_error_context_test.go
@@ -71,7 +71,7 @@ func createMockConnect(mockConn *mockNetConn) *connect {
 		compression:          CompressionLZ4,
 		compressor:           compressor,
 		maxCompressionBuffer: 1024 * 1024,
-		debugfFunc:           func(format string, v ...any) {},
+		logger:               newNoopLogger(),
 		opt:                  &Options{},
 		revision:             ClientTCPProtocolVersion,
 	}

--- a/conn_handshake.go
+++ b/conn_handshake.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	_ "embed"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
@@ -10,7 +11,9 @@ import (
 
 func (c *connect) handshake(auth Auth) error {
 	defer c.buffer.Reset()
-	c.debugf("[handshake] -> %s", proto.ClientHandshake{})
+	c.logger.Debug("handshake: sending client hello",
+		slog.Int("protocol_version", ClientTCPProtocolVersion),
+		slog.String("client_name", c.opt.ClientInfo.String()))
 	// set a read deadline - alternative to context.Read operation will fail if no data is received after deadline.
 	c.conn.SetReadDeadline(time.Now().Add(c.readTimeout))
 	defer c.conn.SetReadDeadline(time.Time{})
@@ -50,7 +53,7 @@ func (c *connect) handshake(auth Auth) error {
 					c.conn.RemoteAddr(), c.id, err)
 			}
 		case proto.ServerEndOfStream:
-			c.debugf("[handshake] <- end of stream")
+			c.logger.Debug("handshake: received end of stream")
 			return nil
 		default:
 			return fmt.Errorf("[handshake] unexpected packet [%d] from server", packet)
@@ -62,9 +65,15 @@ func (c *connect) handshake(auth Auth) error {
 
 	if c.revision > c.server.Revision {
 		c.revision = c.server.Revision
-		c.debugf("[handshake] downgrade client proto")
+		c.logger.Debug("handshake: downgrading client protocol",
+			slog.Uint64("from_revision", c.revision),
+			slog.Uint64("to_revision", c.server.Revision))
 	}
-	c.debugf("[handshake] <- %s", c.server)
+	c.logger.Info("handshake complete",
+		slog.String("server_name", c.server.Name),
+		slog.String("server_version", c.server.Version.String()),
+		slog.Uint64("server_revision", c.server.Revision),
+		slog.String("server_timezone", c.server.Timezone.String()))
 	return nil
 }
 

--- a/conn_handshake.go
+++ b/conn_handshake.go
@@ -69,7 +69,7 @@ func (c *connect) handshake(auth Auth) error {
 			slog.Uint64("from_revision", c.revision),
 			slog.Uint64("to_revision", c.server.Revision))
 	}
-	c.logger.Info("handshake complete",
+	c.logger.Debug("handshake complete",
 		slog.String("server_name", c.server.Name),
 		slog.String("server_version", c.server.Version.String()),
 		slog.Uint64("server_revision", c.server.Revision),

--- a/conn_http.go
+++ b/conn_http.go
@@ -289,16 +289,16 @@ func (h *httpConnect) connectedAtTime() time.Time {
 	return h.connectedAt
 }
 
+func (h *httpConnect) getLogger() *slog.Logger {
+	return h.logger
+}
+
 func (h *httpConnect) isReleased() bool {
 	return h.released
 }
 
 func (h *httpConnect) setReleased(released bool) {
 	h.released = released
-}
-
-func (h *httpConnect) debugf(format string, v ...any) {
-	h.logger.Debug(fmt.Sprintf(format, v...))
 }
 
 func (h *httpConnect) freeBuffer() {
@@ -309,7 +309,7 @@ func (h *httpConnect) isBad() bool {
 }
 
 func (h *httpConnect) queryHello(ctx context.Context, release nativeTransportRelease) (proto.ServerHandshake, error) {
-	h.debugf("[query hello]")
+	h.logger.Debug("querying server info via HTTP")
 	ctx = Context(ctx, ignoreExternalTables())
 	query := "SELECT displayName(), version(), revision(), timezone()"
 	rows, err := h.query(ctx, release, query)
@@ -446,7 +446,7 @@ func (h *httpConnect) readData(reader *chproto.Reader, timezone *time.Location, 
 			captureBuffer.Write(buf[:n])
 		}
 		if readErr != nil {
-			h.debugf("[readData]: decoding block failed when parsing exception block: %v", err)
+			h.logger.Error("HTTP read data: decode error while parsing exception block", slog.Any("error", err))
 		}
 
 		// Check if the captured data contains the exception marker

--- a/conn_http.go
+++ b/conn_http.go
@@ -10,12 +10,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"mime/multipart"
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -145,19 +144,9 @@ func applyOptionsToRequest(ctx context.Context, req *http.Request, opt *Options)
 }
 
 func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpConnect, error) {
-	debugf := func(format string, v ...any) {}
-	if opt.Debug {
-		if opt.Debugf != nil {
-			debugf = func(format string, v ...any) {
-				opt.Debugf(
-					"[clickhouse-http][%s][id=%d] "+format,
-					append([]interface{}{addr, num}, v...)...,
-				)
-			}
-		} else {
-			debugf = log.New(os.Stdout, fmt.Sprintf("[clickhouse-http][%s][id=%d]", addr, num), 0).Printf
-		}
-	}
+	// Get base logger and enrich with connection-specific context
+	baseLogger := opt.logger()
+	logger := prepareConnLogger(baseLogger, num, addr, "http")
 
 	if opt.scheme == "" {
 		switch opt.Protocol {
@@ -213,7 +202,7 @@ func dialHttp(ctx context.Context, addr string, num int, opt *Options) (*httpCon
 		id:          num,
 		connectedAt: time.Now(),
 		released:    false,
-		debugfFunc:  debugf,
+		logger:      logger,
 		opt:         opt,
 		client: &http.Client{
 			Transport: rt,
@@ -274,7 +263,7 @@ type httpConnect struct {
 	id              int
 	connectedAt     time.Time
 	released        bool
-	debugfFunc      func(format string, v ...any)
+	logger          *slog.Logger
 	opt             *Options
 	revision        uint64
 	encodeRevision  uint64
@@ -309,7 +298,7 @@ func (h *httpConnect) setReleased(released bool) {
 }
 
 func (h *httpConnect) debugf(format string, v ...any) {
-	h.debugfFunc(format, v...)
+	h.logger.Debug(fmt.Sprintf(format, v...))
 }
 
 func (h *httpConnect) freeBuffer() {
@@ -457,7 +446,7 @@ func (h *httpConnect) readData(reader *chproto.Reader, timezone *time.Location, 
 			captureBuffer.Write(buf[:n])
 		}
 		if readErr != nil {
-			h.debugf("[readData]: decoding block failed when parsing exception block: %w", err)
+			h.debugf("[readData]: decoding block failed when parsing exception block: %v", err)
 		}
 
 		// Check if the captured data contains the exception marker

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
@@ -263,14 +264,16 @@ func (b *httpBatch) Send() (err error) {
 	options.settings["query"] = b.query
 	headers["Content-Type"] = "application/octet-stream"
 
-	b.conn.debugf("[batch send start] columns=%d rows=%d", len(b.block.Columns), b.block.Rows())
+	b.conn.logger.Info("batch: sending via HTTP",
+		slog.Int("columns", len(b.block.Columns)),
+		slog.Int("rows", b.block.Rows()))
 	res, err := b.conn.sendStreamQuery(b.ctx, pipeReader, &options, headers)
 	if err != nil {
 		return fmt.Errorf("batch sendStreamQuery: %w", err)
 	}
 	discardAndClose(res.Body)
 
-	b.conn.debugf("[batch send complete]")
+	b.conn.logger.Debug("batch: send complete")
 	b.block.Reset()
 
 	return nil

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -3,11 +3,11 @@ package clickhouse
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"io"
+	"log/slog"
 	"os"
 	"slices"
 )
@@ -264,7 +264,7 @@ func (b *httpBatch) Send() (err error) {
 	options.settings["query"] = b.query
 	headers["Content-Type"] = "application/octet-stream"
 
-	b.conn.logger.Info("batch: sending via HTTP",
+	b.conn.logger.Debug("batch: sending via HTTP",
 		slog.Int("columns", len(b.block.Columns)),
 		slog.Int("rows", b.block.Rows()))
 	res, err := b.conn.sendStreamQuery(b.ctx, pipeReader, &options, headers)

--- a/conn_http_query.go
+++ b/conn_http_query.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"io"
+	"log/slog"
 
 	chproto "github.com/ClickHouse/ch-go/proto"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
@@ -29,7 +29,7 @@ func (r *capturingReader) Read(p []byte) (n int, err error) {
 
 // release is ignored, because http used by std with empty release function
 func (h *httpConnect) query(ctx context.Context, release nativeTransportRelease, query string, args ...any) (*rows, error) {
-	h.logger.Info("HTTP query", slog.String("sql", query))
+	h.logger.Debug("HTTP query", slog.String("sql", query))
 	options := queryOptions(ctx)
 	query, err := bindQueryOrAppendParameters(true, &options, query, h.handshake.Timezone, args...)
 	if err != nil {

--- a/conn_http_query.go
+++ b/conn_http_query.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"io"
 
 	chproto "github.com/ClickHouse/ch-go/proto"
@@ -28,7 +29,7 @@ func (r *capturingReader) Read(p []byte) (n int, err error) {
 
 // release is ignored, because http used by std with empty release function
 func (h *httpConnect) query(ctx context.Context, release nativeTransportRelease, query string, args ...any) (*rows, error) {
-	h.debugf("[http query] \"%s\"", query)
+	h.logger.Info("HTTP query", slog.String("sql", query))
 	options := queryOptions(ctx)
 	query, err := bindQueryOrAppendParameters(true, &options, query, h.handshake.Timezone, args...)
 	if err != nil {

--- a/conn_logs.go
+++ b/conn_logs.go
@@ -2,6 +2,7 @@ package clickhouse
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
@@ -23,7 +24,7 @@ func (c *connect) logs(ctx context.Context) ([]Log, error) {
 	if err != nil {
 		return nil, err
 	}
-	c.debugf("[logs] rows=%d", block.Rows())
+	c.logger.Debug("server logs received", slog.Int("rows", block.Rows()))
 	var (
 		logs  []Log
 		names = block.ColumnsNames()

--- a/conn_ping.go
+++ b/conn_ping.go
@@ -19,7 +19,7 @@ func (c *connect) ping(ctx context.Context) (err error) {
 		c.conn.SetDeadline(deadline)
 		defer c.conn.SetDeadline(time.Time{})
 	}
-	c.debugf("[ping] -> ping")
+	c.logger.Debug("ping: sending")
 	c.buffer.PutByte(proto.ClientPing)
 	if err := c.flush(); err != nil {
 		return fmt.Errorf("ping: failed to send ping to %s (conn_id=%d): %w",
@@ -40,7 +40,7 @@ func (c *connect) ping(ctx context.Context) (err error) {
 				return err
 			}
 		case proto.ServerPong:
-			c.debugf("[ping] <- pong")
+			c.logger.Debug("ping: received pong")
 			return nil
 		default:
 			return fmt.Errorf("unexpected packet %d", packet)

--- a/conn_pool_test.go
+++ b/conn_pool_test.go
@@ -2,7 +2,7 @@ package clickhouse
 
 import (
 	"context"
-	"fmt"
+	"log/slog"
 	"sync"
 	"testing"
 	"time"
@@ -532,10 +532,8 @@ func (m *mockTransport) setReleased(released bool) {
 	m.released = released
 }
 
-func (m *mockTransport) debugf(format string, v ...any) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.debugMessages = append(m.debugMessages, fmt.Sprintf(format, v...))
+func (m *mockTransport) getLogger() *slog.Logger {
+	return newNoopLogger()
 }
 
 func (m *mockTransport) freeBuffer() {

--- a/conn_process.go
+++ b/conn_process.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"io"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
@@ -76,7 +77,7 @@ func (c *connect) firstBlockImpl(ctx context.Context, on *onProcess) (*proto.Blo
 			return c.readData(ctx, packet, true)
 
 		case proto.ServerEndOfStream:
-			c.debugf("[end of stream]")
+			c.logger.Debug("end of stream received")
 			return nil, io.EOF
 
 		default:
@@ -147,7 +148,7 @@ func (c *connect) processImpl(ctx context.Context, on *onProcess) error {
 
 		switch packet {
 		case proto.ServerEndOfStream:
-			c.debugf("[end of stream]")
+			c.logger.Debug("end of stream received")
 			return nil
 		}
 
@@ -177,14 +178,17 @@ func (c *connect) handle(ctx context.Context, packet byte, on *onProcess) error 
 		if err := info.Decode(c.reader, c.revision); err != nil {
 			return err
 		}
-		c.debugf("[profile info] %s", &info)
+		c.logger.Debug("profile info received",
+			slog.Uint64("rows", info.Rows),
+			slog.Uint64("blocks", info.Blocks),
+			slog.Uint64("bytes", info.Bytes))
 		on.profileInfo(&info)
 	case proto.ServerTableColumns:
 		var info proto.TableColumns
 		if err := info.Decode(c.reader, c.revision); err != nil {
 			return err
 		}
-		c.debugf("[table columns]")
+		c.logger.Debug("table columns received")
 	case proto.ServerProfileEvents:
 		scanEvents := on.profileEvents != nil
 		events, err := c.profileEvents(ctx, scanEvents)
@@ -205,7 +209,7 @@ func (c *connect) handle(ctx context.Context, packet byte, on *onProcess) error 
 		if err != nil {
 			return err
 		}
-		c.debugf("[progress] %s", progress)
+		// Progress is already logged in c.progress()
 		on.progress(progress)
 	default:
 		return &OpError{
@@ -217,7 +221,7 @@ func (c *connect) handle(ctx context.Context, packet byte, on *onProcess) error 
 }
 
 func (c *connect) cancel() error {
-	c.debugf("[cancel]")
+	c.logger.Debug("cancelling query")
 	c.buffer.PutUVarInt(proto.ClientCancel)
 	wErr := c.flush()
 	// don't reuse a cancelled query as we don't drain the connection

--- a/conn_profile_events.go
+++ b/conn_profile_events.go
@@ -2,6 +2,7 @@ package clickhouse
 
 import (
 	"context"
+	"log/slog"
 	"reflect"
 	"time"
 
@@ -22,9 +23,9 @@ func (c *connect) profileEvents(ctx context.Context, scanEvents bool) ([]Profile
 	if err != nil {
 		return nil, err
 	}
-	c.debugf("[profile events] rows=%d", block.Rows())
+	c.logger.Debug("profile events received", slog.Int("rows", block.Rows()))
 	if !scanEvents {
-		c.debugf("[profile events] skipping scan")
+		c.logger.Debug("profile events: skipping scan")
 		return nil, nil
 	}
 	var (

--- a/conn_query.go
+++ b/conn_query.go
@@ -2,6 +2,8 @@ package clickhouse
 
 import (
 	"context"
+	"log/slog"
+
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
@@ -14,7 +16,7 @@ func (c *connect) query(ctx context.Context, release nativeTransportRelease, que
 	)
 
 	if err != nil {
-		c.debugf("[bindQuery] error: %v", err)
+		c.logger.Error("failed to bind query parameters", slog.Any("error", err))
 		release(c, err)
 		return nil, err
 	}
@@ -27,7 +29,7 @@ func (c *connect) query(ctx context.Context, release nativeTransportRelease, que
 	init, err := c.firstBlock(ctx, onProcess)
 
 	if err != nil {
-		c.debugf("[query] first block error: %v", err)
+		c.logger.Error("failed to get first block", slog.Any("error", err))
 		release(c, err)
 		return nil, err
 	}
@@ -47,7 +49,7 @@ func (c *connect) query(ctx context.Context, release nativeTransportRelease, que
 		}
 		err := c.process(ctx, onProcess)
 		if err != nil {
-			c.debugf("[query] process error: %v", err)
+			c.logger.Error("query processing failed", slog.Any("error", err))
 			errors <- err
 		}
 		close(stream)

--- a/conn_send_query.go
+++ b/conn_send_query.go
@@ -1,13 +1,17 @@
 package clickhouse
 
 import (
+	"log/slog"
+
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
 // Connection::sendQuery
 // https://github.com/ClickHouse/ClickHouse/blob/master/src/Client/Connection.cpp
 func (c *connect) sendQuery(body string, o *QueryOptions) error {
-	c.debugf("[send query] compression=%q %s", c.compression, body)
+	c.logger.Debug("sending query",
+		slog.String("compression", c.compression.String()),
+		slog.String("query", body))
 	c.buffer.PutByte(proto.ClientQuery)
 	q := proto.Query{
 		ClientTCPProtocolVersion: ClientTCPProtocolVersion,

--- a/examples/clickhouse_api/logger_test.go
+++ b/examples/clickhouse_api/logger_test.go
@@ -1,4 +1,4 @@
-package clickhouse_api_test
+package clickhouse_api
 
 import (
 	"fmt"
@@ -8,7 +8,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
-func ExampleOptions_logger() {
+func Logger() error {
 	// Create a structured logger with JSON output
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
@@ -24,16 +24,16 @@ func ExampleOptions_logger() {
 		Logger: logger,
 	})
 	if err != nil {
-		fmt.Printf("Failed to connect: %v\n", err)
-		return
+		return err
 	}
 	defer conn.Close()
 
 	// All connection operations will now be logged with structured fields
 	// Output will include fields like: conn_id, remote_addr, protocol, etc.
+	return nil
 }
 
-func ExampleOptions_legacyDebug() {
+func LegacyDebug() error {
 	conn, err := clickhouse.Open(&clickhouse.Options{
 		Addr: []string{"localhost:9000"},
 		Auth: clickhouse.Auth{
@@ -47,15 +47,15 @@ func ExampleOptions_legacyDebug() {
 		},
 	})
 	if err != nil {
-		fmt.Printf("Failed to connect: %v\n", err)
-		return
+		return err
 	}
 	defer conn.Close()
 
 	// Legacy Debugf will be called for all log messages
+	return nil
 }
 
-func ExampleOptions_textLogger() {
+func TextLogger() error {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	}))
@@ -65,16 +65,16 @@ func ExampleOptions_textLogger() {
 		Logger: logger,
 	})
 	if err != nil {
-		fmt.Printf("Failed to connect: %v\n", err)
-		return
+		return err
 	}
 	defer conn.Close()
 
 	// Logs will be output in human-readable text format
 	// Example: time=2024-01-21T10:00:00.000Z level=DEBUG msg="query" sql="SELECT 1" conn_id=1
+	return nil
 }
 
-func ExampleOptions_enrichedLogger() {
+func EnrichedLogger() error {
 	baseLogger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	}))
@@ -91,11 +91,11 @@ func ExampleOptions_enrichedLogger() {
 		Logger: enrichedLogger,
 	})
 	if err != nil {
-		fmt.Printf("Failed to connect: %v\n", err)
-		return
+		return err
 	}
 	defer conn.Close()
 
 	// All logs will include service, environment, and version fields
 	// in addition to the connection-specific fields
+	return nil
 }

--- a/examples/clickhouse_api/logger_test.go
+++ b/examples/clickhouse_api/logger_test.go
@@ -9,17 +9,22 @@ import (
 )
 
 func Logger() error {
+	env, err := GetNativeTestEnvironment()
+	if err != nil {
+		return err
+	}
+
 	// Create a structured logger with JSON output
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	}))
 
 	conn, err := clickhouse.Open(&clickhouse.Options{
-		Addr: []string{"localhost:9000"},
+		Addr: []string{fmt.Sprintf("%s:%d", env.Host, env.Port)},
 		Auth: clickhouse.Auth{
-			Database: "default",
-			Username: "default",
-			Password: "",
+			Database: env.Database,
+			Username: env.Username,
+			Password: env.Password,
 		},
 		Logger: logger,
 	})
@@ -34,12 +39,16 @@ func Logger() error {
 }
 
 func LegacyDebug() error {
+	env, err := GetNativeTestEnvironment()
+	if err != nil {
+		return err
+	}
 	conn, err := clickhouse.Open(&clickhouse.Options{
-		Addr: []string{"localhost:9000"},
+		Addr: []string{fmt.Sprintf("%s:%d", env.Host, env.Port)},
 		Auth: clickhouse.Auth{
-			Database: "default",
-			Username: "default",
-			Password: "",
+			Database: env.Database,
+			Username: env.Username,
+			Password: env.Password,
 		},
 		Debug: true,
 		Debugf: func(format string, v ...any) {
@@ -56,12 +65,21 @@ func LegacyDebug() error {
 }
 
 func TextLogger() error {
+	env, err := GetNativeTestEnvironment()
+	if err != nil {
+		return err
+	}
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	}))
 
 	conn, err := clickhouse.Open(&clickhouse.Options{
-		Addr:   []string{"localhost:9000"},
+		Addr: []string{fmt.Sprintf("%s:%d", env.Host, env.Port)},
+		Auth: clickhouse.Auth{
+			Database: env.Database,
+			Username: env.Username,
+			Password: env.Password,
+		},
 		Logger: logger,
 	})
 	if err != nil {
@@ -75,6 +93,10 @@ func TextLogger() error {
 }
 
 func EnrichedLogger() error {
+	env, err := GetNativeTestEnvironment()
+	if err != nil {
+		return err
+	}
 	baseLogger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	}))
@@ -87,7 +109,12 @@ func EnrichedLogger() error {
 	)
 
 	conn, err := clickhouse.Open(&clickhouse.Options{
-		Addr:   []string{"localhost:9000"},
+		Addr: []string{fmt.Sprintf("%s:%d", env.Host, env.Port)},
+		Auth: clickhouse.Auth{
+			Database: env.Database,
+			Username: env.Username,
+			Password: env.Password,
+		},
 		Logger: enrichedLogger,
 	})
 	if err != nil {

--- a/examples/clickhouse_api/main_test.go
+++ b/examples/clickhouse_api/main_test.go
@@ -209,6 +209,13 @@ func TestSSLNoVerify(t *testing.T) {
 	require.NoError(t, SSLNoVerifyVersion())
 }
 
+func TestLoggerExample(t *testing.T) {
+	require.NoError(t, Logger())
+	require.NoError(t, LegacyDebug())
+	require.NoError(t, TextLogger())
+	require.NoError(t, EnrichedLogger())
+
+}
 func TestVariantExample(t *testing.T) {
 	clickhouse_tests.SkipOnCloud(t, "cannot modify Variant settings on cloud")
 	require.NoError(t, VariantExample())

--- a/examples/std/logger_test.go
+++ b/examples/std/logger_test.go
@@ -1,0 +1,118 @@
+package std_test
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+func Example_stdLogger() {
+	// Create a structured logger with JSON output
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	db := clickhouse.OpenDB(&clickhouse.Options{
+		Addr: []string{"localhost:9000"},
+		Auth: clickhouse.Auth{
+			Database: "default",
+			Username: "default",
+			Password: "",
+		},
+		Logger: logger,
+	})
+	defer db.Close()
+
+	// All database operations will be logged with structured fields
+	var count uint64
+	if err := db.QueryRow("SELECT count() FROM system.numbers LIMIT 1").Scan(&count); err != nil {
+		fmt.Printf("Query failed: %v\n", err)
+		return
+	}
+
+	fmt.Println("Count: ", count)
+}
+
+func Example_stdTextLogger() {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	db := clickhouse.OpenDB(&clickhouse.Options{
+		Addr:   []string{"localhost:9000"},
+		Logger: logger,
+	})
+	defer db.Close()
+
+	// Logs will be output in human-readable text format
+	// Example: time=2024-01-21T10:00:00.000Z level=DEBUG msg="executing query" sql="SELECT 1" conn_id=1
+}
+
+func Example_stdLegacyDebug() {
+	db := clickhouse.OpenDB(&clickhouse.Options{
+		Addr: []string{"localhost:9000"},
+		Auth: clickhouse.Auth{
+			Database: "default",
+			Username: "default",
+			Password: "",
+		},
+		Debug: true,
+		Debugf: func(format string, v ...any) {
+			fmt.Printf("[LEGACY] "+format+"\n", v...)
+		},
+	})
+	defer db.Close()
+
+	// Legacy Debugf will be called for all log messages
+	var result int
+	db.QueryRow("SELECT 1").Scan(&result)
+}
+
+func Example_stdEnrichedLogger() {
+	baseLogger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
+	// Add application-level context
+	enrichedLogger := baseLogger.With(
+		slog.String("service", "my-service"),
+		slog.String("environment", "production"),
+	)
+
+	db := clickhouse.OpenDB(&clickhouse.Options{
+		Addr:   []string{"localhost:9000"},
+		Logger: enrichedLogger,
+	})
+	defer db.Close()
+
+	// All logs will include service and environment fields
+	db.Ping()
+}
+
+func Example_stdPoolLogging() {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	db := clickhouse.OpenDB(&clickhouse.Options{
+		Addr:         []string{"localhost:9000"},
+		Logger:       logger,
+		MaxOpenConns: 5,
+		MaxIdleConns: 2,
+	})
+	defer db.Close()
+
+	// Pool operations like connection acquisition/release will be logged
+	// with conn_id to track individual connections
+	var result int
+	for i := 0; i < 10; i++ {
+		if err := db.QueryRow("SELECT ?", i).Scan(&result); err != nil {
+			fmt.Printf("Query failed: %v\n", err)
+			return
+		}
+	}
+
+	// You'll see logs showing connection reuse across queries
+}

--- a/examples/std/logger_test.go
+++ b/examples/std/logger_test.go
@@ -1,4 +1,4 @@
-package std_test
+package std
 
 import (
 	"fmt"
@@ -8,7 +8,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
-func Example_stdLogger() {
+func StdLogger() error {
 	// Create a structured logger with JSON output
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
@@ -28,14 +28,14 @@ func Example_stdLogger() {
 	// All database operations will be logged with structured fields
 	var count uint64
 	if err := db.QueryRow("SELECT count() FROM system.numbers LIMIT 1").Scan(&count); err != nil {
-		fmt.Printf("Query failed: %v\n", err)
-		return
+		return err
 	}
 
 	fmt.Println("Count: ", count)
+	return nil
 }
 
-func Example_stdTextLogger() {
+func StdTextLogger() error {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	}))
@@ -48,9 +48,10 @@ func Example_stdTextLogger() {
 
 	// Logs will be output in human-readable text format
 	// Example: time=2024-01-21T10:00:00.000Z level=DEBUG msg="executing query" sql="SELECT 1" conn_id=1
+	return nil
 }
 
-func Example_stdLegacyDebug() {
+func StdLegacyDebug() error {
 	db := clickhouse.OpenDB(&clickhouse.Options{
 		Addr: []string{"localhost:9000"},
 		Auth: clickhouse.Auth{
@@ -68,9 +69,10 @@ func Example_stdLegacyDebug() {
 	// Legacy Debugf will be called for all log messages
 	var result int
 	db.QueryRow("SELECT 1").Scan(&result)
+	return nil
 }
 
-func Example_stdEnrichedLogger() {
+func StdEnrichedLogger() error {
 	baseLogger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	}))
@@ -88,10 +90,10 @@ func Example_stdEnrichedLogger() {
 	defer db.Close()
 
 	// All logs will include service and environment fields
-	db.Ping()
+	return db.Ping()
 }
 
-func Example_stdPoolLogging() {
+func StdPoolLogging() error {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	}))
@@ -109,10 +111,10 @@ func Example_stdPoolLogging() {
 	var result int
 	for i := 0; i < 10; i++ {
 		if err := db.QueryRow("SELECT ?", i).Scan(&result); err != nil {
-			fmt.Printf("Query failed: %v\n", err)
-			return
+			return err
 		}
 	}
 
 	// You'll see logs showing connection reuse across queries
+	return nil
 }

--- a/examples/std/logger_test.go
+++ b/examples/std/logger_test.go
@@ -32,7 +32,7 @@ func StdLogger() error {
 
 	// All database operations will be logged with structured fields
 	var count uint64
-	if err := db.QueryRow("SELECT count() FROM system.numbers LIMIT 1").Scan(&count); err != nil {
+	if err := db.QueryRow("SELECT 1").Scan(&count); err != nil {
 		return err
 	}
 

--- a/examples/std/logger_test.go
+++ b/examples/std/logger_test.go
@@ -9,17 +9,22 @@ import (
 )
 
 func StdLogger() error {
+	env, err := GetStdTestEnvironment()
+	if err != nil {
+		return err
+	}
+
 	// Create a structured logger with JSON output
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	}))
 
 	db := clickhouse.OpenDB(&clickhouse.Options{
-		Addr: []string{"localhost:9000"},
+		Addr: []string{fmt.Sprintf("%s:%d", env.Host, env.Port)},
 		Auth: clickhouse.Auth{
-			Database: "default",
-			Username: "default",
-			Password: "",
+			Database: env.Database,
+			Username: env.Username,
+			Password: env.Password,
 		},
 		Logger: logger,
 	})
@@ -36,12 +41,22 @@ func StdLogger() error {
 }
 
 func StdTextLogger() error {
+	env, err := GetStdTestEnvironment()
+	if err != nil {
+		return err
+	}
+
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	}))
 
 	db := clickhouse.OpenDB(&clickhouse.Options{
-		Addr:   []string{"localhost:9000"},
+		Addr: []string{fmt.Sprintf("%s:%d", env.Host, env.Port)},
+		Auth: clickhouse.Auth{
+			Database: env.Database,
+			Username: env.Username,
+			Password: env.Password,
+		},
 		Logger: logger,
 	})
 	defer db.Close()
@@ -52,12 +67,17 @@ func StdTextLogger() error {
 }
 
 func StdLegacyDebug() error {
+	env, err := GetStdTestEnvironment()
+	if err != nil {
+		return err
+	}
+
 	db := clickhouse.OpenDB(&clickhouse.Options{
-		Addr: []string{"localhost:9000"},
+		Addr: []string{fmt.Sprintf("%s:%d", env.Host, env.Port)},
 		Auth: clickhouse.Auth{
-			Database: "default",
-			Username: "default",
-			Password: "",
+			Database: env.Database,
+			Username: env.Username,
+			Password: env.Password,
 		},
 		Debug: true,
 		Debugf: func(format string, v ...any) {
@@ -73,6 +93,11 @@ func StdLegacyDebug() error {
 }
 
 func StdEnrichedLogger() error {
+	env, err := GetStdTestEnvironment()
+	if err != nil {
+		return err
+	}
+
 	baseLogger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	}))
@@ -84,7 +109,12 @@ func StdEnrichedLogger() error {
 	)
 
 	db := clickhouse.OpenDB(&clickhouse.Options{
-		Addr:   []string{"localhost:9000"},
+		Addr: []string{fmt.Sprintf("%s:%d", env.Host, env.Port)},
+		Auth: clickhouse.Auth{
+			Database: env.Database,
+			Username: env.Username,
+			Password: env.Password,
+		},
 		Logger: enrichedLogger,
 	})
 	defer db.Close()
@@ -94,12 +124,22 @@ func StdEnrichedLogger() error {
 }
 
 func StdPoolLogging() error {
+	env, err := GetStdTestEnvironment()
+	if err != nil {
+		return err
+	}
+
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	}))
 
 	db := clickhouse.OpenDB(&clickhouse.Options{
-		Addr:         []string{"localhost:9000"},
+		Addr: []string{fmt.Sprintf("%s:%d", env.Host, env.Port)},
+		Auth: clickhouse.Auth{
+			Database: env.Database,
+			Username: env.Username,
+			Password: env.Password,
+		},
 		Logger:       logger,
 		MaxOpenConns: 5,
 		MaxIdleConns: 2,

--- a/examples/std/main_test.go
+++ b/examples/std/main_test.go
@@ -140,6 +140,14 @@ func TestConnectionSettings(t *testing.T) {
 	require.NoError(t, ConnectSettings())
 }
 
+func TestLoggerExample(t *testing.T) {
+	require.NoError(t, StdLogger())
+	require.NoError(t, StdTextLogger())
+	require.NoError(t, StdLegacyDebug())
+	require.NoError(t, StdEnrichedLogger())
+	require.NoError(t, StdPoolLogging())
+}
+
 func TestVariantExample(t *testing.T) {
 	clickhouse_tests.SkipOnCloud(t, "cannot modify Variant settings on cloud")
 	require.NoError(t, VariantExample())

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,125 @@
+package clickhouse
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+// debugfHandler is a slog.Handler that wraps the legacy Debugf function
+// for backward compatibility. It converts structured log records back to
+// format string calls.
+type debugfHandler struct {
+	debugf func(format string, v ...any)
+	attrs  []slog.Attr
+	groups []string
+}
+
+func (h *debugfHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	// Legacy Debugf has no level filtering - all logs are enabled
+	return true
+}
+
+func (h *debugfHandler) Handle(ctx context.Context, record slog.Record) error {
+	// Build message with attributes
+	msg := record.Message
+
+	// Collect all attributes
+	attrs := make([]any, 0, len(h.attrs)*2+record.NumAttrs()*2)
+
+	// Add pre-existing attributes (from With)
+	for _, a := range h.attrs {
+		attrs = append(attrs, a.Key, a.Value)
+	}
+
+	// Add record attributes
+	record.Attrs(func(a slog.Attr) bool {
+		attrs = append(attrs, a.Key, a.Value)
+		return true
+	})
+
+	// Format message with attributes if present
+	if len(attrs) > 0 {
+		h.debugf("%s %v", msg, attrs)
+	} else {
+		h.debugf("%s", msg)
+	}
+
+	return nil
+}
+
+func (h *debugfHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	// Accumulate attributes for later formatting
+	newAttrs := make([]slog.Attr, len(h.attrs)+len(attrs))
+	copy(newAttrs, h.attrs)
+	copy(newAttrs[len(h.attrs):], attrs)
+
+	return &debugfHandler{
+		debugf: h.debugf,
+		attrs:  newAttrs,
+		groups: h.groups,
+	}
+}
+
+func (h *debugfHandler) WithGroup(name string) slog.Handler {
+	// Accumulate groups (though legacy Debugf won't use them meaningfully)
+	newGroups := make([]string, len(h.groups)+1)
+	copy(newGroups, h.groups)
+	newGroups[len(h.groups)] = name
+
+	return &debugfHandler{
+		debugf: h.debugf,
+		attrs:  h.attrs,
+		groups: newGroups,
+	}
+}
+
+// noopHandler is a slog.Handler that discards all logs.
+// Used when no logger is configured.
+type noopHandler struct{}
+
+func (h *noopHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	// Disable all log levels
+	return false
+}
+
+func (h *noopHandler) Handle(ctx context.Context, record slog.Record) error {
+	// Discard the log
+	return nil
+}
+
+func (h *noopHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *noopHandler) WithGroup(name string) slog.Handler {
+	return h
+}
+
+// newDebugfLogger creates a slog.Logger that wraps the legacy Debugf function.
+// This is used for backward compatibility when Debug=true and Debugf is provided.
+func newDebugfLogger(debugf func(format string, v ...any)) *slog.Logger {
+	return slog.New(&debugfHandler{debugf: debugf})
+}
+
+// newNoopLogger creates a slog.Logger that discards all logs.
+// This is used when no logger is configured (default behavior).
+func newNoopLogger() *slog.Logger {
+	return slog.New(&noopHandler{})
+}
+
+// prepareConnLogger enriches a base logger with connection-specific attributes.
+// This adds context like connection ID, remote address, and protocol type.
+func prepareConnLogger(base *slog.Logger, connID int, remoteAddr, protocol string) *slog.Logger {
+	return base.With(
+		slog.Int("conn_id", connID),
+		slog.String("remote_addr", remoteAddr),
+		slog.String("protocol", protocol),
+	)
+}
+
+// formatForDebugf is a helper that formats a message for the legacy debugf wrapper.
+// It's used by the debugf() methods to maintain compatibility with existing call sites.
+func formatForDebugf(format string, v ...any) string {
+	return fmt.Sprintf(format, v...)
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,125 @@
+package clickhouse
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestLegacyDebugfBackwardCompatibility tests that the old Debug/Debugf options still work
+func TestLegacyDebugfBackwardCompatibility(t *testing.T) {
+	var buf bytes.Buffer
+	called := false
+
+	opt := &Options{
+		Debug: true,
+		Debugf: func(format string, v ...any) {
+			called = true
+			buf.WriteString("LEGACY: ")
+			buf.WriteString(format)
+		},
+	}
+
+	logger := opt.logger()
+	logger.Debug("test message")
+
+	if !called {
+		t.Error("Legacy Debugf was not called")
+	}
+
+	if !strings.Contains(buf.String(), "LEGACY:") {
+		t.Error("Legacy Debugf did not write expected prefix")
+	}
+}
+
+// TestNewLoggerOption tests the new Logger option with slog
+func TestNewLoggerOption(t *testing.T) {
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
+	customLogger := slog.New(handler)
+
+	opt := &Options{
+		Logger: customLogger,
+	}
+
+	logger := opt.logger()
+	logger.Debug("test message", slog.String("key", "value"))
+
+	output := buf.String()
+	if !strings.Contains(output, "test message") {
+		t.Error("Expected message not found in log output")
+	}
+	if !strings.Contains(output, "key=value") {
+		t.Error("Expected structured field not found in log output")
+	}
+}
+
+// TestNoopLoggerDefault tests that noop logger is used when no logging is configured
+func TestNoopLoggerDefault(t *testing.T) {
+	opt := &Options{}
+	logger := opt.logger()
+
+	// Should not panic with noop logger
+	logger.Debug("test message")
+	logger.Info("test message")
+	logger.Warn("test message")
+	logger.Error("test message")
+}
+
+// TestLegacyDebugfPriority tests that legacy Debugf takes priority over new Logger
+func TestLegacyDebugfPriority(t *testing.T) {
+	var buf bytes.Buffer
+	legacyCalled := false
+
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
+	customLogger := slog.New(handler)
+
+	opt := &Options{
+		Debug: true,
+		Debugf: func(format string, v ...any) {
+			legacyCalled = true
+		},
+		Logger: customLogger,
+	}
+
+	logger := opt.logger()
+	logger.Debug("test message")
+
+	// Legacy Debugf should take priority
+	if !legacyCalled {
+		t.Error("Legacy Debugf should take priority but was not called")
+	}
+
+	// Buffer should be empty since legacy Debugf was used instead
+	if buf.Len() > 0 {
+		t.Error("New Logger should not be used when legacy Debugf is set")
+	}
+}
+
+// TestPrepareConnLogger tests the connection logger enrichment
+func TestPrepareConnLogger(t *testing.T) {
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
+	baseLogger := slog.New(handler)
+
+	connLogger := prepareConnLogger(baseLogger, 123, "localhost:9000", "native")
+	connLogger.Debug("connection established")
+
+	output := buf.String()
+	if !strings.Contains(output, "conn_id=123") {
+		t.Error("Expected conn_id in log output")
+	}
+	if !strings.Contains(output, "remote_addr=localhost:9000") {
+		t.Error("Expected remote_addr in log output")
+	}
+	if !strings.Contains(output, "protocol=native") {
+		t.Error("Expected protocol in log output")
+	}
+}


### PR DESCRIPTION
## Summary
1. Uses standard lib's log/slog as a main logger.
2. Deprecates the old way of logging via Debug flag and DebugF
3. Provide adapter for legacy way of logging with no-op logging
4. Backward compatible with Debug and DebugF apporach of logging

closes: #1698 

Notes (for the reviewers):
1. There are only few significant changes that deserves full review (which I marked as comments)
2. Most of the file changes are updating the caller of log lines.

FAQ:
1. Why deprecate Debug and DebugF - These are unstructured log lines, no labels, no filterable, no much pattern.
2. Why update all the call-sites? - With proper levels and structured labels improve the logging UX
3. Why use slog? why not new `Logger` interface - slog is from standard library, and has all the helpers and log levels already.
4. Is updating the existing Debug logs breaking changes?. No. it's debug logs.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
