### PR TITLE
chore: make PR from forks run cloud tests correctly

### DIFF
--- a/.github/workflows/run-tests-cloud.yml
+++ b/.github/workflows/run-tests-cloud.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
 
       - name: Install Go ${{ matrix.go }}
         uses: actions/setup-go@v5

--- a/.github/workflows/run-tests-cloud.yml
+++ b/.github/workflows/run-tests-cloud.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'pull_request_target'
     runs-on: [self-hosted, style-checker-aarch64]
     defaults:
       run:

--- a/.github/workflows/run-tests-cloud.yml
+++ b/.github/workflows/run-tests-cloud.yml
@@ -7,7 +7,9 @@ on:
     branches:
       - main
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
+    branches:
+      - main
     types: [opened, labeled, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
This enables any PR from forks to origin (main branch) runs the cloud tests without any problem with secrets/envs needed to run the tests.

Basically to avoid cases like this #1796 PR.

It's also secure as we use `pull_request_target` [trigger](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target) which applies only if PR is raised against the origin (this repo) and maintainers approve the workflow gate.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
