### PR TITLE
chore: add test to lock single enum value behavior

### DIFF
--- a/lib/column/enum_test.go
+++ b/lib/column/enum_test.go
@@ -16,6 +16,22 @@ func TestExtractEnumNamedValues(t *testing.T) {
 		isNotValid     bool
 	}{
 		{
+			name:         "Enum8 single zero value",
+			chType:       "Enum8('FOO' = 0)",
+			expectedType: "Enum8",
+			expectedValues: map[int]string{
+				0: "FOO",
+			},
+		},
+		{
+			name:         "Enum16 single zero value",
+			chType:       "Enum16('FOO' = 0)",
+			expectedType: "Enum16",
+			expectedValues: map[int]string{
+				0: "FOO",
+			},
+		},
+		{
 			name:         "Enum8",
 			chType:       "Enum8('a'=1,'b'=2)",
 			expectedType: "Enum8",


### PR DESCRIPTION


## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fixes: https://github.com/ClickHouse/clickhouse-go/issues/1434

Even though reported issue is not showing anymore in latest version of the client. I think it's better to add a test to lock the behavior

## Checklist
Delete items not relevant to your PR:
- [ x Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
