### PR TITLE
Automatically set send_profile_events=false when no listener is registered

### DIFF
--- a/conn_async_insert.go
+++ b/conn_async_insert.go
@@ -25,6 +25,7 @@ func (c *connect) asyncInsert(ctx context.Context, query string, wait bool, args
 		}
 	}
 
+	options.injectSendProfileEvents(c.opt.Settings, c.server.Version)
 	if err := c.sendQuery(query, &options); err != nil {
 		return err
 	}

--- a/conn_batch.go
+++ b/conn_batch.go
@@ -26,6 +26,7 @@ func (c *connect) prepareBatch(ctx context.Context, release nativeTransportRelea
 	}
 
 	options := queryOptions(ctx)
+	options.injectSendProfileEvents(c.opt.Settings, c.server.Version)
 	if deadline, ok := ctx.Deadline(); ok {
 		c.conn.SetDeadline(deadline)
 		defer c.conn.SetDeadline(time.Time{})
@@ -250,6 +251,7 @@ func (b *batch) resetConnection() (err error) {
 	}()
 
 	options := queryOptions(b.ctx)
+	options.injectSendProfileEvents(b.conn.opt.Settings, b.conn.server.Version)
 	if deadline, ok := b.ctx.Deadline(); ok {
 		b.conn.conn.SetDeadline(deadline)
 		defer b.conn.conn.SetDeadline(time.Time{})

--- a/conn_exec.go
+++ b/conn_exec.go
@@ -23,6 +23,7 @@ func (c *connect) exec(ctx context.Context, query string, args ...any) error {
 		c.conn.SetDeadline(deadline)
 		defer c.conn.SetDeadline(time.Time{})
 	}
+	options.injectSendProfileEvents(c.opt.Settings, c.server.Version)
 	if err := c.sendQuery(body, &options); err != nil {
 		return err
 	}

--- a/conn_http_async_insert.go
+++ b/conn_http_async_insert.go
@@ -20,6 +20,7 @@ func (h *httpConnect) asyncInsert(ctx context.Context, query string, wait bool, 
 		}
 	}
 
+	options.injectSendProfileEvents(h.opt.Settings, h.handshake.Version)
 	res, err := h.sendQuery(ctx, query, &options, nil)
 	if err != nil {
 		return err

--- a/conn_http_exec.go
+++ b/conn_http_exec.go
@@ -11,6 +11,7 @@ func (h *httpConnect) exec(ctx context.Context, query string, args ...any) error
 		return err
 	}
 
+	options.injectSendProfileEvents(h.opt.Settings, h.handshake.Version)
 	res, err := h.sendQuery(ctx, query, &options, nil)
 	if err != nil {
 		return err

--- a/conn_http_query.go
+++ b/conn_http_query.go
@@ -37,6 +37,7 @@ func (h *httpConnect) query(ctx context.Context, release nativeTransportRelease,
 		release(h, err)
 		return nil, err
 	}
+	options.injectSendProfileEvents(h.opt.Settings, h.handshake.Version)
 	headers := make(map[string]string)
 	switch h.compression {
 	case CompressionZSTD, CompressionLZ4:

--- a/conn_query.go
+++ b/conn_query.go
@@ -21,6 +21,7 @@ func (c *connect) query(ctx context.Context, release nativeTransportRelease, que
 		return nil, err
 	}
 
+	options.injectSendProfileEvents(c.opt.Settings, c.server.Version)
 	if err = c.sendQuery(body, &options); err != nil {
 		release(c, err)
 		return nil, err

--- a/tests/issues/1708_test.go
+++ b/tests/issues/1708_test.go
@@ -1,0 +1,60 @@
+package issues
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhousetests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/require"
+)
+
+func Test1708(t *testing.T) {
+	testEnv, err := clickhousetests.GetTestEnvironment("issues")
+	require.NoError(t, err)
+	conn, err := clickhousetests.TestClientWithDefaultSettings(testEnv)
+	require.NoError(t, err)
+
+	if !clickhousetests.CheckMinServerServerVersion(conn, 25, 11, 0) {
+		t.Skip("send_profile_events setting requires ClickHouse >= 25.11")
+	}
+
+	t.Run("query without listener succeeds", func(t *testing.T) {
+		var result uint64
+		err := conn.QueryRow(context.Background(), "SELECT 1").Scan(&result)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), result)
+	})
+
+	t.Run("query with profile events listener receives events", func(t *testing.T) {
+		var received bool
+		ctx := clickhouse.Context(context.Background(),
+			clickhouse.WithProfileEvents(func(events []clickhouse.ProfileEvent) {
+				if len(events) > 0 {
+					received = true
+				}
+			}),
+		)
+
+		var result uint64
+		err := conn.QueryRow(ctx, "SELECT 1").Scan(&result)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), result)
+		// Profile events may or may not arrive for simple queries depending on timing,
+		// but the query must succeed regardless.
+		_ = received
+	})
+
+	t.Run("explicit send_profile_events setting is not overridden", func(t *testing.T) {
+		ctx := clickhouse.Context(context.Background(),
+			clickhouse.WithSettings(clickhouse.Settings{
+				"send_profile_events": 1,
+			}),
+		)
+
+		var result uint64
+		err := conn.QueryRow(ctx, "SELECT 1").Scan(&result)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), result)
+	})
+}


### PR DESCRIPTION
## Summary

Closes #1708

- Automatically inject `send_profile_events=false` into query settings when no `WithProfileEvents()` listener is registered
- Only applied when the user hasn't explicitly set the setting and the server is ClickHouse >= 25.11
- Eliminates ProfileEvents packet transmission over the wire, complementing PR #1686 which skipped client-side parsing

## Test plan

- [x] Unit tests covering all branches in `context_test.go`
- [x] Integration test in `tests/issues/1708_test.go` (gated on server >= 25.11)
- [x] Existing tests pass with no regressions

Tests written by Claude 