### PR TITLE
upgrade to Golangci-lint v2; add lint to CI

### DIFF
--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -1,0 +1,29 @@
+name: Lint
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: [self-hosted, style-checker-aarch64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -34,6 +34,7 @@ linters:
 formatters:
   enable:
     - gofmt
+    - goimports
   exclusions:
     paths:
       - examples
@@ -44,3 +45,6 @@ formatters:
           replacement: any
         - pattern: a[b:len(a)]
           replacement: a[b:]
+    goimports:
+      local-prefixes:
+        - "github.com/ClickHouse/clickhouse-go/v2"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,71 +1,46 @@
+version: "2"
 run:
   tests: false
-  skip-dirs:
-  - benchmark
-  - tests
-  - internal/cmd
-
-linters-settings:
-  gocritic:
-    disabled-checks:
-    - singleCaseSwitch
-    - commentFormatting
-
-  decorder:
-    dec-order:
-    - type
-    - const
-    - var
-    - func
-    disable-dec-order-check: false
-
-  revive:
-    enable-all-rules: true
-    rules:
-    - name:     cyclomatic
-      disabled: true
-    - name:     argument-limit
-      disabled: true
-    - name:     function-length
-      disabled: true
-    - name:     function-result-limit
-      disabled: true
-    - name:     line-length-limit
-      disabled: true
-    - name:     file-header
-      disabled: true
-    - name:     cognitive-complexity
-      disabled: true
-    - name:     banned-characters
-      disabled: true
-    - name:     max-public-structs
-      disabled: true
-    - name:     add-constant
-      disabled: true
-    - name:     unhandled-error
-      disabled: true
-    - name:     deep-exit
-      disabled: true
-    - name:     nested-structs
-      disabled: true
-
-  gofmt:
-    rewrite-rules:
-    - pattern:     'interface{}'
-      replacement: 'any'
-    - pattern:     'a[b:len(a)]'
-      replacement: 'a[b:]'
-
 linters:
-  disable-all: true
+  default: none
   enable:
-  - asciicheck
-  - bodyclose
-  - depguard
-  - gocritic
-  - gofmt
-  - govet
-  - ineffassign
-  - imports
-  - misspell
-  - staticcheck
+    - asciicheck
+    - bodyclose
+    - gocritic
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+  settings:
+    gocritic:
+      disabled-checks:
+        - commentFormatting
+        - exitAfterDefer
+        - ifElseChain
+        - singleCaseSwitch
+  exclusions:
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters: [staticcheck]
+        path: "lib/cityhash102"
+    paths:
+      - benchmark
+      - examples
+      - tests
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    paths:
+      - examples
+  settings:
+    gofmt:
+      rewrite-rules:
+        - pattern: interface{}
+          replacement: any
+        - pattern: a[b:len(a)]
+          replacement: a[b:]

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,7 +16,6 @@ linters:
       disabled-checks:
         - commentFormatting
         - exitAfterDefer
-        - ifElseChain
         - singleCaseSwitch
   exclusions:
     presets:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,7 +15,6 @@ linters:
     gocritic:
       disabled-checks:
         - commentFormatting
-        - exitAfterDefer
         - singleCaseSwitch
   exclusions:
     presets:

--- a/benchmark/json_test.go
+++ b/benchmark/json_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"os"
+	"testing"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"os"
-	"testing"
 )
 
 const testSet string = "json_bench"

--- a/benchmark/v2/read-native/basic_test.go
+++ b/benchmark/v2/read-native/basic_test.go
@@ -3,10 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"log"
 	"testing"
 	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func getConnection() clickhouse.Conn {

--- a/benchmark/v2/write-compress-buffer-limit/write_test.go
+++ b/benchmark/v2/write-compress-buffer-limit/write_test.go
@@ -3,11 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"log"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func bToMb(b uint64) uint64 {

--- a/benchmark/v2/write-native/write_test.go
+++ b/benchmark/v2/write-native/write_test.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"context"
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"log"
 	"testing"
 	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func getConnection() clickhouse.Conn {

--- a/bind.go
+++ b/bind.go
@@ -391,7 +391,7 @@ func format(tz *time.Location, scale TimeUnit, v any) (string, error) {
 }
 
 func join[E any](tz *time.Location, scale TimeUnit, values []E) (string, error) {
-	items := make([]string, len(values), len(values))
+	items := make([]string, len(values))
 	for i := range values {
 		val, err := format(tz, scale, values[i])
 		if err != nil {

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/ClickHouse/ch-go/compress"
+
 	"github.com/ClickHouse/clickhouse-go/v2/lib/churl"
 )
 

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -413,7 +413,7 @@ func (o Options) setDefaults() *Options {
 	if o.MaxCompressionBuffer <= 0 {
 		o.MaxCompressionBuffer = 10485760
 	}
-	if o.Addr == nil || len(o.Addr) == 0 {
+	if len(o.Addr) == 0 {
 		switch o.Protocol {
 		case Native:
 			o.Addr = []string{"localhost:9000"}

--- a/clickhouse_rows_test.go
+++ b/clickhouse_rows_test.go
@@ -1,11 +1,13 @@
 package clickhouse
 
 import (
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
-	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
 func TestReadWithEmptyBlock(t *testing.T) {

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -55,7 +55,7 @@ func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) 
 		}
 	}
 
-	if o.opt.Addr == nil || len(o.opt.Addr) == 0 {
+	if len(o.opt.Addr) == 0 {
 		return nil, ErrAcquireConnNoAddress
 	}
 

--- a/client_info.go
+++ b/client_info.go
@@ -37,19 +37,11 @@ func (a ClientInfo) Append(b ClientInfo) ClientInfo {
 		Comment: make([]string, 0, len(a.Comment)+len(b.Comment)),
 	}
 
-	for _, p := range a.Products {
-		c.Products = append(c.Products, p)
-	}
-	for _, p := range b.Products {
-		c.Products = append(c.Products, p)
-	}
+	c.Products = append(c.Products, a.Products...)
+	c.Products = append(c.Products, b.Products...)
 
-	for _, cm := range a.Comment {
-		c.Comment = append(c.Comment, cm)
-	}
-	for _, cm := range b.Comment {
-		c.Comment = append(c.Comment, cm)
-	}
+	c.Comment = append(c.Comment, a.Comment...)
+	c.Comment = append(c.Comment, b.Comment...)
 
 	return c
 }

--- a/conn.go
+++ b/conn.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"io"
 	"log/slog"
 	"net"
@@ -13,10 +12,13 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
+
 	"github.com/ClickHouse/clickhouse-go/v2/resources"
 
 	"github.com/ClickHouse/ch-go/compress"
 	chproto "github.com/ClickHouse/ch-go/proto"
+
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 

--- a/conn_error_context_test.go
+++ b/conn_error_context_test.go
@@ -11,9 +11,10 @@ import (
 
 	"github.com/ClickHouse/ch-go/compress"
 	chproto "github.com/ClickHouse/ch-go/proto"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
 // mockNetConn is a mock net.Conn that can be configured to return specific errors

--- a/conn_exec.go
+++ b/conn_exec.go
@@ -2,8 +2,9 @@ package clickhouse
 
 import (
 	"context"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
 func (c *connect) exec(ctx context.Context, query string, args ...any) error {

--- a/conn_http.go
+++ b/conn_http.go
@@ -108,7 +108,8 @@ func applyOptionsToRequest(ctx context.Context, req *http.Request, opt *Options)
 	jwt := queryOpt.jwt
 	useJWT := jwt != "" || useJWTAuth(opt)
 
-	if opt.TLS != nil && useJWT {
+	switch {
+	case opt.TLS != nil && useJWT:
 		if jwt == "" {
 			var err error
 			jwt, err = opt.GetJWT(ctx)
@@ -118,7 +119,7 @@ func applyOptionsToRequest(ctx context.Context, req *http.Request, opt *Options)
 		}
 
 		req.Header.Set("Authorization", "Bearer "+jwt)
-	} else if opt.TLS != nil && len(opt.Auth.Username) > 0 {
+	case opt.TLS != nil && len(opt.Auth.Username) > 0:
 		req.Header.Set("X-ClickHouse-User", opt.Auth.Username)
 		if len(opt.Auth.Password) > 0 {
 			req.Header.Set("X-ClickHouse-Key", opt.Auth.Password)
@@ -126,7 +127,7 @@ func applyOptionsToRequest(ctx context.Context, req *http.Request, opt *Options)
 		} else {
 			req.Header.Set("X-ClickHouse-SSL-Certificate-Auth", "on")
 		}
-	} else if opt.TLS == nil && len(opt.Auth.Username) > 0 {
+	case opt.TLS == nil && len(opt.Auth.Username) > 0:
 		if len(opt.Auth.Password) > 0 {
 			req.URL.User = url.UserPassword(opt.Auth.Username, opt.Auth.Password)
 

--- a/conn_http.go
+++ b/conn_http.go
@@ -22,8 +22,9 @@ import (
 
 	"github.com/ClickHouse/ch-go/compress"
 	chproto "github.com/ClickHouse/ch-go/proto"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"github.com/andybalholm/brotli"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
 const (

--- a/conn_http_async_insert.go
+++ b/conn_http_async_insert.go
@@ -20,7 +20,7 @@ func (h *httpConnect) asyncInsert(ctx context.Context, query string, wait bool, 
 		}
 	}
 
-	res, err := h.sendQuery(ctx, query, &options, nil)
+	res, err := h.sendQuery(ctx, query, &options, nil) //nolint:bodyclose // false positive
 	if err != nil {
 		return err
 	}

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -267,7 +267,7 @@ func (b *httpBatch) Send() (err error) {
 	b.conn.logger.Debug("batch: sending via HTTP",
 		slog.Int("columns", len(b.block.Columns)),
 		slog.Int("rows", b.block.Rows()))
-	res, err := b.conn.sendStreamQuery(b.ctx, pipeReader, &options, headers)
+	res, err := b.conn.sendStreamQuery(b.ctx, pipeReader, &options, headers) //nolint:bodyclose // false positive
 	if err != nil {
 		return fmt.Errorf("batch sendStreamQuery: %w", err)
 	}

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -3,13 +3,14 @@ package clickhouse
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"io"
 	"log/slog"
 	"os"
 	"slices"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
 func fetchColumnNamesAndTypesForInsert(h *httpConnect, release nativeTransportRelease, ctx context.Context, tableName string, requestedColumnNames []string) ([]ColumnNameAndType, error) {

--- a/conn_http_exec.go
+++ b/conn_http_exec.go
@@ -11,7 +11,7 @@ func (h *httpConnect) exec(ctx context.Context, query string, args ...any) error
 		return err
 	}
 
-	res, err := h.sendQuery(ctx, query, &options, nil)
+	res, err := h.sendQuery(ctx, query, &options, nil) //nolint:bodyclose // false positive
 	if err != nil {
 		return err
 	}

--- a/conn_http_query.go
+++ b/conn_http_query.go
@@ -46,7 +46,7 @@ func (h *httpConnect) query(ctx context.Context, release nativeTransportRelease,
 		headers["Accept-Encoding"] = h.compression.String()
 	}
 
-	res, err := h.sendQuery(ctx, query, &options, headers)
+	res, err := h.sendQuery(ctx, query, &options, headers) //nolint:bodyclose // false positive
 	if err != nil {
 		err = fmt.Errorf("sendQuery: %w", err)
 		release(h, err)

--- a/conn_http_query.go
+++ b/conn_http_query.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 
 	chproto "github.com/ClickHouse/ch-go/proto"
+
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 

--- a/conn_pool_test.go
+++ b/conn_pool_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
 func TestConnPool_Cap(t *testing.T) {

--- a/context.go
+++ b/context.go
@@ -6,8 +6,9 @@ import (
 	"slices"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2/ext"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/ClickHouse/clickhouse-go/v2/ext"
 )
 
 var _contextOptionKey = &QueryOptions{

--- a/ext/ext.go
+++ b/ext/ext.go
@@ -2,9 +2,10 @@ package ext
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
-	"strings"
 )
 
 func NewTable(name string, columns ...func(t *Table) error) (*Table, error) {

--- a/internal/cmd/release/main.go
+++ b/internal/cmd/release/main.go
@@ -247,7 +247,7 @@ func getLatestDraftReleaseURL() (string, error) {
 	}
 
 	// filter out releases that are not drafts
-	for i := 0; i < len(releases); {
+	for i := 0; i < len(releases); i++ {
 		if releases[i].Draft {
 			return releases[i].URL, nil
 		}

--- a/internal/cmd/release/main.go
+++ b/internal/cmd/release/main.go
@@ -273,11 +273,12 @@ func updateClientInfo(major, minor, patch int) error {
 	var newContent string
 	for scanner.Scan() {
 		line := scanner.Text()
-		if reMajor.MatchString(line) {
+		switch {
+		case reMajor.MatchString(line):
 			line = newLines[0]
-		} else if reMinor.MatchString(line) {
+		case reMinor.MatchString(line):
 			line = newLines[1]
-		} else if rePatch.MatchString(line) {
+		case rePatch.MatchString(line):
 			line = newLines[2]
 		}
 		newContent += line + "\n"

--- a/internal/cmd/release/main.go
+++ b/internal/cmd/release/main.go
@@ -26,12 +26,20 @@ func main() {
 		return
 	}
 
-	releaseURL := getLatestDraftReleaseURL()
+	releaseURL, err := getLatestDraftReleaseURL()
+	if err != nil {
+		log.Fatalln(err)
+		return
+	}
 
 	log.Println("Latest draft release URL:")
 	log.Println(releaseURL)
 
-	r := getRelease(releaseURL)
+	r, err := getRelease(releaseURL)
+	if err != nil {
+		log.Fatalln(err)
+		return
+	}
 
 	log.Println("Release tag:")
 	log.Println(r.TagName)
@@ -50,7 +58,10 @@ func main() {
 	}
 
 	changelogPath := changelogFilePath()
-	prependReleaseToChangelog(changelogPath, r)
+	if err := prependReleaseToChangelog(changelogPath, r); err != nil {
+		log.Fatalln(err)
+		return
+	}
 
 	if err := updateClientInfo(major, minor, patch); err != nil {
 		log.Fatalln(err)
@@ -60,35 +71,34 @@ func main() {
 	runGoGenerate()
 	runGoFmt()
 
-	gitHubOutputReleaseURLIfAvailable(releaseURL)
+	if err := gitHubOutputReleaseURLIfAvailable(releaseURL); err != nil {
+		log.Fatalln(err)
+		return
+	}
 }
 
-func gitHubOutputReleaseURLIfAvailable(url string) {
+func gitHubOutputReleaseURLIfAvailable(url string) error {
 	if len(url) == 0 {
-		return
+		return nil
 	}
 
 	gitHubOutputFile, exists := os.LookupEnv("GITHUB_OUTPUT")
 	if !exists {
-		return
+		return nil
 	}
 
 	f, err := os.OpenFile(gitHubOutputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		log.Fatalln(err)
-		return
+		return err
 	}
 
-	defer func() {
-		if err := f.Close(); err != nil {
-			log.Fatalln(err)
-		}
-	}()
+	defer f.Close()
 
 	if _, err := fmt.Fprintf(f, "RELEASE_URL=%s\n", url); err != nil {
-		log.Fatalln(err)
-		return
+		return err
 	}
+
+	return nil
 }
 
 func runGoFmt() {
@@ -155,17 +165,16 @@ func parseSemVer(version string) (major, minor, patch int, err error) {
 	return
 }
 
-func prependReleaseToChangelog(changelogPath string, r release) {
+func prependReleaseToChangelog(changelogPath string, r release) error {
 	f, err := os.OpenFile(changelogPath, os.O_RDWR, 0666)
 	if err != nil {
-		log.Fatalln(err)
+		return err
 	}
 	defer f.Close()
 
 	content, err := io.ReadAll(f)
 	if err != nil {
-		log.Fatalln(err)
-		return
+		return err
 	}
 
 	f.Seek(0, io.SeekStart)
@@ -173,6 +182,8 @@ func prependReleaseToChangelog(changelogPath string, r release) {
 	f.WriteString(r.Body)
 	f.WriteString("\n\n")
 	f.Write(content)
+
+	return nil
 }
 
 func changelogFilePath() string {
@@ -187,24 +198,24 @@ func getRootPath() string {
 	return rootPath
 }
 
-func getRelease(releaseURL string) release {
+func getRelease(releaseURL string) (release, error) {
 	req, err := http.NewRequest(http.MethodGet, releaseURL, nil)
 	if err != nil {
-		log.Fatalln(err)
+		return release{}, err
 	}
 	req.Header.Set("Authorization", "token "+os.Getenv("GITHUB_TOKEN"))
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		log.Fatalln(err)
+		return release{}, err
 	}
 	defer res.Body.Close()
 
-	var release release
-	if err := json.NewDecoder(res.Body).Decode(&release); err != nil {
-		log.Fatalln(err)
+	var rel release
+	if err := json.NewDecoder(res.Body).Decode(&rel); err != nil {
+		return release{}, err
 	}
 
-	return release
+	return rel, nil
 }
 
 type release struct {
@@ -213,17 +224,17 @@ type release struct {
 	TagName string `json:"tag_name"`
 }
 
-func getLatestDraftReleaseURL() string {
+func getLatestDraftReleaseURL() (string, error) {
 	// Fetch the latest release from GitHub repository using GitHub API
 	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/repos/clickhouse/clickhouse-go/releases?per_page=100", nil)
 	if err != nil {
-		log.Fatalln(err)
+		return "", err
 	}
 
 	req.Header.Set("Authorization", "token "+os.Getenv("GITHUB_TOKEN"))
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		log.Fatalln(err)
+		return "", err
 	}
 	defer res.Body.Close()
 
@@ -232,18 +243,17 @@ func getLatestDraftReleaseURL() string {
 		Draft bool   `json:"draft"`
 	}
 	if err := json.NewDecoder(res.Body).Decode(&releases); err != nil {
-		log.Fatalln(err)
+		return "", err
 	}
 
 	// filter out releases that are not drafts
 	for i := 0; i < len(releases); {
 		if releases[i].Draft {
-			return releases[i].URL
+			return releases[i].URL, nil
 		}
 	}
 
-	log.Fatalln("No draft releases found")
-	return ""
+	return "", fmt.Errorf("no draft releases found")
 }
 
 func updateClientInfo(major, minor, patch int) error {

--- a/internal/cmd/release/main.go
+++ b/internal/cmd/release/main.go
@@ -85,7 +85,7 @@ func gitHubOutputReleaseURLIfAvailable(url string) {
 		}
 	}()
 
-	if _, err := f.WriteString(fmt.Sprintf("RELEASE_URL=%s\n", url)); err != nil {
+	if _, err := fmt.Fprintf(f, "RELEASE_URL=%s\n", url); err != nil {
 		log.Fatalln(err)
 		return
 	}
@@ -169,7 +169,7 @@ func prependReleaseToChangelog(changelogPath string, r release) {
 	}
 
 	f.Seek(0, io.SeekStart)
-	f.WriteString(fmt.Sprintf("# %s, %s ", r.TagName, time.Now().Format("2006-01-02")))
+	fmt.Fprintf(f, "# %s, %s ", r.TagName, time.Now().Format("2006-01-02"))
 	f.WriteString(r.Body)
 	f.WriteString("\n\n")
 	f.Write(content)

--- a/lib/chcol/json.go
+++ b/lib/chcol/json.go
@@ -123,7 +123,7 @@ func (o *JSON) MarshalJSON() ([]byte, error) {
 }
 
 // Scan implements the sql.Scanner interface
-func (o *JSON) Scan(value interface{}) error {
+func (o *JSON) Scan(value any) error {
 	switch vv := value.(type) {
 	case JSON:
 		o.valuesByPath = vv.valuesByPath

--- a/lib/chcol/variant.go
+++ b/lib/chcol/variant.go
@@ -56,7 +56,7 @@ func (v Variant) Any() any {
 }
 
 // Scan implements the sql.Scanner interface
-func (v *Variant) Scan(value interface{}) error {
+func (v *Variant) Scan(value any) error {
 	switch vv := value.(type) {
 	case Variant:
 		v.value = vv.value

--- a/lib/column/array.go
+++ b/lib/column/array.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-var scanTypeAny = reflect.TypeOf((*interface{})(nil)).Elem()
+var scanTypeAny = reflect.TypeOf((*any)(nil)).Elem()
 
 type offset struct {
 	values   UInt64

--- a/lib/column/array.go
+++ b/lib/column/array.go
@@ -3,9 +3,10 @@ package column
 import (
 	"database/sql"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
 	"strings"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 var scanTypeAny = reflect.TypeOf((*any)(nil)).Elem()

--- a/lib/column/bigint.go
+++ b/lib/column/bigint.go
@@ -4,9 +4,10 @@ import (
 	"database/sql/driver"
 	"encoding/binary"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"math/big"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type BigInt struct {

--- a/lib/column/bool.go
+++ b/lib/column/bool.go
@@ -4,8 +4,9 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type Bool struct {

--- a/lib/column/column.go
+++ b/lib/column/column.go
@@ -2,11 +2,12 @@ package column
 
 import (
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 // column names which match this must be escaped - see https://clickhouse.com/docs/en/sql-reference/syntax/#identifiers

--- a/lib/column/dynamic.go
+++ b/lib/column/dynamic.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/ClickHouse/ch-go/proto"
+
 	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 )
 

--- a/lib/column/enum.go
+++ b/lib/column/enum.go
@@ -91,23 +91,19 @@ func extractEnumNamedValues(chType Type) (typ string, values []string, indexes [
 			}
 
 			bracketOpen = true
-			break
 		// when inside a bracket, we can start capture value inside single quotes
 		case bracketOpen && token == '\'' && !stringOpen:
 			foundValueOffset = c + 1
 			stringOpen = true
-			break
 		// close the string and capture the value
 		case token == '\'' && stringOpen:
 			stringOpen = false
 			foundValueLen = c - foundValueOffset
 			valueFound = true
-			break
 		// escape character, skip the next character
 		case token == '\\' && stringOpen:
 			skippedValueTokens = append(skippedValueTokens, c-foundValueOffset)
 			c++
-			break
 		// capture optional index. `=` token is followed with an integer index
 		case token == '=' && !stringOpen:
 			if !valueFound {
@@ -128,7 +124,6 @@ func extractEnumNamedValues(chType Type) (typ string, values []string, indexes [
 			}
 			valueIndex = idx
 			indexFound = true
-			break
 		// capture the value and index when a comma or closing bracket is found
 		case (token == ',' || token == ')') && !stringOpen:
 			if !valueFound {
@@ -157,7 +152,6 @@ func extractEnumNamedValues(chType Type) (typ string, values []string, indexes [
 			values = append(values, string(foundName))
 			indexFound = false
 			valueFound = false
-			break
 		}
 	}
 

--- a/lib/column/enum16.go
+++ b/lib/column/enum16.go
@@ -4,8 +4,9 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type Enum16 struct {

--- a/lib/column/enum8.go
+++ b/lib/column/enum8.go
@@ -4,8 +4,9 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type Enum8 struct {

--- a/lib/column/fixed_string.go
+++ b/lib/column/fixed_string.go
@@ -138,12 +138,13 @@ func (col *FixedString) Append(v any) (nulls []uint8, err error) {
 		nulls = make([]uint8, len(v))
 		for i, v := range v {
 			var err error
-			if v == nil {
+			switch {
+			case v == nil:
 				nulls[i] = 1
 				err = col.safeAppendRow(nil)
-			} else if *v == "" {
+			case *v == "":
 				err = col.safeAppendRow(nil)
-			} else {
+			default:
 				err = col.safeAppendRow(binary.Str2Bytes(*v, col.col.Size))
 			}
 
@@ -175,11 +176,12 @@ func (col *FixedString) Append(v any) (nulls []uint8, err error) {
 			}
 			n := len(v)
 			var err error
-			if n == 0 {
+			switch {
+			case n == 0:
 				err = col.safeAppendRow(nil)
-			} else if n >= col.col.Size {
+			case n >= col.col.Size:
 				err = col.safeAppendRow(v[0:col.col.Size])
-			} else {
+			default:
 				err = col.safeAppendRow(v)
 			}
 

--- a/lib/column/geo_multi_polygon.go
+++ b/lib/column/geo_multi_polygon.go
@@ -4,8 +4,9 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 
 	"github.com/paulmach/orb"
 )

--- a/lib/column/geo_point.go
+++ b/lib/column/geo_point.go
@@ -4,8 +4,9 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 
 	"github.com/paulmach/orb"
 )

--- a/lib/column/geo_polygon.go
+++ b/lib/column/geo_polygon.go
@@ -4,8 +4,9 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 
 	"github.com/paulmach/orb"
 )

--- a/lib/column/geo_ring.go
+++ b/lib/column/geo_ring.go
@@ -4,8 +4,9 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 
 	"github.com/paulmach/orb"
 )

--- a/lib/column/interval.go
+++ b/lib/column/interval.go
@@ -3,9 +3,10 @@ package column
 import (
 	"errors"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
 	"strings"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type Interval struct {

--- a/lib/column/ipv4.go
+++ b/lib/column/ipv4.go
@@ -117,7 +117,7 @@ func (col *IPv4) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []string:
 		nulls = make([]uint8, len(v))
-		ips := make([]netip.Addr, len(v), len(v))
+		ips := make([]netip.Addr, len(v))
 		for i := range v {
 			ip, err := strToIPV4(v[i])
 			if err != nil {
@@ -128,7 +128,7 @@ func (col *IPv4) Append(v any) (nulls []uint8, err error) {
 		col.AppendV4IPs(ips)
 	case []*string:
 		nulls = make([]uint8, len(v))
-		ips := make([]netip.Addr, len(v), len(v))
+		ips := make([]netip.Addr, len(v))
 		for i := range v {
 			switch {
 			case v[i] != nil:

--- a/lib/column/ipv4.go
+++ b/lib/column/ipv4.go
@@ -5,10 +5,11 @@ import (
 	"database/sql/driver"
 	"encoding/binary"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"net"
 	"net/netip"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type IPv4 struct {

--- a/lib/column/ipv6.go
+++ b/lib/column/ipv6.go
@@ -4,10 +4,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"net"
 	"net/netip"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type IPv6 struct {
@@ -105,7 +106,7 @@ func (col *IPv6) Append(v any) (nulls []uint8, err error) {
 	switch v := v.(type) {
 	case []string:
 		nulls = make([]uint8, len(v))
-		ips := make([]netip.Addr, len(v), len(v))
+		ips := make([]netip.Addr, len(v))
 		for i := range v {
 			ip, err := strToIPV6(v[i])
 			if err != nil {
@@ -120,7 +121,7 @@ func (col *IPv6) Append(v any) (nulls []uint8, err error) {
 		col.AppendV6IPs(ips)
 	case []*string:
 		nulls = make([]uint8, len(v))
-		ips := make([]netip.Addr, len(v), len(v))
+		ips := make([]netip.Addr, len(v))
 		for i := range v {
 			switch {
 			case v[i] != nil:

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/ClickHouse/ch-go/proto"
+
 	"github.com/ClickHouse/clickhouse-go/v2/lib/binary"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 )

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -487,7 +487,7 @@ func (c *JSON) appendRowObject(v any) error {
 		// Even if value is nil, we must append a value for this row.
 		// nil is a valid value for most column types, with most implementations putting a zero value.
 		// If the column doesn't support appending nil, then the user must provide a zero value.
-		value, _ := valuesByPath[typedPath]
+		value := valuesByPath[typedPath]
 
 		col := c.typedColumns[i]
 		err := col.AppendRow(value)

--- a/lib/column/json_reflect.go
+++ b/lib/column/json_reflect.go
@@ -215,11 +215,12 @@ func (c *JSON) fillMap(val reflect.Value, prefix string, row int) error {
 			mapValueType := val.Type().Elem()
 			var newMap reflect.Value
 
-			if mapValueType.Kind() == reflect.Interface {
+			switch mapValueType.Kind() {
+			case reflect.Interface:
 				newMap = reflect.MakeMap(reflect.TypeOf(map[string]any{}))
-			} else if mapValueType.Kind() == reflect.Map {
+			case reflect.Map:
 				newMap = reflect.MakeMap(mapValueType)
-			} else {
+			default:
 				return fmt.Errorf("invalid map value type for nested path \"%s\"", newPrefix)
 			}
 
@@ -372,13 +373,14 @@ func handleValue(val reflect.Value, path string, json *chcol.JSON, forcedType st
 		return iterateStruct(val, path, json)
 
 	case reflect.Map:
-		if forcedType == "" && val.Type().Elem().Kind() == reflect.Interface {
+		switch {
+		case forcedType == "" && val.Type().Elem().Kind() == reflect.Interface:
 			// Only iterate maps if they are map[string]interface{}
 			return iterateMap(val, path, json)
-		} else if forcedType == "" {
+		case forcedType == "":
 			json.SetValueAtPath(path, val.Interface())
 			return nil
-		} else {
+		default:
 			json.SetValueAtPath(path, chcol.NewDynamicWithType(val.Interface(), forcedType))
 			return nil
 		}

--- a/lib/column/json_reflect.go
+++ b/lib/column/json_reflect.go
@@ -216,7 +216,7 @@ func (c *JSON) fillMap(val reflect.Value, prefix string, row int) error {
 			var newMap reflect.Value
 
 			if mapValueType.Kind() == reflect.Interface {
-				newMap = reflect.MakeMap(reflect.TypeOf(map[string]interface{}{}))
+				newMap = reflect.MakeMap(reflect.TypeOf(map[string]any{}))
 			} else if mapValueType.Kind() == reflect.Map {
 				newMap = reflect.MakeMap(mapValueType)
 			} else {

--- a/lib/column/json_test.go
+++ b/lib/column/json_test.go
@@ -3,9 +3,10 @@ package column
 import (
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 )
 
 // newTestJSONColumn creates a JSON column with unset serialization version (default state)

--- a/lib/column/lowcardinality.go
+++ b/lib/column/lowcardinality.go
@@ -3,10 +3,11 @@ package column
 import (
 	"errors"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"math"
 	"reflect"
 	"time"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 const indexTypeMask = 0b11111111

--- a/lib/column/map.go
+++ b/lib/column/map.go
@@ -4,9 +4,10 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
 	"strings"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 // https://github.com/ClickHouse/ClickHouse/blob/master/src/Columns/ColumnMap.cpp

--- a/lib/column/map.go
+++ b/lib/column/map.go
@@ -48,7 +48,7 @@ func (col *Map) Name() string {
 
 func (col *Map) parse(t Type, sc *ServerContext) (_ Interface, err error) {
 	col.chType = t
-	types := make([]string, 2, 2)
+	types := make([]string, 2)
 	typeParams := t.params()
 	idx := strings.Index(typeParams, ",")
 	if strings.HasPrefix(typeParams, "Enum") {

--- a/lib/column/nested.go
+++ b/lib/column/nested.go
@@ -16,7 +16,7 @@ func (col *Nested) Reset() {
 }
 
 func asDDL(cols []namedCol) string {
-	sCols := make([]string, len(cols), len(cols))
+	sCols := make([]string, len(cols))
 	for i := range cols {
 		sCols[i] = fmt.Sprintf("%s %s", cols[i].name, cols[i].colType)
 	}

--- a/lib/column/nested.go
+++ b/lib/column/nested.go
@@ -2,8 +2,9 @@ package column
 
 import (
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"strings"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type Nested struct {

--- a/lib/column/nothing.go
+++ b/lib/column/nothing.go
@@ -2,8 +2,9 @@ package column
 
 import (
 	"errors"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 type Nothing struct {

--- a/lib/column/orderedmap/orderedmap.go
+++ b/lib/column/orderedmap/orderedmap.go
@@ -2,8 +2,9 @@ package orderedmap
 
 import (
 	"cmp"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"slices"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 )
 
 // Map is a simple implementation of [column.IterableOrderedMap] interface.

--- a/lib/column/orderedmap/orderedmap_test.go
+++ b/lib/column/orderedmap/orderedmap_test.go
@@ -2,9 +2,10 @@ package orderedmap
 
 import (
 	"cmp"
-	"github.com/stretchr/testify/assert"
 	"slices"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMap(t *testing.T) {

--- a/lib/column/sharedvariant.go
+++ b/lib/column/sharedvariant.go
@@ -1,8 +1,9 @@
 package column
 
 import (
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 )
 
 // SharedVariant deprecated. Use Dynamic/JSON serialization version 3.

--- a/lib/column/tuple.go
+++ b/lib/column/tuple.go
@@ -437,7 +437,7 @@ func (col *Tuple) scan(targetType reflect.Type, row int) (reflect.Value, error) 
 		if !col.isNamed {
 			return reflect.Value{}, &ColumnConverterError{
 				Op:   "ScanRow",
-				To:   fmt.Sprintf("%s", targetType),
+				To:   targetType.String(),
 				From: string(col.chType),
 				Hint: "cannot use interface for unnamed tuples, use slice",
 			}

--- a/lib/column/uuid.go
+++ b/lib/column/uuid.go
@@ -4,8 +4,9 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
 	"reflect"
+
+	"github.com/ClickHouse/ch-go/proto"
 
 	"github.com/google/uuid"
 )

--- a/lib/column/variant.go
+++ b/lib/column/variant.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/ClickHouse/ch-go/proto"
+
 	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 )
 

--- a/lib/column/variant_test.go
+++ b/lib/column/variant_test.go
@@ -1,9 +1,10 @@
 package column
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestColVariant_parse(t *testing.T) {

--- a/lib/proto/block.go
+++ b/lib/proto/block.go
@@ -3,9 +3,11 @@ package proto
 import (
 	"errors"
 	"fmt"
-	"github.com/ClickHouse/ch-go/proto"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"sort"
+
+	"github.com/ClickHouse/ch-go/proto"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 )
 
 type Block struct {

--- a/lib/proto/block.go
+++ b/lib/proto/block.go
@@ -188,8 +188,8 @@ func (b *Block) Decode(reader *proto.Reader, revision uint64) (err error) {
 			Err: errors.New("more than 1 billion rows in block - suspiciously big - preventing OOM"),
 		}
 	}
-	b.Columns = make([]column.Interface, numCols, numCols)
-	b.names = make([]string, numCols, numCols)
+	b.Columns = make([]column.Interface, numCols)
+	b.names = make([]string, numCols)
 	for i := 0; i < int(numCols); i++ {
 		var (
 			columnName string

--- a/lib/proto/handshake.go
+++ b/lib/proto/handshake.go
@@ -2,11 +2,12 @@ package proto
 
 import (
 	"fmt"
-	chproto "github.com/ClickHouse/ch-go/proto"
-	"go.yaml.in/yaml/v3"
 	"strconv"
 	"strings"
 	"time"
+
+	chproto "github.com/ClickHouse/ch-go/proto"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/timezone"
 )

--- a/lib/proto/profile_info.go
+++ b/lib/proto/profile_info.go
@@ -2,6 +2,7 @@ package proto
 
 import (
 	"fmt"
+
 	chproto "github.com/ClickHouse/ch-go/proto"
 )
 

--- a/lib/proto/query.go
+++ b/lib/proto/query.go
@@ -3,10 +3,11 @@ package proto
 import (
 	stdbin "encoding/binary"
 	"fmt"
-	chproto "github.com/ClickHouse/ch-go/proto"
-	"go.opentelemetry.io/otel/trace"
 	"os"
 	"strings"
+
+	chproto "github.com/ClickHouse/ch-go/proto"
+	"go.opentelemetry.io/otel/trace"
 )
 
 var (

--- a/lib/proto/table_columns.go
+++ b/lib/proto/table_columns.go
@@ -2,6 +2,7 @@ package proto
 
 import (
 	"fmt"
+
 	chproto "github.com/ClickHouse/ch-go/proto"
 )
 

--- a/resources/meta.go
+++ b/resources/meta.go
@@ -35,7 +35,7 @@ func (m *Meta) IsSupportedClickHouseVersion(v proto.Version) bool {
 }
 
 func (m *Meta) SupportedVersions() string {
-	versions := make([]string, len(m.ClickhouseVersions), len(m.ClickhouseVersions))
+	versions := make([]string, len(m.ClickhouseVersions))
 	for i := range m.ClickhouseVersions {
 		versions[i] = m.ClickhouseVersions[i].String()
 	}

--- a/resources/meta.go
+++ b/resources/meta.go
@@ -2,9 +2,11 @@ package resources
 
 import (
 	_ "embed"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
-	"go.yaml.in/yaml/v3"
 	"strings"
+
+	"go.yaml.in/yaml/v3"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
 type Meta struct {

--- a/resources/meta_test.go
+++ b/resources/meta_test.go
@@ -1,10 +1,12 @@
 package resources
 
 import (
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
 var m Meta = Meta{

--- a/scan.go
+++ b/scan.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"reflect"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )

--- a/tests/abort_test.go
+++ b/tests/abort_test.go
@@ -2,11 +2,13 @@ package tests
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestAbort(t *testing.T) {

--- a/tests/array_test.go
+++ b/tests/array_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestSimpleArray(t *testing.T) {
@@ -161,26 +163,26 @@ func TestArray(t *testing.T) {
 			timestamp = time.Now().Truncate(time.Second).In(time.UTC)
 			col1Data  = []string{"A", "b", "c"}
 			col2Data  = [][]uint32{
-				[]uint32{1, 2},
-				[]uint32{3, 87},
-				[]uint32{33, 3, 847},
+				{1, 2},
+				{3, 87},
+				{33, 3, 847},
 			}
 			col3Data = [][][]time.Time{
-				[][]time.Time{
-					[]time.Time{
+				{
+					{
 						timestamp,
 						timestamp,
 						timestamp,
 						timestamp,
 					},
 				},
-				[][]time.Time{
-					[]time.Time{
+				{
+					{
 						timestamp,
 						timestamp,
 						timestamp,
 					},
-					[]time.Time{
+					{
 						timestamp,
 						timestamp,
 					},
@@ -235,26 +237,26 @@ func TestColumnarArray(t *testing.T) {
 			timestamp = time.Now().Truncate(time.Second).In(time.UTC)
 			col1Data  = []string{"A", "b", "c"}
 			col2Data  = [][]uint32{
-				[]uint32{1, 2},
-				[]uint32{3, 87},
-				[]uint32{33, 3, 847},
+				{1, 2},
+				{3, 87},
+				{33, 3, 847},
 			}
 			col3Data = [][][]time.Time{
-				[][]time.Time{
-					[]time.Time{
+				{
+					{
 						timestamp,
 						timestamp,
 						timestamp,
 						timestamp,
 					},
 				},
-				[][]time.Time{
-					[]time.Time{
+				{
+					{
 						timestamp,
 						timestamp,
 						timestamp,
 					},
-					[]time.Time{
+					{
 						timestamp,
 						timestamp,
 					},

--- a/tests/base_types_test.go
+++ b/tests/base_types_test.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 type customUint8 uint8

--- a/tests/batch_release_connection_test.go
+++ b/tests/batch_release_connection_test.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBatchReleaseConnection(t *testing.T) {

--- a/tests/batch_test.go
+++ b/tests/batch_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestBatchContextCancellation(t *testing.T) {

--- a/tests/bfloat16_test.go
+++ b/tests/bfloat16_test.go
@@ -10,8 +10,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestSimpleBFloat16(t *testing.T) {

--- a/tests/bigint_test.go
+++ b/tests/bigint_test.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestSimpleBigInt(t *testing.T) {

--- a/tests/bool_test.go
+++ b/tests/bool_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestBool(t *testing.T) {

--- a/tests/client_info_test.go
+++ b/tests/client_info_test.go
@@ -6,10 +6,11 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
 func TestClientInfo(t *testing.T) {

--- a/tests/column_types_test.go
+++ b/tests/column_types_test.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestColumnTypes(t *testing.T) {

--- a/tests/columnar_batch_test.go
+++ b/tests/columnar_batch_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestColumnarInterface(t *testing.T) {

--- a/tests/compression_test.go
+++ b/tests/compression_test.go
@@ -2,11 +2,13 @@ package tests
 
 import (
 	"context"
+	"testing"
+
 	"github.com/ClickHouse/ch-go/compress"
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestZSTDCompression(t *testing.T) {

--- a/tests/conn_test.go
+++ b/tests/conn_test.go
@@ -12,9 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestConn(t *testing.T) {

--- a/tests/context_cancel_test.go
+++ b/tests/context_cancel_test.go
@@ -11,9 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestContextCancellationOfHeavyGeneratedInsert(t *testing.T) {

--- a/tests/contributors_test.go
+++ b/tests/contributors_test.go
@@ -3,8 +3,9 @@ package tests
 import (
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestContributors(t *testing.T) {

--- a/tests/custom_dial_test.go
+++ b/tests/custom_dial_test.go
@@ -12,8 +12,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestCustomDialContext(t *testing.T) {

--- a/tests/datetime64_test.go
+++ b/tests/datetime64_test.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestDateTime64(t *testing.T) {

--- a/tests/datetime_test.go
+++ b/tests/datetime_test.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestDateTime(t *testing.T) {

--- a/tests/ddl_test.go
+++ b/tests/ddl_test.go
@@ -3,9 +3,11 @@ package tests
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestQuotedDDL(t *testing.T) {

--- a/tests/decimal_test.go
+++ b/tests/decimal_test.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestDecimal(t *testing.T) {

--- a/tests/dynamic_test.go
+++ b/tests/dynamic_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/stretchr/testify/require"
 )
 
 var dynamicTestDate, _ = time.Parse(time.RFC3339, "2024-12-13T02:09:30.123Z")

--- a/tests/empty_query_test.go
+++ b/tests/empty_query_test.go
@@ -2,12 +2,14 @@ package tests
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestEmptyQuery(t *testing.T) {

--- a/tests/enum_test.go
+++ b/tests/enum_test.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestSimpleEnum(t *testing.T) {

--- a/tests/external_table_test.go
+++ b/tests/external_table_test.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/ext"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestExternalTable(t *testing.T) {

--- a/tests/fixed_string_test.go
+++ b/tests/fixed_string_test.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 type BinFixedString struct {

--- a/tests/float64_test.go
+++ b/tests/float64_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestFloat64(t *testing.T) {

--- a/tests/float_test.go
+++ b/tests/float_test.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestSimpleFloat(t *testing.T) {

--- a/tests/flush_test.go
+++ b/tests/flush_test.go
@@ -3,12 +3,14 @@ package tests
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
 func TestBatchNoFlush(t *testing.T) {

--- a/tests/geo_linestring_test.go
+++ b/tests/geo_linestring_test.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestGeoLineString(t *testing.T) {

--- a/tests/geo_multi_linestring_test.go
+++ b/tests/geo_multi_linestring_test.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestGeoMultiLineString(t *testing.T) {

--- a/tests/geo_multipolygon_test.go
+++ b/tests/geo_multipolygon_test.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestGeoMultiPolygon(t *testing.T) {
@@ -65,21 +66,21 @@ func TestGeoMultiPolygon(t *testing.T) {
 			col2Data = []orb.MultiPolygon{
 				[]orb.Polygon{
 					[]orb.Ring{
-						orb.Ring{
+						{
 							orb.Point{1, 2},
 							orb.Point{1, 22},
 						},
-						orb.Ring{
+						{
 							orb.Point{1, 23},
 							orb.Point{12, 2},
 						},
 					},
 					[]orb.Ring{
-						orb.Ring{
+						{
 							orb.Point{21, 2},
 							orb.Point{1, 222},
 						},
-						orb.Ring{
+						{
 							orb.Point{21, 23},
 							orb.Point{12, 22},
 						},
@@ -87,21 +88,21 @@ func TestGeoMultiPolygon(t *testing.T) {
 				},
 				[]orb.Polygon{
 					[]orb.Ring{
-						orb.Ring{
+						{
 							orb.Point{11, 2},
 							orb.Point{1, 22},
 						},
-						orb.Ring{
+						{
 							orb.Point{1, 23},
 							orb.Point{12, 22},
 						},
 					},
 					[]orb.Ring{
-						orb.Ring{
+						{
 							orb.Point{21, 2},
 							orb.Point{1, 222},
 						},
-						orb.Ring{
+						{
 							orb.Point{21, 23},
 							orb.Point{12, 22},
 						},

--- a/tests/geo_point_test.go
+++ b/tests/geo_point_test.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestGeoPoint(t *testing.T) {

--- a/tests/geo_polygon_test.go
+++ b/tests/geo_polygon_test.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestGeoPolygon(t *testing.T) {
@@ -52,21 +53,21 @@ func TestGeoPolygon(t *testing.T) {
 			}
 			col2Data = []orb.Polygon{
 				[]orb.Ring{
-					orb.Ring{
+					{
 						orb.Point{1, 2},
 						orb.Point{1, 22},
 					},
-					orb.Ring{
+					{
 						orb.Point{1, 23},
 						orb.Point{12, 2},
 					},
 				},
 				[]orb.Ring{
-					orb.Ring{
+					{
 						orb.Point{21, 2},
 						orb.Point{1, 222},
 					},
-					orb.Ring{
+					{
 						orb.Point{21, 23},
 						orb.Point{12, 22},
 					},

--- a/tests/geo_ring_test.go
+++ b/tests/geo_ring_test.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestGeoRing(t *testing.T) {
@@ -44,11 +45,11 @@ func TestGeoRing(t *testing.T) {
 				orb.Point{1, 2},
 			}
 			col2Data = []orb.Ring{
-				orb.Ring{
+				{
 					orb.Point{1, 2},
 					orb.Point{1, 2},
 				},
-				orb.Ring{
+				{
 					orb.Point{1, 2},
 					orb.Point{1, 2},
 				},

--- a/tests/http_exception_test.go
+++ b/tests/http_exception_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestHTTPExceptionHandling(t *testing.T) {

--- a/tests/insert_bind_test.go
+++ b/tests/insert_bind_test.go
@@ -2,9 +2,11 @@ package tests
 
 import (
 	"context"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestBindArrayInsert(t *testing.T) {

--- a/tests/int64_test.go
+++ b/tests/int64_test.go
@@ -2,11 +2,13 @@ package tests
 
 import (
 	"context"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestDurationInt64(t *testing.T) {

--- a/tests/interval_test.go
+++ b/tests/interval_test.go
@@ -2,11 +2,13 @@ package tests
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestInterval(t *testing.T) {

--- a/tests/ipv4_test.go
+++ b/tests/ipv4_test.go
@@ -9,11 +9,13 @@ import (
 	"net/netip"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestSimpleIPv4(t *testing.T) {

--- a/tests/ipv6_test.go
+++ b/tests/ipv6_test.go
@@ -9,11 +9,13 @@ import (
 	"testing"
 
 	"github.com/ClickHouse/ch-go/proto"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestIPv6(t *testing.T) {

--- a/tests/issues/1016_test.go
+++ b/tests/issues/1016_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 	"time"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func Test1016(t *testing.T) {

--- a/tests/issues/1049_test.go
+++ b/tests/issues/1049_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test1049(t *testing.T) {

--- a/tests/issues/1053_test.go
+++ b/tests/issues/1053_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test1053(t *testing.T) {

--- a/tests/issues/1066_test.go
+++ b/tests/issues/1066_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func Test1066(t *testing.T) {

--- a/tests/issues/1067_test.go
+++ b/tests/issues/1067_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test1067(t *testing.T) {

--- a/tests/issues/1072_test.go
+++ b/tests/issues/1072_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test1072(t *testing.T) {

--- a/tests/issues/1106_test.go
+++ b/tests/issues/1106_test.go
@@ -5,9 +5,10 @@ import (
 	"net"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test1106(t *testing.T) {

--- a/tests/issues/1113_test.go
+++ b/tests/issues/1113_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test1113(t *testing.T) {

--- a/tests/issues/1119_test.go
+++ b/tests/issues/1119_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test1119(t *testing.T) {

--- a/tests/issues/1127_test.go
+++ b/tests/issues/1127_test.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func Test1127(t *testing.T) {

--- a/tests/issues/1128_test.go
+++ b/tests/issues/1128_test.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/tests/issues/1163_test.go
+++ b/tests/issues/1163_test.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIssue1163(t *testing.T) {

--- a/tests/issues/1164_test.go
+++ b/tests/issues/1164_test.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIssue1164(t *testing.T) {

--- a/tests/issues/1169_test.go
+++ b/tests/issues/1169_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test1169(t *testing.T) {

--- a/tests/issues/1200_pr_test.go
+++ b/tests/issues/1200_pr_test.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test1200(t *testing.T) {

--- a/tests/issues/1216_test.go
+++ b/tests/issues/1216_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test1216(t *testing.T) {

--- a/tests/issues/1229_test.go
+++ b/tests/issues/1229_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func Test1229(t *testing.T) {

--- a/tests/issues/1245_test.go
+++ b/tests/issues/1245_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func Test1245Native(t *testing.T) {

--- a/tests/issues/1247_test.go
+++ b/tests/issues/1247_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test1247(t *testing.T) {

--- a/tests/issues/1257_test.go
+++ b/tests/issues/1257_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 	"time"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func Test1257(t *testing.T) {

--- a/tests/issues/1271_test.go
+++ b/tests/issues/1271_test.go
@@ -9,12 +9,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/google/uuid"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 // test for https://github.com/ClickHouse/clickhouse-go/issues/1271

--- a/tests/issues/1280_test.go
+++ b/tests/issues/1280_test.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test1280(t *testing.T) {

--- a/tests/issues/1297_test.go
+++ b/tests/issues/1297_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test1297(t *testing.T) {

--- a/tests/issues/1299_test.go
+++ b/tests/issues/1299_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestIssue1299(t *testing.T) {

--- a/tests/issues/1329_test.go
+++ b/tests/issues/1329_test.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test1329(t *testing.T) {

--- a/tests/issues/1345_test.go
+++ b/tests/issues/1345_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestIssue1345(t *testing.T) {

--- a/tests/issues/1349_test.go
+++ b/tests/issues/1349_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestIssue1349(t *testing.T) {
@@ -31,8 +32,8 @@ func TestIssue1349(t *testing.T) {
 	var (
 		a        = "a"
 		b        = "b"
-		col1Data = []interface{}{[]string{}, []string{"a", "b"}, &[]string{"c"}, []interface{}{&a, &b}}
-		col2Data = []interface{}{[]*string{&a, nil}, &[]*string{&b, nil}, &[]interface{}{nil, &a}}
+		col1Data = []any{[]string{}, []string{"a", "b"}, &[]string{"c"}, []any{&a, &b}}
+		col2Data = []any{[]*string{&a, nil}, &[]*string{&b, nil}, &[]any{nil, &a}}
 	)
 
 	err = batch.Append(col1Data, col2Data)

--- a/tests/issues/1359_test.go
+++ b/tests/issues/1359_test.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"testing"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 type SomeStruct struct {

--- a/tests/issues/1365_test.go
+++ b/tests/issues/1365_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 type T1365OrderedMap int

--- a/tests/issues/1395_test.go
+++ b/tests/issues/1395_test.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test1395(t *testing.T) {

--- a/tests/issues/1421_test.go
+++ b/tests/issues/1421_test.go
@@ -7,11 +7,12 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 //goland:noinspection ALL

--- a/tests/issues/1446_test.go
+++ b/tests/issues/1446_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 type sampleFailTuple struct {

--- a/tests/issues/1503_test.go
+++ b/tests/issues/1503_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIssue1503(t *testing.T) {

--- a/tests/issues/1515_test.go
+++ b/tests/issues/1515_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestIssue1515(t *testing.T) {

--- a/tests/issues/1565_test.go
+++ b/tests/issues/1565_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestIssue1565(t *testing.T) {

--- a/tests/issues/1638_test.go
+++ b/tests/issues/1638_test.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIssue1638_NullableJSON(t *testing.T) {

--- a/tests/issues/164_test.go
+++ b/tests/issues/164_test.go
@@ -3,13 +3,15 @@ package issues
 import (
 	"context"
 	"database/sql"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"strconv"
-	"testing"
 )
 
 func TestIssue164(t *testing.T) {

--- a/tests/issues/1685_test.go
+++ b/tests/issues/1685_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func benchmark1685(ctx context.Context, conn clickhouse.Conn) error {

--- a/tests/issues/1708_test.go
+++ b/tests/issues/1708_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhousetests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test1708(t *testing.T) {

--- a/tests/issues/1775_test.go
+++ b/tests/issues/1775_test.go
@@ -5,9 +5,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIssue1775_JSONMapScanOmitsAbsentKeys(t *testing.T) {

--- a/tests/issues/1801_test.go
+++ b/tests/issues/1801_test.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test1801(t *testing.T) {

--- a/tests/issues/260_test.go
+++ b/tests/issues/260_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 	"time"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/issues/357_test.go
+++ b/tests/issues/357_test.go
@@ -1,13 +1,15 @@
 package issues
 
 import (
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/issues/360/main.go
+++ b/tests/issues/360/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"database/sql"
 	"fmt"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
 	"log"
 	"net/http"
 	_ "net/http/pprof"
 	"time"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 )

--- a/tests/issues/389_test.go
+++ b/tests/issues/389_test.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestIssue389(t *testing.T) {

--- a/tests/issues/406_test.go
+++ b/tests/issues/406_test.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestIssue406(t *testing.T) {

--- a/tests/issues/412_test.go
+++ b/tests/issues/412_test.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestIssue412(t *testing.T) {

--- a/tests/issues/470/main.go
+++ b/tests/issues/470/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"database/sql"
 	"fmt"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
 	"log"
 	"reflect"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
 
 	_ "github.com/ClickHouse/clickhouse-go/v2"
 )

--- a/tests/issues/470_pr_test.go
+++ b/tests/issues/470_pr_test.go
@@ -1,12 +1,14 @@
 package issues
 
 import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
-	"github.com/stretchr/testify/require"
-	"strconv"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/issues/472_test.go
+++ b/tests/issues/472_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 	"time"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/google/uuid"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestIssue472(t *testing.T) {

--- a/tests/issues/476_test.go
+++ b/tests/issues/476_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"testing"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestIssue476(t *testing.T) {

--- a/tests/issues/482_test.go
+++ b/tests/issues/482_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 	"time"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestIssue482(t *testing.T) {

--- a/tests/issues/483_test.go
+++ b/tests/issues/483_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"testing"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestIssue483(t *testing.T) {

--- a/tests/issues/502_test.go
+++ b/tests/issues/502_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"testing"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestIssue502(t *testing.T) {

--- a/tests/issues/504_test.go
+++ b/tests/issues/504_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"testing"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestIssue504(t *testing.T) {

--- a/tests/issues/506_test.go
+++ b/tests/issues/506_test.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestIssue506(t *testing.T) {

--- a/tests/issues/517_test.go
+++ b/tests/issues/517_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestIssue517(t *testing.T) {

--- a/tests/issues/546_test.go
+++ b/tests/issues/546_test.go
@@ -6,11 +6,13 @@ import (
 	"testing"
 	"time"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestIssue546(t *testing.T) {

--- a/tests/issues/548_test.go
+++ b/tests/issues/548_test.go
@@ -7,8 +7,9 @@ import (
 
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestIssue548(t *testing.T) {

--- a/tests/issues/570_test.go
+++ b/tests/issues/570_test.go
@@ -4,14 +4,16 @@ import (
 	"crypto/tls"
 	"database/sql"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
 )
 
 func TestIssue570(t *testing.T) {

--- a/tests/issues/578_test.go
+++ b/tests/issues/578_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestIssue578(t *testing.T) {

--- a/tests/issues/584_test.go
+++ b/tests/issues/584_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestIssue584(t *testing.T) {

--- a/tests/issues/592_test.go
+++ b/tests/issues/592_test.go
@@ -2,9 +2,11 @@ package issues
 
 import (
 	"context"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestIssue592(t *testing.T) {

--- a/tests/issues/615_test.go
+++ b/tests/issues/615_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestIssue615(t *testing.T) {

--- a/tests/issues/647_test.go
+++ b/tests/issues/647_test.go
@@ -8,9 +8,10 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIssue647(t *testing.T) {

--- a/tests/issues/648_test.go
+++ b/tests/issues/648_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIssue648(t *testing.T) {

--- a/tests/issues/655_test.go
+++ b/tests/issues/655_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 // Test655 confirms an agreed semantic on failing batch append results with entire batch cancellation.

--- a/tests/issues/692_test.go
+++ b/tests/issues/692_test.go
@@ -6,12 +6,13 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/ClickHouse/clickhouse-go/v2/tests/std"
 	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIssue692(t *testing.T) {

--- a/tests/issues/693_test.go
+++ b/tests/issues/693_test.go
@@ -1,14 +1,16 @@
 package issues
 
 import (
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
 )
 
 func TestIssue693(t *testing.T) {

--- a/tests/issues/741_test.go
+++ b/tests/issues/741_test.go
@@ -10,12 +10,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
 )
 
 func TestIssue741(t *testing.T) {

--- a/tests/issues/751_test.go
+++ b/tests/issues/751_test.go
@@ -5,9 +5,10 @@ import (
 	"database/sql"
 	"testing"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestIssue751(t *testing.T) {

--- a/tests/issues/759_test.go
+++ b/tests/issues/759_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test759(t *testing.T) {

--- a/tests/issues/762_test.go
+++ b/tests/issues/762_test.go
@@ -5,10 +5,11 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
-	"github.com/stretchr/testify/require"
 )
 
 func Test762(t *testing.T) {

--- a/tests/issues/777_test.go
+++ b/tests/issues/777_test.go
@@ -5,10 +5,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func TestInsertNullableString(t *testing.T) {

--- a/tests/issues/783_test.go
+++ b/tests/issues/783_test.go
@@ -5,10 +5,11 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
-	"github.com/stretchr/testify/require"
 )
 
 func Test783(t *testing.T) {

--- a/tests/issues/798_test.go
+++ b/tests/issues/798_test.go
@@ -6,9 +6,10 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test798(t *testing.T) {

--- a/tests/issues/812_test.go
+++ b/tests/issues/812_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test812(t *testing.T) {

--- a/tests/issues/813_test.go
+++ b/tests/issues/813_test.go
@@ -1,12 +1,14 @@
 package issues
 
 import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
-	"github.com/stretchr/testify/require"
-	"strconv"
-	"testing"
 )
 
 func Test813(t *testing.T) {

--- a/tests/issues/816_test.go
+++ b/tests/issues/816_test.go
@@ -1,13 +1,15 @@
 package issues
 
 import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"strconv"
-	"testing"
 )
 
 func Test816(t *testing.T) {

--- a/tests/issues/828_test.go
+++ b/tests/issues/828_test.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test828(t *testing.T) {

--- a/tests/issues/870_test.go
+++ b/tests/issues/870_test.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func Test870(t *testing.T) {

--- a/tests/issues/904_test.go
+++ b/tests/issues/904_test.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func Test904(t *testing.T) {

--- a/tests/issues/955_test.go
+++ b/tests/issues/955_test.go
@@ -5,11 +5,12 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func Test955(t *testing.T) {

--- a/tests/issues/957_test.go
+++ b/tests/issues/957_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 func Test957(t *testing.T) {

--- a/tests/issues/990_test.go
+++ b/tests/issues/990_test.go
@@ -3,15 +3,17 @@ package issues
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/ext"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"strconv"
-	"testing"
-	"time"
 )
 
 func Test990(t *testing.T) {

--- a/tests/issues/stress_http_batch_test.go
+++ b/tests/issues/stress_http_batch_test.go
@@ -4,14 +4,16 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestStressHTTPBatchConcurrency(t *testing.T) {

--- a/tests/json_helper.go
+++ b/tests/json_helper.go
@@ -27,7 +27,7 @@ type TestStruct struct {
 	Address TestStructAddress
 
 	KeysNumbers map[string]int64
-	Metadata    map[string]interface{}
+	Metadata    map[string]any
 
 	Timestamp time.Time `chType:"DateTime64(3)"`
 
@@ -112,10 +112,10 @@ func BuildTestJSONStruct() TestStruct {
 			Country: "Country",
 		},
 		KeysNumbers: map[string]int64{"FieldA": 42, "FieldB": 32},
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"FieldA": "a",
 			"FieldB": int64(123),
-			"FieldC": map[string]interface{}{
+			"FieldC": map[string]any{
 				"FieldD": "d",
 			},
 		},

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/stretchr/testify/require"
 )
 
 func setupJSONTest(t *testing.T, protocol clickhouse.Protocol) driver.Conn {

--- a/tests/lowcardinality_test.go
+++ b/tests/lowcardinality_test.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestLowCardinality(t *testing.T) {
@@ -50,13 +51,13 @@ func TestLowCardinality(t *testing.T) {
 				col2Data = "RU"
 				col3Data = []string{"A", "B", "C"}
 				col4Data = [][]string{
-					[]string{"Q", "W", "E"},
-					[]string{"R", "T", "Y"},
+					{"Q", "W", "E"},
+					{"R", "T", "Y"},
 				}
 				col5Data = &col2Data
 				col6Data = [][]*string{
-					[]*string{&col2Data, nil, &col2Data},
-					[]*string{nil, &col2Data, nil},
+					{&col2Data, nil, &col2Data},
+					{nil, &col2Data, nil},
 				}
 			)
 			if i%2 == 0 {
@@ -84,8 +85,8 @@ func TestLowCardinality(t *testing.T) {
 			assert.Equal(t, "RU", col2)
 			assert.Equal(t, []string{"A", "B", "C"}, col3)
 			assert.Equal(t, [][]string{
-				[]string{"Q", "W", "E"},
-				[]string{"R", "T", "Y"},
+				{"Q", "W", "E"},
+				{"R", "T", "Y"},
 			}, col4)
 			switch {
 			case i%2 == 0:
@@ -95,8 +96,8 @@ func TestLowCardinality(t *testing.T) {
 			}
 			col2Data := "RU"
 			assert.Equal(t, [][]*string{
-				[]*string{&col2Data, nil, &col2Data},
-				[]*string{nil, &col2Data, nil},
+				{&col2Data, nil, &col2Data},
+				{nil, &col2Data, nil},
 			}, col6)
 		}
 	})

--- a/tests/map_test.go
+++ b/tests/map_test.go
@@ -11,8 +11,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestMap(t *testing.T) {
@@ -53,8 +54,8 @@ func TestMap(t *testing.T) {
 			}
 			col3Data = map[string]uint64{}
 			col4Data = []map[string]string{
-				map[string]string{"A": "B"},
-				map[string]string{"C": "D"},
+				{"A": "B"},
+				{"C": "D"},
 			}
 			col5Data = map[string]string{
 				"key_col_5_1": "100",

--- a/tests/nested_test.go
+++ b/tests/nested_test.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestSimpleNested(t *testing.T) {
@@ -90,14 +91,14 @@ func TestNestedFlattened(t *testing.T) {
 			col2Data = []uint8{10, 20, 30}
 			col3Data = []uint8{101, 201, 230} // Col2.Col1_N2
 			col4Data = [][][]any{
-				[][]any{
-					[]any{uint8(1), uint8(2)},
+				{
+					{uint8(1), uint8(2)},
 				},
-				[][]any{
-					[]any{uint8(1), uint8(2)},
+				{
+					{uint8(1), uint8(2)},
 				},
-				[][]any{
-					[]any{uint8(1), uint8(2)},
+				{
+					{uint8(1), uint8(2)},
 				},
 			}
 		)

--- a/tests/nothing_test.go
+++ b/tests/nothing_test.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestNothing(t *testing.T) {

--- a/tests/nullable_array_test.go
+++ b/tests/nullable_array_test.go
@@ -3,15 +3,17 @@ package tests
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"net"
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestNullableArray(t *testing.T) {

--- a/tests/opentelemetry_test.go
+++ b/tests/opentelemetry_test.go
@@ -2,12 +2,14 @@ package tests
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestOpenTelemetry(t *testing.T) {

--- a/tests/package.go
+++ b/tests/package.go
@@ -1,10 +1,11 @@
 package tests
 
 import (
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 var LocalClickHouse = false

--- a/tests/query_parameters_test.go
+++ b/tests/query_parameters_test.go
@@ -3,11 +3,13 @@ package tests
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestQueryParameters(t *testing.T) {

--- a/tests/read_only_user_test.go
+++ b/tests/read_only_user_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
 func TestReadOnlyUser(t *testing.T) {

--- a/tests/scan_struct_test.go
+++ b/tests/scan_struct_test.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestQueryRowScanStruct(t *testing.T) {

--- a/tests/simple_aggregate_function_test.go
+++ b/tests/simple_aggregate_function_test.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestSimpleAggregateFunction(t *testing.T) {

--- a/tests/std/array_test.go
+++ b/tests/std/array_test.go
@@ -2,12 +2,14 @@ package std
 
 import (
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/bigint_test.go
+++ b/tests/std/bigint_test.go
@@ -2,12 +2,14 @@ package std
 
 import (
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 	"math/big"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/bool_test.go
+++ b/tests/std/bool_test.go
@@ -2,11 +2,13 @@ package std
 
 import (
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/client_info_test.go
+++ b/tests/std/client_info_test.go
@@ -9,10 +9,11 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestClientInfo(t *testing.T) {

--- a/tests/std/close_test.go
+++ b/tests/std/close_test.go
@@ -3,14 +3,17 @@ package std
 import (
 	"crypto/tls"
 	"fmt"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestStdConnClose(t *testing.T) {

--- a/tests/std/compression_test.go
+++ b/tests/std/compression_test.go
@@ -3,13 +3,15 @@ package std
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net/url"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestCompressionStd(t *testing.T) {

--- a/tests/std/conn_test.go
+++ b/tests/std/conn_test.go
@@ -12,10 +12,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestStdConn(t *testing.T) {

--- a/tests/std/connect_check_test.go
+++ b/tests/std/connect_check_test.go
@@ -3,12 +3,14 @@ package std
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/context_timeout_test.go
+++ b/tests/std/context_timeout_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/custom_dial_test.go
+++ b/tests/std/custom_dial_test.go
@@ -4,15 +4,18 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 	"net"
 	"strconv"
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestStdCustomDial(t *testing.T) {

--- a/tests/std/date32_test.go
+++ b/tests/std/date32_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestStdDate32(t *testing.T) {

--- a/tests/std/date_test.go
+++ b/tests/std/date_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestStdDate(t *testing.T) {

--- a/tests/std/datetime64_test.go
+++ b/tests/std/datetime64_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestStdDateTime64(t *testing.T) {

--- a/tests/std/datetime_test.go
+++ b/tests/std/datetime_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestStdDateTime(t *testing.T) {

--- a/tests/std/ddl_test.go
+++ b/tests/std/ddl_test.go
@@ -3,11 +3,13 @@ package std
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestQuotedDDL(t *testing.T) {

--- a/tests/std/decimal_test.go
+++ b/tests/std/decimal_test.go
@@ -5,9 +5,10 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"

--- a/tests/std/dynamic_test.go
+++ b/tests/std/dynamic_test.go
@@ -3,14 +3,17 @@ package std
 import (
 	"context"
 	"database/sql"
+
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 )
 
 var dynamicTestDate, _ = time.Parse(time.RFC3339, "2024-12-13T02:09:30.123Z")

--- a/tests/std/enum_test.go
+++ b/tests/std/enum_test.go
@@ -2,11 +2,13 @@ package std
 
 import (
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/external_table_test.go
+++ b/tests/std/external_table_test.go
@@ -3,15 +3,18 @@ package std
 import (
 	"context"
 	"fmt"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/ext"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestStdExternalTable(t *testing.T) {

--- a/tests/std/fixed_string_test.go
+++ b/tests/std/fixed_string_test.go
@@ -3,11 +3,13 @@ package std
 import (
 	"crypto/rand"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/geo_linestring_test.go
+++ b/tests/std/geo_linestring_test.go
@@ -6,12 +6,14 @@ import (
 	"strconv"
 	"testing"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestStdGeoLineString(t *testing.T) {

--- a/tests/std/geo_multi_linestring_test.go
+++ b/tests/std/geo_multi_linestring_test.go
@@ -6,12 +6,14 @@ import (
 	"strconv"
 	"testing"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestStdGeoMultiLineString(t *testing.T) {

--- a/tests/std/geo_multipolygon_test.go
+++ b/tests/std/geo_multipolygon_test.go
@@ -3,14 +3,17 @@ package std
 import (
 	"context"
 	"fmt"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestStdGeoMultiPolygon(t *testing.T) {
@@ -70,21 +73,21 @@ func TestStdGeoMultiPolygon(t *testing.T) {
 				col2Data = []orb.MultiPolygon{
 					[]orb.Polygon{
 						[]orb.Ring{
-							orb.Ring{
+							{
 								orb.Point{1, 2},
 								orb.Point{1, 22},
 							},
-							orb.Ring{
+							{
 								orb.Point{1, 23},
 								orb.Point{12, 2},
 							},
 						},
 						[]orb.Ring{
-							orb.Ring{
+							{
 								orb.Point{21, 2},
 								orb.Point{1, 222},
 							},
-							orb.Ring{
+							{
 								orb.Point{21, 23},
 								orb.Point{12, 22},
 							},
@@ -92,21 +95,21 @@ func TestStdGeoMultiPolygon(t *testing.T) {
 					},
 					[]orb.Polygon{
 						[]orb.Ring{
-							orb.Ring{
+							{
 								orb.Point{11, 2},
 								orb.Point{1, 22},
 							},
-							orb.Ring{
+							{
 								orb.Point{1, 23},
 								orb.Point{12, 22},
 							},
 						},
 						[]orb.Ring{
-							orb.Ring{
+							{
 								orb.Point{21, 2},
 								orb.Point{1, 222},
 							},
-							orb.Ring{
+							{
 								orb.Point{21, 23},
 								orb.Point{12, 22},
 							},

--- a/tests/std/geo_point_test.go
+++ b/tests/std/geo_point_test.go
@@ -3,14 +3,17 @@ package std
 import (
 	"context"
 	"fmt"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestStdGeoPoint(t *testing.T) {

--- a/tests/std/geo_polygon_test.go
+++ b/tests/std/geo_polygon_test.go
@@ -3,14 +3,17 @@ package std
 import (
 	"context"
 	"fmt"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestStdGeoPolygon(t *testing.T) {
@@ -57,21 +60,21 @@ func TestStdGeoPolygon(t *testing.T) {
 				}
 				col2Data = []orb.Polygon{
 					[]orb.Ring{
-						orb.Ring{
+						{
 							orb.Point{1, 2},
 							orb.Point{1, 22},
 						},
-						orb.Ring{
+						{
 							orb.Point{1, 23},
 							orb.Point{12, 2},
 						},
 					},
 					[]orb.Ring{
-						orb.Ring{
+						{
 							orb.Point{21, 2},
 							orb.Point{1, 222},
 						},
-						orb.Ring{
+						{
 							orb.Point{21, 23},
 							orb.Point{12, 22},
 						},

--- a/tests/std/geo_ring_test.go
+++ b/tests/std/geo_ring_test.go
@@ -3,14 +3,17 @@ package std
 import (
 	"context"
 	"fmt"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestStdGeoRing(t *testing.T) {
@@ -49,11 +52,11 @@ func TestStdGeoRing(t *testing.T) {
 					orb.Point{1, 2},
 				}
 				col2Data = []orb.Ring{
-					orb.Ring{
+					{
 						orb.Point{1, 2},
 						orb.Point{1, 2},
 					},
-					orb.Ring{
+					{
 						orb.Point{1, 2},
 						orb.Point{1, 2},
 					},

--- a/tests/std/http_exception_test.go
+++ b/tests/std/http_exception_test.go
@@ -6,10 +6,11 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestHTTPExceptionHandlingDB(t *testing.T) {

--- a/tests/std/ipv4_test.go
+++ b/tests/std/ipv4_test.go
@@ -2,12 +2,14 @@ package std
 
 import (
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 	"net"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/json_test.go
+++ b/tests/std/json_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 )
 
 var jsonTestDate, _ = time.Parse(time.RFC3339, "2024-12-13T02:09:30.123Z")
@@ -142,7 +143,7 @@ type TestStruct struct {
 	Address Address
 
 	KeysNumbers map[string]int64
-	Metadata    map[string]interface{}
+	Metadata    map[string]any
 
 	Timestamp time.Time `chType:"DateTime64(3)"`
 
@@ -188,10 +189,10 @@ func TestJSONStruct(t *testing.T) {
 			Country: "Country",
 		},
 		KeysNumbers: map[string]int64{"FieldA": 42, "FieldB": 32},
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"FieldA": "a",
 			"FieldB": "b",
-			"FieldC": map[string]interface{}{
+			"FieldC": map[string]any{
 				"FieldD": "d",
 			},
 		},
@@ -206,13 +207,13 @@ func TestJSONStruct(t *testing.T) {
 	inputRow2 := TestStruct{
 		KeysNumbers: map[string]int64{},
 		Timestamp:   jsonTestDate,
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"FieldA": "a",
 			"FieldB": "b",
-			"FieldC": map[string]interface{}{
+			"FieldC": map[string]any{
 				"FieldD": int64(5),
 			},
-			"FieldE": map[string]interface{}{
+			"FieldE": map[string]any{
 				"FieldF": "f",
 			},
 		},
@@ -231,7 +232,7 @@ func TestJSONStruct(t *testing.T) {
 	err = rows.Scan(&row)
 	require.NoError(t, err)
 	// The second row adds a nil value at this path. Update the inputRow for easier deep equal check
-	inputRow.Metadata["FieldE"] = map[string]interface{}{
+	inputRow.Metadata["FieldE"] = map[string]any{
 		"FieldF": nil,
 	}
 	require.Equal(t, inputRow, row)
@@ -293,10 +294,10 @@ func TestJSONString(t *testing.T) {
 			Country: "Country",
 		},
 		KeysNumbers: map[string]int64{"FieldA": 42, "FieldB": 32},
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"FieldA": "a",
 			"FieldB": "b",
-			"FieldC": map[string]interface{}{
+			"FieldC": map[string]any{
 				"FieldD": "d",
 			},
 		},

--- a/tests/std/lowcardinality_test.go
+++ b/tests/std/lowcardinality_test.go
@@ -7,11 +7,13 @@ import (
 	"testing"
 	"time"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestStdLowCardinality(t *testing.T) {
@@ -57,13 +59,13 @@ func TestStdLowCardinality(t *testing.T) {
 					col2Data = "RU"
 					col3Data = []string{"A", "B", "C"}
 					col4Data = [][]string{
-						[]string{"Q", "W", "E"},
-						[]string{"R", "T", "Y"},
+						{"Q", "W", "E"},
+						{"R", "T", "Y"},
 					}
 					col5Data = &col2Data
 					col6Data = [][]*string{
-						[]*string{&col2Data, nil, &col2Data},
-						[]*string{nil, &col2Data, nil},
+						{&col2Data, nil, &col2Data},
+						{nil, &col2Data, nil},
 					}
 				)
 				if i%2 == 0 {
@@ -96,8 +98,8 @@ func TestStdLowCardinality(t *testing.T) {
 				assert.Equal(t, "RU", col2)
 				assert.Equal(t, []string{"A", "B", "C"}, col3)
 				assert.Equal(t, [][]string{
-					[]string{"Q", "W", "E"},
-					[]string{"R", "T", "Y"},
+					{"Q", "W", "E"},
+					{"R", "T", "Y"},
 				}, col4)
 				switch {
 				case i%2 == 0:
@@ -107,8 +109,8 @@ func TestStdLowCardinality(t *testing.T) {
 				}
 				col2Data := "RU"
 				assert.Equal(t, [][]*string{
-					[]*string{&col2Data, nil, &col2Data},
-					[]*string{nil, &col2Data, nil},
+					{&col2Data, nil, &col2Data},
+					{nil, &col2Data, nil},
 				}, col6)
 			}
 		})

--- a/tests/std/map_test.go
+++ b/tests/std/map_test.go
@@ -6,9 +6,10 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -54,8 +55,8 @@ func TestStdMap(t *testing.T) {
 				}
 				col3Data = map[string]uint64{}
 				col4Data = []map[string]string{
-					map[string]string{"A": "B"},
-					map[string]string{"C": "D"},
+					{"A": "B"},
+					{"C": "D"},
 				}
 				col5Data = map[string]string{
 					"key_col_5_1": "100",

--- a/tests/std/materialized_column_test.go
+++ b/tests/std/materialized_column_test.go
@@ -6,10 +6,11 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestMaterializedColumnInsert(t *testing.T) {

--- a/tests/std/nested_test.go
+++ b/tests/std/nested_test.go
@@ -3,12 +3,14 @@ package std
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestStdNested(t *testing.T) {

--- a/tests/std/query_parameters_test.go
+++ b/tests/std/query_parameters_test.go
@@ -2,13 +2,15 @@ package std
 
 import (
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestQueryParameters(t *testing.T) {

--- a/tests/std/string_test.go
+++ b/tests/std/string_test.go
@@ -3,11 +3,13 @@ package std
 import (
 	"database/sql"
 	"fmt"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func TestSimpleStdString(t *testing.T) {

--- a/tests/std/temporary_table_test.go
+++ b/tests/std/temporary_table_test.go
@@ -6,11 +6,13 @@ import (
 	"strconv"
 	"testing"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestStdTemporaryTable(t *testing.T) {

--- a/tests/std/totals_test.go
+++ b/tests/std/totals_test.go
@@ -4,9 +4,10 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/tuples_test.go
+++ b/tests/std/tuples_test.go
@@ -7,11 +7,13 @@ import (
 	"testing"
 	"time"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 var testDate, _ = time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", "2022-05-25 17:20:57 +0100 WEST")
@@ -64,8 +66,8 @@ func TestTuple(t *testing.T) {
 			},
 		}
 		col4Data = [][][]any{
-			[][]any{
-				[]any{"Hi", int64(42)},
+			{
+				{"Hi", int64(42)},
 			},
 		}
 		col5Data = []any{

--- a/tests/std/utils.go
+++ b/tests/std/utils.go
@@ -5,13 +5,14 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
 func GetStdTestEnvironment() (clickhouse_tests.ClickHouseTestEnvironment, error) {

--- a/tests/std/uuid_test.go
+++ b/tests/std/uuid_test.go
@@ -2,10 +2,12 @@ package std
 
 import (
 	"fmt"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"

--- a/tests/std/variant_test.go
+++ b/tests/std/variant_test.go
@@ -3,14 +3,17 @@ package std
 import (
 	"context"
 	"database/sql"
+
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 )
 
 var variantTestDate, _ = time.Parse(time.RFC3339, "2024-12-13T02:09:30.123Z")

--- a/tests/stress/stress.go
+++ b/tests/stress/stress.go
@@ -2,20 +2,22 @@ package main
 
 import (
 	"context"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 	"log"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+
 	"net/http"
 	_ "net/http/pprof"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/google/uuid"
 	_ "github.com/mkevac/debugcharts"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
 type App struct {
@@ -57,15 +59,15 @@ func (app *App) batch() {
 			uuid.New(),
 			time.Now(),
 			[][]time.Time{
-				[]time.Time{
+				{
 					time.Now(),
 					time.Now(),
 				},
-				[]time.Time{
+				{
 					time.Now(),
 					time.Now(),
 				},
-				[]time.Time{
+				{
 					time.Now(),
 					time.Now(),
 				},

--- a/tests/struct_map_test.go
+++ b/tests/struct_map_test.go
@@ -3,11 +3,13 @@ package tests
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestAppendStruct(t *testing.T) {

--- a/tests/time64_test.go
+++ b/tests/time64_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func setupTime64Test(t *testing.T, protocol clickhouse.Protocol) clickhouse.Conn {

--- a/tests/time_mixed_test.go
+++ b/tests/time_mixed_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func setupTimeMixedTest(t *testing.T, protocol clickhouse.Protocol) clickhouse.Conn {

--- a/tests/time_test.go
+++ b/tests/time_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func setupTimeTest(t *testing.T, protocol clickhouse.Protocol) clickhouse.Conn {

--- a/tests/totals_test.go
+++ b/tests/totals_test.go
@@ -2,11 +2,13 @@ package tests
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestWithTotals(t *testing.T) {

--- a/tests/tuple_test.go
+++ b/tests/tuple_test.go
@@ -58,8 +58,8 @@ func TestTuple(t *testing.T) {
 				},
 			}
 			col4Data = [][][]any{
-				[][]any{
-					[]any{"Hi", int64(42)},
+				{
+					{"Hi", int64(42)},
 				},
 			}
 			col5Data = []any{

--- a/tests/uint8_test.go
+++ b/tests/uint8_test.go
@@ -2,9 +2,11 @@ package tests
 
 import (
 	"context"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func TestBoolUInt8(t *testing.T) {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -22,15 +22,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-units"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
 var testUUID = uuid.NewString()[0:12]

--- a/tests/uuid_test.go
+++ b/tests/uuid_test.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
+
 	"github.com/google/uuid"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/variant_test.go
+++ b/tests/variant_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/stretchr/testify/require"
 )
 
 var variantTestDate, _ = time.Parse(time.RFC3339, "2024-12-13T02:09:30.123Z")


### PR DESCRIPTION
## Summary

Add linting workflow and migrate Golangci-lint configuration to v2 (v1 is deprecated).


The upgrade reveals a few lint issues that I fixed as well:

- simplify slice initialization in various files
- replace interface{} with any in multiple locations