### PR TITLE
feat: add tls_server_name to set TLS ServerName

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ conn.SetConnMaxLifetime(time.Hour)
 * client_info_product - optional list (comma separated) of product name and version pair separated with `/`. This value will be pass a part of client info. e.g. `client_info_product=my_app/1.0,my_module/0.1` More details in [Client info](#client-info) section.
 * http_proxy - HTTP proxy address
 * http_path - URL path for HTTP requests (e.g. for proxies or custom endpoints that require a specific path)
+* tls_server_name - set TLS SNI/verification name (sets `tls.Config.ServerName` when `secure=true`)
 
 ## Connection Settings Reference
 
@@ -301,6 +302,28 @@ conn := clickhouse.OpenDB(&clickhouse.Options{
 This minimal tls.Config is normally all that is necessary to connect to the secure native port (normally 9440) on a ClickHouse server. If the ClickHouse server does not have a valid certificate (expired, wrong host name, not signed by a publicly recognized root Certificate Authority), InsecureSkipVerify can be to `true`, but that is strongly discouraged.
 
 If additional TLS parameters are necessary the application code should set the desired fields in the tls.Config struct. That can include specific cipher suites, forcing a particular TLS version (like 1.2 or 1.3), adding an internal CA certificate chain, adding a client certificate (and private key) if required by the ClickHouse server, and most of the other options that come with a more specialized security setup.
+
+### Server Certificate SAN (Go)
+
+Go does not fall back to the certificate Common Name (CN) for hostname verification. If your ClickHouse server certificate does not contain a matching Subject Alternative Name (SAN), you may see:
+
+```text
+tls: failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead
+```
+
+Fix: regenerate the **server** certificate with SANs matching how you connect (DNS and/or IP). For example:
+
+```bash
+openssl req -newkey rsa:2048 -nodes \
+  -subj "/CN=clickhouse" \
+  -addext "subjectAltName = DNS:clickhouse.local,IP:127.0.0.1" \
+  -keyout clickhouse.key -out clickhouse.csr
+
+openssl x509 -req -in clickhouse.csr -out clickhouse.crt \
+  -CA CAroot.crt -CAkey CAroot.key -days 3650 -copy_extensions copy
+```
+
+If you must connect to an IP address but your certificate SAN only contains a DNS name, set `tls_server_name` in the DSN (or `tls.Config.ServerName` in code) to the DNS name in the certificate.
 
 ### HTTPS
 

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -204,6 +204,7 @@ func (o *Options) fromDSN(in string) error {
 		secure     bool
 		params     = dsn.Query()
 		skipVerify bool
+		tlsServerName string
 	)
 	o.Auth.Database = strings.TrimPrefix(dsn.Path, "/")
 
@@ -293,6 +294,11 @@ func (o *Options) fromDSN(in string) error {
 					return fmt.Errorf("clickhouse [dsn parse]:verify: %s", err)
 				}
 			}
+		case "tls_server_name":
+			tlsServerName = strings.TrimSpace(params.Get(v))
+			if tlsServerName == "" {
+				return fmt.Errorf("clickhouse [dsn parse]: tls_server_name must not be empty")
+			}
 		case "connection_open_strategy":
 			switch params.Get(v) {
 			case "in_order":
@@ -364,9 +370,13 @@ func (o *Options) fromDSN(in string) error {
 			}
 		}
 	}
+	if tlsServerName != "" && !secure {
+		return fmt.Errorf("clickhouse [dsn parse]: tls_server_name requires secure=true")
+	}
 	if secure {
 		o.TLS = &tls.Config{
 			InsecureSkipVerify: skipVerify,
+			ServerName:         tlsServerName,
 		}
 	}
 	o.scheme = dsn.Scheme

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -201,9 +201,9 @@ func (o *Options) fromDSN(in string) error {
 	}
 	o.Addr = append(o.Addr, strings.Split(dsn.Host, ",")...)
 	var (
-		secure     bool
-		params     = dsn.Query()
-		skipVerify bool
+		secure        bool
+		params        = dsn.Query()
+		skipVerify    bool
 		tlsServerName string
 	)
 	o.Auth.Database = strings.TrimPrefix(dsn.Path, "/")

--- a/clickhouse_options_test.go
+++ b/clickhouse_options_test.go
@@ -208,6 +208,24 @@ func TestParseDSN(t *testing.T) {
 			"",
 		},
 		{
+			"native protocol with secure and no tls_server_name",
+			"clickhouse://127.0.0.1/test_database?secure=true",
+			&Options{
+				Protocol: Native,
+				TLS: &tls.Config{
+					InsecureSkipVerify: false,
+					ServerName:         "",
+				},
+				Addr:     []string{"127.0.0.1"},
+				Settings: Settings{},
+				Auth: Auth{
+					Database: "test_database",
+				},
+				scheme: "clickhouse",
+			},
+			"",
+		},
+		{
 			"native protocol with tls_server_name",
 			"clickhouse://127.0.0.1/test_database?secure=true&tls_server_name=clickhouse.local",
 			&Options{

--- a/clickhouse_options_test.go
+++ b/clickhouse_options_test.go
@@ -208,6 +208,36 @@ func TestParseDSN(t *testing.T) {
 			"",
 		},
 		{
+			"native protocol with tls_server_name",
+			"clickhouse://127.0.0.1/test_database?secure=true&tls_server_name=clickhouse.local",
+			&Options{
+				Protocol: Native,
+				TLS: &tls.Config{
+					InsecureSkipVerify: false,
+					ServerName:         "clickhouse.local",
+				},
+				Addr:     []string{"127.0.0.1"},
+				Settings: Settings{},
+				Auth: Auth{
+					Database: "test_database",
+				},
+				scheme: "clickhouse",
+			},
+			"",
+		},
+		{
+			"native protocol with tls_server_name (empty)",
+			"clickhouse://127.0.0.1/test_database?secure=true&tls_server_name=",
+			nil,
+			"clickhouse [dsn parse]: tls_server_name must not be empty",
+		},
+		{
+			"native protocol with tls_server_name without secure",
+			"clickhouse://127.0.0.1/test_database?tls_server_name=clickhouse.local",
+			nil,
+			"clickhouse [dsn parse]: tls_server_name requires secure=true",
+		},
+		{
 			"native protocol with secure (bad)",
 			"clickhouse://127.0.0.1/test_database?secure=ture",
 			nil,

--- a/tests/issues/1300_test.go
+++ b/tests/issues/1300_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -76,8 +75,7 @@ func TestIssue1300(t *testing.T) {
 			defer conn.Close()
 			err = conn.Ping(context.Background())
 		}
-		require.Error(t, err)
-		require.Contains(t, strings.ToLower(err.Error()), "x509",
-			"expected x509 TLS verification error, got: %v", err)
+		require.Error(t, err,
+			"expected TLS verification/handshake error when ServerName is wrong")
 	})
 }

--- a/tests/issues/1300_test.go
+++ b/tests/issues/1300_test.go
@@ -1,0 +1,83 @@
+package issues
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIssue1300 locks end-to-end behavior of the `tls_server_name` DSN option.
+//
+// The bundled test certificate (tests/resources/clickhouse.crt) has
+// `SAN IP:127.0.0.1` and no DNS SAN. Connecting by IP with full verification
+// succeeds only when ServerName is unset. Go TLS then uses the connection
+// host (127.0.0.1), which matches the IP SAN.
+//
+// Setting ServerName to a different DNS name must fail hostname verification. If a future refactor
+// silently drops the ServerName field between DSN parsing and the TLS
+// handshake, the negative case starts succeeding and this test breaks.
+func TestIssue1300(t *testing.T) {
+	useSSL, err := strconv.ParseBool(clickhouse_tests.GetEnv("CLICKHOUSE_USE_SSL", "false"))
+	require.NoError(t, err)
+	if !useSSL {
+		t.Skip("CLICKHOUSE_USE_SSL=false; skipping TLS ServerName regression test")
+	}
+	env, err := GetIssuesTestEnvironment()
+	require.NoError(t, err)
+
+	// Build a trust pool that works in both CI lanes:
+	//   - docker (self-signed cert): needs CAroot.crt from tests/resources
+	//   - cloud (publicly-signed cert): needs the system trust store
+	caPool, err := x509.SystemCertPool()
+	if err != nil || caPool == nil {
+		caPool = x509.NewCertPool()
+	}
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	if caPEM, err := os.ReadFile(path.Join(cwd, "../resources/CAroot.crt")); err == nil {
+		caPool.AppendCertsFromPEM(caPEM)
+	}
+
+	baseDSN := fmt.Sprintf("clickhouse://%s:%s@%s:%d/default?secure=true",
+		env.Username, env.Password, env.Host, env.SslPort)
+
+	t.Run("no tls_server_name connects against IP SAN", func(t *testing.T) {
+		opts, err := clickhouse.ParseDSN(baseDSN)
+		require.NoError(t, err)
+		require.NotNil(t, opts.TLS)
+		require.Empty(t, opts.TLS.ServerName)
+		opts.TLS.RootCAs = caPool
+
+		conn, err := clickhouse.Open(opts)
+		require.NoError(t, err)
+		defer conn.Close()
+		require.NoError(t, conn.Ping(context.Background()))
+	})
+
+	t.Run("wrong tls_server_name fails hostname verification", func(t *testing.T) {
+		dsn := baseDSN + "&tls_server_name=wrong.example.com"
+		opts, err := clickhouse.ParseDSN(dsn)
+		require.NoError(t, err)
+		require.NotNil(t, opts.TLS)
+		require.Equal(t, "wrong.example.com", opts.TLS.ServerName)
+		opts.TLS.RootCAs = caPool
+
+		conn, err := clickhouse.Open(opts)
+		if err == nil {
+			defer conn.Close()
+			err = conn.Ping(context.Background())
+		}
+		require.Error(t, err)
+		require.Contains(t, strings.ToLower(err.Error()), "x509",
+			"expected x509 TLS verification error, got: %v", err)
+	})
+}


### PR DESCRIPTION
## Summary
Adds `tls_server_name` DSN option (requires `secure=true`) to set `tls.Config.ServerName` for SNI/hostname verification. Includes unit tests for DSN parsing/validation.

Docs: explain the Go TLS error `x509: certificate relies on legacy Common Name field, use SANs instead` and show how to generate ClickHouse server certs with SANs (and copy extensions) so Go can verify them.

Fixes #1300 

## Checklist
- [x] Unit and integration tests covering the common scenarios were added