### PR TITLE
refactor: remove ineffective break from switch

### DIFF
--- a/lib/column/enum.go
+++ b/lib/column/enum.go
@@ -75,7 +75,7 @@ func extractEnumNamedValues(chType Type) (typ string, values []string, indexes [
 	var skippedValueTokens []int
 	var indexFound bool
 	var valueFound bool
-	var valueIndex = 0
+	valueIndex := 0
 
 	for c := 0; c < len(src); c++ {
 		token := src[c]


### PR DESCRIPTION
 ## Summary
  Remove redundant `break` statements inside `switch` cases in `extractEnumNamedValues`.
  In Go, `switch` cases do not fall through by default, so these `break` statements
  have no effect.

  Also simplifies `var valueIndex = 0` to `valueIndex := 0` per Go idioms.

  ## Checklist
  - [x] No behavior change — existing tests cover all cases
