### PR TITLE
Create cross-repo-bug-relay.yml

### DIFF
--- a/.github/workflows/cross-repo-bug-relay.yml
+++ b/.github/workflows/cross-repo-bug-relay.yml
@@ -1,0 +1,16 @@
+name: Relay bugs for cross-repo investigation
+
+# Relays newly-opened issues to ClickHouse/integrations-ai-playground for cross-repo investigation.
+
+on:
+  issues:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  relay:
+    uses: ClickHouse/integrations-shared-workflows/.github/workflows/cross-repo-bug-relay.yml@main
+    secrets:
+      WORKFLOW_AUTH_PUBLIC_APP_ID: ${{ secrets.WORKFLOW_AUTH_PUBLIC_APP_ID }}
+      WORKFLOW_AUTH_PUBLIC_PRIVATE_KEY: ${{ secrets.WORKFLOW_AUTH_PUBLIC_PRIVATE_KEY }}


### PR DESCRIPTION
Sets up new issue relay for cross-repo investigation.

If you'd rather trigger this on labeling an issue a bug we can do this instead:

```
  on:
    issues:
      types: [labeled]

  permissions: {}

  jobs:
    relay:
      if: github.event.label.name == 'bug'
      uses: ClickHouse/integrations-shared-workflows/.github/workflows/cross-repo-bug-relay.yml@main
      secrets: inherit
```

But there's a triage before the cross-repo investigation that filters out irrelevant issues.