### PR TITLE
chore: add `maintainers-edit-check` for forks PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 
 ## Checklist
 Delete items not relevant to your PR:
+- [ ] **For external contributors**: "Allow edits from maintainers" is enabled (see sidebar) - [Why?](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
 - [ ] Unit and integration tests covering the common scenarios were added
 - [ ] A human-readable description of the changes was provided to include in CHANGELOG
 - [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

--- a/.github/workflows/check-maintainer-edit.yml
+++ b/.github/workflows/check-maintainer-edit.yml
@@ -1,0 +1,31 @@
+name: Check Maintainer Edit Permission
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+  check-maintainer-edit:
+    runs-on: ubuntu-latest
+    # Only run on PRs from forks
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - name: Check if maintainer can modify
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            if (!pr.maintainer_can_modify) {
+              core.setFailed(
+                '❌ This PR does not allow edits from maintainers.\n\n' +
+                'Please enable "Allow edits from maintainers" in the PR sidebar.\n' +
+                'This helps maintainers make minor fixes and speed up the review process.\n\n' +
+                'To enable it:\n' +
+                '1. Scroll to the right sidebar of this PR\n' +
+                '2. Check the box "Allow edits and access to secrets by maintainers"\n\n' +
+                'See: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork'
+              );
+            } else {
+              core.info('✅ Maintainer edit permission is enabled');
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,16 @@
 # Contributing notes
 
+## Pull Request Guidelines
+
+When creating a pull request from a fork, please **enable "Allow edits from maintainers"** in the PR sidebar. This allows maintainers to make minor fixes (typos, formatting, small adjustments) directly to your branch, which speeds up the review process and helps get your changes merged faster.
+
+To enable it:
+1. Open your pull request
+2. Look at the right sidebar
+3. Check the box "Allow edits and access to secrets by maintainers"
+
+[Learn more](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
+
 ## Local setup
 
 The easiest way to run tests is to use Docker Compose:


### PR DESCRIPTION
## Summary
Sometimes after the review it usually take few small changes before merging the PR. Maintainers can do such work without waiting for authors

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
