### PR TITLE
chore: make cloud test runs on-demand only with labeling

### DIFF
--- a/.github/workflows/run-tests-cloud.yml
+++ b/.github/workflows/run-tests-cloud.yml
@@ -10,11 +10,11 @@ on:
   pull_request_target:
     branches:
       - main
-    types: [opened, labeled, synchronize, reopened]
+    types: [labeled]
 
 jobs:
   test:
-    if: github.event_name == 'push' || github.event_name == 'pull_request_target'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request_target' && github.event.label.name == 'tests:run-cloud')
     runs-on: [self-hosted, style-checker-aarch64]
     defaults:
       run:
@@ -45,3 +45,10 @@ jobs:
           GOTOOLCHAIN: "local"
         run: |
           CLICKHOUSE_DIAL_TIMEOUT=20 CLICKHOUSE_TEST_TIMEOUT=600s CLICKHOUSE_QUORUM_INSERT=2 make test
+
+      - name: Remove tests:run-cloud label
+        if: always() && github.event_name == 'pull_request_target'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/tests%3Arun-cloud -X DELETE || true


### PR DESCRIPTION

## Summary
<!-- A short description of the changes with a link to an open issue. -->
Follow up to #1803 

This is needed for two reasons
1. `pull_request_target` cannot be included in the workflow approve gate.
2. without approval gate, we cannot avoid bad actors to trigger cloud run just by creating PR to origin.
3. I changed the trigger to `labeled` only because this can only run when maintainer explicitly label it.
4. After success/fail run, it automatically remove the label thus no additional commit would trigger it automatically unless maintainer lable it again

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
