### PR TITLE
Upgrade from math/rand to math/rand/v2

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -283,6 +283,7 @@ func (ch *clickhouse) dial(ctx context.Context) (conn nativeTransport, err error
 }
 
 func DefaultDialStrategy(ctx context.Context, connID int, opt *Options, dial Dial) (r DialResult, err error) {
+	random := rand.IntN(len(opt.Addr))
 	for i := range opt.Addr {
 		var num int
 		switch opt.ConnOpenStrategy {
@@ -291,7 +292,6 @@ func DefaultDialStrategy(ctx context.Context, connID int, opt *Options, dial Dia
 		case ConnOpenRoundRobin:
 			num = (connID + i) % len(opt.Addr)
 		case ConnOpenRandom:
-			random := rand.Int()
 			num = (random + i) % len(opt.Addr)
 		}
 

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"reflect"
 	"sync/atomic"
@@ -59,6 +59,7 @@ func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) 
 		return nil, ErrAcquireConnNoAddress
 	}
 
+	random := rand.IntN(len(o.opt.Addr))
 	for i := range o.opt.Addr {
 		var num int
 		switch o.opt.ConnOpenStrategy {
@@ -67,7 +68,6 @@ func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) 
 		case ConnOpenRoundRobin:
 			num = (connID + i) % len(o.opt.Addr)
 		case ConnOpenRandom:
-			random := rand.Int()
 			num = (random + i) % len(o.opt.Addr)
 		}
 		if conn, err = dialFunc(ctx, o.opt.Addr[num], connID, o.opt); err == nil {

--- a/examples/clickhouse_api/multi_host.go
+++ b/examples/clickhouse_api/multi_host.go
@@ -2,7 +2,6 @@ package clickhouse_api
 
 import (
 	"fmt"
-	"math/rand"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 )
@@ -17,8 +16,6 @@ func MultiHostRoundRobinVersion() error {
 }
 
 func MultiHostRandomVersion() error {
-	rand.Seed(85206178671753424)
-	defer ResetRandSeed()
 	connOpenStrategy := clickhouse.ConnOpenRandom
 	return multiHostVersion(&connOpenStrategy)
 }

--- a/examples/clickhouse_api/qbit.go
+++ b/examples/clickhouse_api/qbit.go
@@ -3,7 +3,7 @@ package clickhouse_api
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 )

--- a/examples/clickhouse_api/utils.go
+++ b/examples/clickhouse_api/utils.go
@@ -2,8 +2,6 @@ package clickhouse_api
 
 import (
 	"crypto/tls"
-	"math/rand"
-	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -32,8 +30,6 @@ func CheckMinServerVersion(conn driver.Conn, major, minor, patch uint64) bool {
 	return clickhouse_tests.CheckMinServerServerVersion(conn, major, minor, patch)
 }
 
-var randSeed = time.Now().UnixNano()
-
-func ResetRandSeed() {
-	rand.Seed(randSeed)
-}
+// ResetRandSeed is a no-op. math/rand/v2 automatically seeds the global
+// random source and does not support manual seeding via rand.Seed.
+func ResetRandSeed() {}

--- a/examples/std/main_test.go
+++ b/examples/std/main_test.go
@@ -3,20 +3,16 @@ package std
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"os"
 	"strconv"
 	"testing"
-	"time"
 
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
-	seed := time.Now().UnixNano()
-	fmt.Printf("using random seed %d for %s tests\n", seed, TestSet)
-	rand.Seed(seed)
+	fmt.Printf("using auto-seeded random for %s tests\n", TestSet)
 	useDocker, err := strconv.ParseBool(clickhouse_tests.GetEnv("CLICKHOUSE_USE_DOCKER", "true"))
 	if err != nil {
 		panic(err)

--- a/examples/std/qbit.go
+++ b/examples/std/qbit.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 )

--- a/tests/bfloat16_test.go
+++ b/tests/bfloat16_test.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/require"

--- a/tests/bool_test.go
+++ b/tests/bool_test.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 	"time"
 
@@ -169,11 +169,10 @@ func TestBoolFlush(t *testing.T) {
 		batch, err := conn.PrepareBatch(ctx, "INSERT INTO bool_flush")
 		require.NoError(t, err)
 		vals := [1000]bool{}
-		var src = rand.NewSource(time.Now().UnixNano())
-		var r = rand.New(src)
+		var r = rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), uint64(time.Now().UnixNano()>>32)))
 
 		for i := 0; i < 1000; i++ {
-			vals[i] = r.Intn(2) != 0
+			vals[i] = r.IntN(2) != 0
 			require.NoError(t, batch.Append(vals[i]))
 			require.Equal(t, 1, batch.Rows())
 			require.NoError(t, batch.Flush())
@@ -229,11 +228,10 @@ func TestBoolValuer(t *testing.T) {
 		batch, err := conn.PrepareBatch(ctx, "INSERT INTO bool_flush")
 		require.NoError(t, err)
 		vals := [1000]bool{}
-		var src = rand.NewSource(time.Now().UnixNano())
-		var r = rand.New(src)
+		var r = rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), uint64(time.Now().UnixNano()>>32)))
 
 		for i := 0; i < 1000; i++ {
-			vals[i] = r.Intn(2) != 0
+			vals[i] = r.IntN(2) != 0
 			require.NoError(t, batch.Append(testBoolSerializer{val: vals[i]}))
 		}
 		batch.Send()

--- a/tests/conn_test.go
+++ b/tests/conn_test.go
@@ -59,9 +59,6 @@ func TestConnFailoverRoundRobin(t *testing.T) {
 }
 
 func TestConnFailoverRandom(t *testing.T) {
-	t.Skip("Go 1.25 math/random changes")
-	//rand.Seed(85206178671753423)
-	//defer ResetRandSeed()
 	testConnFailover(t, clickhouse.ConnOpenRandom)
 }
 

--- a/tests/float_test.go
+++ b/tests/float_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/require"

--- a/tests/geo_multi_linestring_test.go
+++ b/tests/geo_multi_linestring_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/require"

--- a/tests/geo_multipolygon_test.go
+++ b/tests/geo_multipolygon_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/require"

--- a/tests/geo_point_test.go
+++ b/tests/geo_point_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/require"

--- a/tests/geo_polygon_test.go
+++ b/tests/geo_polygon_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/require"

--- a/tests/issues/1271_test.go
+++ b/tests/issues/1271_test.go
@@ -3,7 +3,7 @@ package issues
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"runtime"
 	"strings"
 	"testing"
@@ -89,15 +89,15 @@ func RandAsciiString(n int) string {
 	return randString(n, letterBytes)
 }
 
-var src = rand.NewSource(time.Now().UnixNano())
+var rng1271 = rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), uint64(time.Now().UnixNano()>>32)))
 
 func randString(n int, bytes string) string {
 	sb := strings.Builder{}
 	sb.Grow(n)
-	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
-	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
+	// rng1271.Int64() generates 63 random bits, enough for letterIdxMax characters!
+	for i, cache, remain := n-1, rng1271.Int64(), letterIdxMax; i >= 0; {
 		if remain == 0 {
-			cache, remain = src.Int63(), letterIdxMax
+			cache, remain = rng1271.Int64(), letterIdxMax
 		}
 		if idx := int(cache & letterIdxMask); idx < len(bytes) {
 			sb.WriteByte(bytes[idx])

--- a/tests/issues/741_test.go
+++ b/tests/issues/741_test.go
@@ -3,7 +3,7 @@ package issues
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"strconv"
 	"strings"

--- a/tests/std/conn_test.go
+++ b/tests/std/conn_test.go
@@ -42,9 +42,6 @@ func TestStdConnFailoverRoundRobin(t *testing.T) {
 }
 
 func TestStdConnFailoverRandom(t *testing.T) {
-	t.Skip("Go 1.25 math/random changes")
-	//rand.Seed(85206178671753428)
-	//defer clickhouse_tests.ResetRandSeed()
 	testStdConnFailover(t, "random")
 }
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/url"
 	"os"
@@ -668,7 +668,7 @@ func IsSetInEnv(key string) bool {
 	return ok
 }
 
-var src = rand.NewSource(time.Now().UnixNano())
+var rng = rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), uint64(time.Now().UnixNano()>>32)))
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 const numberBytes = "123456789"
@@ -687,14 +687,14 @@ func RandIntString(n int) string {
 }
 
 func RandIPv4() net.IP {
-	return net.IPv4(uint8(rand.Int()), uint8(rand.Int()), uint8(rand.Int()), uint8(rand.Int())).To4()
+	return net.IPv4(uint8(rand.IntN(256)), uint8(rand.IntN(256)), uint8(rand.IntN(256)), uint8(rand.IntN(256))).To4()
 }
 
 func RandIPv6() net.IP {
 	size := 16
 	ip := make([]byte, size)
 	for i := 0; i < size; i++ {
-		ip[i] = byte(rand.Intn(256))
+		ip[i] = byte(rand.IntN(256))
 	}
 	return net.IP(ip).To16()
 }
@@ -702,10 +702,10 @@ func RandIPv6() net.IP {
 func randString(n int, bytes string) string {
 	sb := strings.Builder{}
 	sb.Grow(n)
-	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
-	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
+	// rng.Int64() generates 63 random bits, enough for letterIdxMax characters!
+	for i, cache, remain := n-1, rng.Int64(), letterIdxMax; i >= 0; {
 		if remain == 0 {
-			cache, remain = src.Int63(), letterIdxMax
+			cache, remain = rng.Int64(), letterIdxMax
 		}
 		if idx := int(cache & letterIdxMask); idx < len(bytes) {
 			sb.WriteByte(bytes[idx])
@@ -953,9 +953,9 @@ func OptionsToDSN(o *clickhouse.Options) string {
 	return u.String()
 }
 
-func ResetRandSeed() {
-	rand.Seed(randSeed)
-}
+// ResetRandSeed is a no-op. math/rand/v2 automatically seeds the global
+// random source and does not support manual seeding via rand.Seed.
+func ResetRandSeed() {}
 
 func Runtime(m *testing.M, ts string) (exitCode int) {
 	ResetRandSeed()


### PR DESCRIPTION
## Summary

- Migrate all `math/rand` usages to `math/rand/v2` across the entire codebase (19 files)
- Fix `ConnOpenRandom` strategy to pick random offset once outside the loop
- Re-enable skipped random failover tests

## Motivation

Go 1.25 broke `rand.Seed` which caused `ConnOpenRandom` failover tests to be skipped (#1652). The `math/rand` package is deprecated in favor of `math/rand/v2` which provides automatic seeding and better APIs.

As discussed in #1653, the `ConnOpenRandom` strategy also had a bug where `rand.Int()` was called on every loop iteration, meaning a connection attempt could pick the same (broken) address multiple times and fail to try all addresses.

## Changes

**Core library (`clickhouse.go`, `clickhouse_std.go`):**
- Replace `math/rand` with `math/rand/v2`
- Fix `ConnOpenRandom`: pick random starting offset once via `rand.IntN(len(addrs))` before the loop, then iterate through all addresses deterministically from that offset. This ensures every address is tried exactly once before failing.

**Tests (11 files):**
- Replace `rand.NewSource`/`rand.New` with `rand.NewPCG`/`rand.New`
- Replace `rand.Intn(n)` with `rand.IntN(n)` (v2 naming)
- Replace `src.Int63()` with `rng.Int64()` in string generators
- Remove `rand.Seed` calls (v2 auto-seeds)
- Re-enable `TestConnFailoverRandom` and `TestStdConnFailoverRandom`

**Examples (5 files):**
- Remove `rand.Seed` calls from multi-host and test setup
- Update `ResetRandSeed()` to no-op (v2 has no `rand.Seed`)
- Remove unused imports (`time`, `math/rand`)

## Test Plan

- [x] `go build ./...` passes cleanly
- [x] No remaining `math/rand` v1 imports (`grep` confirms zero matches)
- [x] `TestConnFailoverRandom` and `TestStdConnFailoverRandom` re-enabled (previously skipped)
- [ ] CI integration tests (require ClickHouse Docker container)

Fixes #1653