### PR TITLE
workflows: integrate claude code Github action for code-review

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -32,6 +32,7 @@ Follow [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments) in full
 - Error strings: lowercase, no trailing punctuation — `"clickhouse: connection closed"`.
 - Wrap with `fmt.Errorf("context: %w", err)` to preserve the chain; sentinel errors live in `clickhouse.go`.
 - Do not `panic` in library code. Panics belong only in `init()` for invariants that can never recover.
+- Error message returned to the end-user should be actionable as possible.
 
 **Context**
 - Every network call takes `context.Context` as its first parameter — no exceptions.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: review-pr
+description: Review a pull request and post structured feedback as a comment.
+argument-hint: "<PR-number>"
+allowed-tools: Read, Glob, Bash(grep:*), Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr comment:*)
+---
+
 Review the pull request and provide structured feedback.
 
 ## How to fetch the PR

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -52,7 +52,9 @@ Work through each category before writing the review.
 - [ ] New ClickHouse type support: column implementation + round-trip test + example?
 - [ ] Do test failure messages say what was wrong, what input triggered it, and what was expected vs. got?
 - [ ] Are tests table-driven where there are multiple cases?
-- [ ] No test mocking of `driver.Conn` or `driver.Rows` — use a real ClickHouse via testcontainers.
+- [ ] No test mocking of `driver.Conn` or `driver.Rows` for integrations tests inside root `/tests/` — use a real ClickHouse via testcontainers.
+- [ ] Make sure tests are covered for both TCP and HTTP protocol cases.
+- [ ] Make sure tests are covered for both `clickhouse_native` (Open() api returns) api and `std` api (OpenDB() api returns).
 
 ### Performance & protocol
 - [ ] Does the change avoid unnecessary allocations in hot paths (encoding/decoding columns)?
@@ -62,3 +64,7 @@ Work through each category before writing the review.
 ### Documentation
 - [ ] Are new exported symbols documented with a full-sentence doc comment beginning with the symbol name?
 - [ ] ClickHouse SQL types and function names wrapped in backticks in any prose.
+- [ ] Make sure existing docs and examples are updated.
+- [ ] Make sure new docs and examples are added if needed for new features or bug fixes.
+- [ ] Make sure the docs are covered for both TCP and HTTP protocol cases.
+- [ ] Make sure the docs are covered for both `clickhouse_native` (Open() api returns) api and `std` api (OpenDB() api returns).

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,6 +26,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args:
+            --allowedTools "Read,Glob,Bash(grep:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*)"
           prompt: |
             Review pull request #${{ github.event.pull_request.number }} using the checklist in `.claude/skills/review-pr/SKILL.md`.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,48 @@
+name: Claude Code Review
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  review:
+    # Only run when the exact trigger label is applied.
+    if: github.event.label.name == 'review:claude-agent'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read        # read repo files (SKILL.md, etc.)
+      pull-requests: write  # post review comments
+      issues: write         # update labels / post issue comments
+
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        # SECURITY: pull_request_target checks out the base branch by default.
+        # Do NOT add `ref: ${{ github.event.pull_request.head.sha }}` here —
+        # that would run untrusted fork code with access to repository secrets.
+        # that's why labeling check (usually by maintainer)
+
+      - name: Review PR with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Review pull request #${{ github.event.pull_request.number }} using the checklist in `.claude/skills/review-pr/SKILL.md`.
+
+            Steps:
+            1. Read `.claude/skills/review-pr/SKILL.md` to load the review checklist and output format.
+            2. Fetch the PR description with `gh pr view ${{ github.event.pull_request.number }}`.
+            3. Fetch the diff with `gh pr diff ${{ github.event.pull_request.number }}`.
+            4. Work through every checklist category in SKILL.md: Correctness, API design, Go idioms, Tests, Performance & protocol, Documentation.
+            5. Post a single review comment on the PR using `gh pr comment ${{ github.event.pull_request.number }} --body "..."` with the sections defined in SKILL.md: Summary, Must fix, Should fix, Nits, Verdict.
+            6. Omit any section that has no items.
+
+      - name: Remove trigger label
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method DELETE \
+            repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/review%3Aclaude-agent \
+            || true  # ignore 404 if label was already removed


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

Changes
1. Use `pull_request_targe`t to trigger claude agent review based on
labelling.
2. Fixes remarks on cloud skills and instructions about tests, docs and errors

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
