### PR TITLE
chore: pass explicity github token for claude review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ github.token }}
           claude_args:
             --allowedTools "Read,Glob,Bash(grep:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*)"
           prompt: |


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

pass in `github.token` to avoid OIDC authentication. It was not able to get the [token correctly with OIDC.](https://github.com/ClickHouse/clickhouse-go/actions/runs/23816568572/job/69417542961)

Validated this changes works correctly by triggering the [PR review manually here](https://github.com/ClickHouse/clickhouse-go/actions/runs/23841642786/job/69498491456). Which [did the review here](https://github.com/ClickHouse/clickhouse-go/pull/1788#issuecomment-4168764680)


## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
