### PR TITLE
fix: set req.Host for Host header in HTTP transport

### DIFF
--- a/conn_http.go
+++ b/conn_http.go
@@ -137,7 +137,11 @@ func applyOptionsToRequest(ctx context.Context, req *http.Request, opt *Options)
 	req.Header.Set("User-Agent", opt.ClientInfo.Append(queryOpt.clientInfo).String())
 
 	for k, v := range opt.HttpHeaders {
-		req.Header.Set(k, v)
+		if strings.EqualFold(k, "Host") {
+			req.Host = v
+		} else {
+			req.Header.Set(k, v)
+		}
 	}
 
 	return nil

--- a/conn_http_test.go
+++ b/conn_http_test.go
@@ -1,6 +1,7 @@
 package clickhouse
 
 import (
+	"context"
 	"net/http"
 	"testing"
 )
@@ -18,5 +19,83 @@ func TestCreateHTTPRoundTripper(t *testing.T) {
 	}
 	if !transportFnCalled {
 		t.Fatal("TransportFn not called")
+	}
+}
+
+func TestApplyOptionsToRequest_HostHeader(t *testing.T) {
+	tests := []struct {
+		name            string
+		headers         map[string]string
+		expectedHost    string
+		expectedInMap   map[string]string
+		unexpectedInMap []string
+	}{
+		{
+			name:            "Host header sets req.Host",
+			headers:         map[string]string{"Host": "my-service.example.com"},
+			expectedHost:    "my-service.example.com",
+			unexpectedInMap: []string{"Host"},
+		},
+		{
+			name:            "lowercase host header sets req.Host",
+			headers:         map[string]string{"host": "my-service.example.com"},
+			expectedHost:    "my-service.example.com",
+			unexpectedInMap: []string{"Host"},
+		},
+		{
+			name:            "uppercase HOST header sets req.Host",
+			headers:         map[string]string{"HOST": "my-service.example.com"},
+			expectedHost:    "my-service.example.com",
+			unexpectedInMap: []string{"Host"},
+		},
+		{
+			name: "Host header with other headers",
+			headers: map[string]string{
+				"Host":           "my-service.example.com",
+				"X-Custom-Token": "abc123",
+			},
+			expectedHost:    "my-service.example.com",
+			expectedInMap:   map[string]string{"X-Custom-Token": "abc123"},
+			unexpectedInMap: []string{"Host"},
+		},
+		{
+			name:         "no Host header leaves req.Host unchanged",
+			headers:      map[string]string{"X-Custom": "value"},
+			expectedHost: "localhost:8123",
+			expectedInMap: map[string]string{"X-Custom": "value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, "http://localhost:8123/", nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %s", err)
+			}
+
+			opts := &Options{
+				HttpHeaders: tt.headers,
+			}
+
+			if err := applyOptionsToRequest(context.Background(), req, opts); err != nil {
+				t.Fatalf("applyOptionsToRequest failed: %s", err)
+			}
+
+			if req.Host != tt.expectedHost {
+				t.Errorf("req.Host = %q, want %q", req.Host, tt.expectedHost)
+			}
+
+			for k, v := range tt.expectedInMap {
+				if got := req.Header.Get(k); got != v {
+					t.Errorf("req.Header[%q] = %q, want %q", k, got, v)
+				}
+			}
+
+			for _, k := range tt.unexpectedInMap {
+				if got := req.Header.Get(k); got != "" {
+					t.Errorf("req.Header[%q] = %q, want it absent", k, got)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Go's `net/http` silently ignores `req.Header.Set("Host", ...)` — the wire `Host` header can only be set via `req.Host` ([Go docs](https://pkg.go.dev/net/http#Request)). The driver currently sets all custom headers uniformly via `req.Header.Set()` in `conn_http.go`, so a `Host` header specified in `HttpHeaders` has no effect on the outgoing request.

This one-line fix special-cases the `Host` key (case-insensitive) to set `req.Host` instead, ensuring the header reaches the wire.

## Problem

```go
conn, err := clickhouse.Open(&clickhouse.Options{
    Addr:     []string{"localhost:8123"},
    Protocol: clickhouse.HTTP,
    HTTPHeaders: map[string]string{
        "Host": "my-service.example.com",
    },
})
```

The `Host` header is silently dropped. This breaks routing through HTTP proxies (e.g. Envoy) that rely on the `Host` header for routing decisions.

## Fix

```go
for k, v := range opt.HttpHeaders {
    if strings.EqualFold(k, "Host") {
        req.Host = v
    } else {
        req.Header.Set(k, v)
    }
}
```

## Test plan

- Added unit tests in `conn_http_test.go` covering:
  - `Host` header sets `req.Host`
  - Case-insensitive matching (`host`, `HOST`)
  - `Host` header coexists with other custom headers
  - Non-Host headers are unaffected

Fixes #1825