### PR TITLE
fix: choosing serialization version correctly in JSON column type

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,33 @@ For `clickhouse.Conn.PrepareBatch` (native interface):
 - Use `Send` to flush any remaining rows and finalize the INSERT. After `Send`, the batch is considered sent and should not be reused.
 - Use `defer batch.Close()` to ensure resources are released if `Send` is not reached.
 
+## JSON columns: append contract
+
+The ClickHouse Native protocol requires **one serialization version per `JSON` column per block** — a column cannot mix `object` rows and `string` rows on the wire. The driver enforces this at append time.
+
+**Two modes, one per batch:**
+
+- `object` — the driver decomposes a value into typed/dynamic paths. Accepts: `struct`, `map[string]any`, `*struct`, `*map`, `*clickhouse.JSON`, and any type implementing `clickhouse.JSONSerializer`.
+- `string` — the driver stores raw JSON text. Accepts: `string`, `*string`, `[]byte`, `*[]byte`, `json.RawMessage`, `*json.RawMessage`, `sql.NullString`, `*sql.NullString`, and types implementing `driver.Valuer` or `fmt.Stringer`.
+
+**Null rows are mode-agnostic.** `nil`, typed-nil pointers (`(*string)(nil)`, `(*clickhouse.JSON)(nil)`), `*interface{}` holding nil, and `sql.NullString{Valid: false}` do **not** latch a mode. They are buffered until a non-null row chooses the mode, and then flushed into the chosen backing column. `Nullable(JSON)` works the same way — the null mask lives on the Nullable wrapper; the inner JSON column still needs to emit something that parses server-side.
+
+**The first non-null row picks the mode.** Subsequent rows must match:
+
+```go
+batch.Append(struct{ Name string }{"Alice"}) // latches "object"
+batch.Append(`{"x":1}`)                      // error: string in an object-mode column
+```
+
+**Mixed-mode appends return an error**, identifying the type of the rejected row. There is no silent `{}` fallback.
+
+**All-null batches** default to `string` mode at send time and encode each null row as the JSON literal `"null"` (smaller on the wire than an empty object, and valid JSON so the server accepts the payload in `Nullable(JSON)` String mode).
+
+**Columnar bulk inserts (`batch.Column(i).Append(slice)`)** follow the same rules:
+- `[]string`, `[]*string`, `[][]byte`, `[]*[]byte`, `[]json.RawMessage`, `[]*json.RawMessage`, `[]sql.NullString`, `[]*sql.NullString` → `string` mode.
+- `[]struct{...}`, `[]map[string]any`, `[]clickhouse.JSON`, `[]*clickhouse.JSON`, `[]clickhouse.JSONSerializer` → `object` mode.
+- `Append` expects a slice — passing a single scalar returns an error. Use `AppendRow` for per-row inserts.
+
 ## Benchmark
 
 Indicative numbers measured on: Linux 6.19.6-arch1-1 · Intel Core Ultra 7 258V (8 cores) · 30 GiB RAM · NVMe SSD. Run the linked programs directly to get numbers on your hardware, e.g. `go run benchmark/v2/read/main.go`. Go benchmark tests can be run with `go test -bench=. ./benchmark/...`.

--- a/lib/column/dynamic.go
+++ b/lib/column/dynamic.go
@@ -286,7 +286,7 @@ func (c *Dynamic) AppendRow(v any) error {
 		return c.AppendRow(chcol.NewDynamicWithType(v, inferredTypeName))
 	}
 
-	return fmt.Errorf("value \"%v\" cannot be stored in dynamic column: no compatible types. hint: use clickhouse.DynamicWithType to wrap the value", v)
+	return fmt.Errorf("value \"%v\" cannot be stored in dynamic column: no compatible types. hint: either use fixed types like int64, int32, etc or use clickhouse.DynamicWithType to wrap the value with concrete ClickHouse column type", v)
 }
 
 func (c *Dynamic) encodeHeader(buffer *proto.Buffer) error {

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -540,7 +540,7 @@ func (c *JSON) reconcileMode(m jsonMode) error {
 		"clickhouse: JSON column is already using %s serialization after row %d; "+
 			"cannot append a value that requires %s serialization. "+
 			"The wire format allows only one serialization version per column per block — "+
-			"every row in a batch must use the same mode.",
+			"every row in a batch must use the same mode",
 		serializationVersionName(c.serializationVersion),
 		c.rows,
 		serializationVersionName(want),

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -24,7 +24,7 @@ const DefaultMaxDynamicPaths = 1024
 
 // JSON implements ClickHouse JSON column on the native protocol layer.
 // We choose how to encode the JSON based on serializationVersion.
-// It can be either plain string or object type (more latest support).
+// It can be either plain string or object type with newer server support.
 type JSON struct {
 	chType Type
 	sc     *ServerContext

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -1,6 +1,9 @@
 package column
 
 import (
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
 	"fmt"
 	"math"
 	"reflect"
@@ -19,6 +22,9 @@ const JSONObjectSerializationVersion uint64 = 3
 const JSONUnsetSerializationVersion uint64 = math.MaxUint64
 const DefaultMaxDynamicPaths = 1024
 
+// JSON implements ClickHouse JSON column on the native protocol layer.
+// We choose how to encode the JSON based on serializationVersion.
+// It can be either plain string or object type (more latest support).
 type JSON struct {
 	chType Type
 	sc     *ServerContext
@@ -26,6 +32,12 @@ type JSON struct {
 	rows   int
 
 	serializationVersion uint64
+	// pendingNullRows holds null-row counts received before a serialization
+	// mode has been latched. A null row carries no mode preference, so we
+	// defer the mode decision until a non-null row arrives. Pending nulls
+	// are flushed to the latched backing column inside reconcileMode, or —
+	// if the whole batch is null — at WriteStatePrefix using String mode.
+	pendingNullRows int
 
 	jsonStrings String
 
@@ -44,6 +56,19 @@ type JSON struct {
 	maxDynamicPaths int
 	maxDynamicTypes int
 }
+
+// jsonMode is the mode preference a value carries when offered to a JSON
+// column. It is deliberately separate from the wire-format constants
+// (JSONObjectSerializationVersion / JSONStringSerializationVersion) so the
+// classifier stays free of wire concerns and so we can express
+// "no preference" (jsonModeAny) for null-equivalent inputs.
+type jsonMode uint8
+
+const (
+	jsonModeAny    jsonMode = iota // nil / typed-nil — does not latch
+	jsonModeObject                 // struct, map, *clickhouse.JSON, JSONSerializer
+	jsonModeString                 // string, []byte, json.RawMessage, sql.NullString, Stringer, Valuer
+)
 
 func (c *JSON) parse(t Type, sc *ServerContext) (_ *JSON, err error) {
 	c.chType = t
@@ -307,34 +332,48 @@ func (c *JSON) Append(v any) (nulls []uint8, err error) {
 	case JSONStringSerializationVersion:
 		return c.appendString(v)
 	default:
-		// Unset serialization preference, try object first unless it's specifically string
+		// Typed-slice fast paths. Each routes through reconcileMode so any
+		// pending null rows (from prior AppendRow(nil) calls) get flushed
+		// into the now-latched backing column before we iterate.
 		switch v.(type) {
-		case []chcol.JSON:
-			c.serializationVersion = JSONObjectSerializationVersion
+		case []chcol.JSON, []*chcol.JSON, []chcol.JSONSerializer:
+			if err := c.reconcileMode(jsonModeObject); err != nil {
+				return nil, err
+			}
 			return c.appendObject(v)
-		case []*chcol.JSON:
-			c.serializationVersion = JSONObjectSerializationVersion
-			return c.appendObject(v)
-		case []chcol.JSONSerializer:
-			c.serializationVersion = JSONObjectSerializationVersion
-			return c.appendObject(v)
-		case string, []byte:
-			c.serializationVersion = JSONStringSerializationVersion
+		case []string, []*string,
+			[][]byte, []*[]byte,
+			[]json.RawMessage, []*json.RawMessage,
+			[]sql.NullString, []*sql.NullString:
+			// Slice of JSON-text-like values — string serialization.
+			// Append is columnar; single values (string, *string, etc.)
+			// should go through AppendRow instead.
+			if err := c.reconcileMode(jsonModeString); err != nil {
+				return nil, err
+			}
 			return c.appendString(v)
 		}
 
-		// Also route other []byte-compatible types (e.g. json.RawMessage) to string serialization
+		// Named []byte-compatible slices (e.g. user aliases of []byte).
 		if rv := reflect.ValueOf(v); rv.IsValid() && rv.Kind() == reflect.Slice && rv.Type().Elem().Kind() == reflect.Uint8 {
-			c.serializationVersion = JSONStringSerializationVersion
+			if err := c.reconcileMode(jsonModeString); err != nil {
+				return nil, err
+			}
 			return c.appendString(v)
 		}
 
+		// Fallback: appendObject iterates the slice reflectively and calls
+		// AppendRow per element. AppendRow's own classify+reconcile decides
+		// the column's mode based on what the elements actually are — do
+		// not force a mode here, or all-null slices and []string would be
+		// miscategorized.
 		var err error
 		if _, err = c.appendObject(v); err == nil {
-			c.serializationVersion = JSONObjectSerializationVersion
 			return nil, nil
 		} else if _, err = c.appendString(v); err == nil {
-			c.serializationVersion = JSONStringSerializationVersion
+			if c.serializationVersion == JSONUnsetSerializationVersion {
+				c.serializationVersion = JSONStringSerializationVersion
+			}
 			return nil, nil
 		}
 
@@ -383,7 +422,11 @@ func (c *JSON) appendObject(v any) (nulls []uint8, err error) {
 		}
 	}
 	for i := 0; i < value.Len(); i++ {
-		if err := c.AppendRow(value.Index(i)); err != nil {
+		// Unwrap the reflect.Value to the underlying element before dispatch.
+		// Passing value.Index(i) directly would wrap a reflect.Value struct
+		// as the `any` argument, which hits structToJSON's struct path and
+		// produces an empty {} for every row — silent data loss.
+		if err := c.AppendRow(value.Index(i).Interface()); err != nil {
 			return nil, err
 		}
 	}
@@ -401,45 +444,174 @@ func (c *JSON) appendString(v any) (nulls []uint8, err error) {
 	return nulls, nil
 }
 
+// classifyJSONValue decides whether v should take the object or string
+// serialization path, or whether it carries no preference (null). Pure:
+// no state mutation, no I/O. Ordering:
+//  1. Untyped nil and typed-nil pointers → jsonModeAny (deferred).
+//  2. Known object-mode types (chcol.JSON, chcol.JSONSerializer, struct/map/ptr-to-either).
+//  3. Known string-mode types (string/[]byte and their pointers, json.RawMessage,
+//     sql.NullString, named byte slices, driver.Valuer, fmt.Stringer).
+//  4. Everything else → error; never silently store as {}.
+func classifyJSONValue(v any) (jsonMode, error) {
+	if v == nil {
+		return jsonModeAny, nil
+	}
+
+	// Fast path for common exact types.
+	switch v.(type) {
+	case chcol.JSON, *chcol.JSON, chcol.JSONSerializer:
+		return jsonModeObject, nil
+	case string, *string,
+		[]byte, *[]byte,
+		json.RawMessage, *json.RawMessage,
+		sql.NullString, *sql.NullString:
+		return jsonModeString, nil
+	}
+
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Struct, reflect.Map:
+		return jsonModeObject, nil
+
+	case reflect.Slice:
+		// Named []byte types (e.g. user aliases of []byte) → string mode.
+		if rv.Type().Elem().Kind() == reflect.Uint8 {
+			return jsonModeString, nil
+		}
+
+	case reflect.Pointer:
+		// Typed nil pointer carries no mode preference — treat like untyped nil.
+		if rv.IsNil() {
+			return jsonModeAny, nil
+		}
+		switch rv.Elem().Kind() {
+		case reflect.Interface:
+			// *any holding nil is also a null row.
+			if rv.Elem().IsNil() {
+				return jsonModeAny, nil
+			}
+		case reflect.Struct, reflect.Map:
+			return jsonModeObject, nil
+		case reflect.String:
+			return jsonModeString, nil
+		case reflect.Slice:
+			if rv.Elem().Type().Elem().Kind() == reflect.Uint8 {
+				return jsonModeString, nil
+			}
+		}
+	}
+
+	// Interface-based fallbacks. driver.Valuer before fmt.Stringer — the SQL
+	// ecosystem convention is that Value() drives serialization.
+	if _, ok := v.(driver.Valuer); ok {
+		return jsonModeString, nil
+	}
+	if _, ok := v.(fmt.Stringer); ok {
+		return jsonModeString, nil
+	}
+
+	return 0, fmt.Errorf(
+		"clickhouse: cannot append value of type %T to JSON column; "+
+			"use string, []byte, json.RawMessage, *clickhouse.JSON, a struct, a map, "+
+			"or a type implementing clickhouse.JSONSerializer",
+		v)
+}
+
+// reconcileMode latches the column's serialization version on the first
+// non-null row and rejects any subsequent row that disagrees. When
+// latching transitions the column from Unset to Object/String, any pending
+// null rows are flushed into the newly-chosen backing column.
+func (c *JSON) reconcileMode(m jsonMode) error {
+	if m == jsonModeAny {
+		return nil
+	}
+	want := JSONObjectSerializationVersion
+	if m == jsonModeString {
+		want = JSONStringSerializationVersion
+	}
+
+	if c.serializationVersion == JSONUnsetSerializationVersion {
+		c.serializationVersion = want
+		return c.flushPendingNulls()
+	}
+	if c.serializationVersion == want {
+		return nil
+	}
+	return fmt.Errorf(
+		"clickhouse: JSON column is already using %s serialization after row %d; "+
+			"cannot append a value that requires %s serialization. "+
+			"The wire format allows only one serialization version per column per block — "+
+			"every row in a batch must use the same mode.",
+		serializationVersionName(c.serializationVersion),
+		c.rows,
+		serializationVersionName(want),
+	)
+}
+
+// flushPendingNulls writes buffered null rows into the currently-latched
+// backing column. c.rows was already bumped when each null was queued, so
+// we subtract the pending count first and let the per-row append helpers
+// re-increment it.
+func (c *JSON) flushPendingNulls() error {
+	if c.pendingNullRows == 0 {
+		return nil
+	}
+	pending := c.pendingNullRows
+	c.pendingNullRows = 0
+	c.rows -= pending
+	for i := 0; i < pending; i++ {
+		var err error
+		switch c.serializationVersion {
+		case JSONObjectSerializationVersion:
+			err = c.appendRowObject(nil)
+		case JSONStringSerializationVersion:
+			err = c.appendRowString(nil)
+		default:
+			return fmt.Errorf("clickhouse: cannot flush %d pending null row(s): no serialization version latched", pending)
+		}
+		if err != nil {
+			return fmt.Errorf("clickhouse: flush pending null row %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func serializationVersionName(v uint64) string {
+	switch v {
+	case JSONObjectSerializationVersion, JSONDeprecatedObjectSerializationVersion:
+		return "object"
+	case JSONStringSerializationVersion:
+		return "string"
+	}
+	return "unset"
+}
+
 func (c *JSON) AppendRow(v any) error {
+	mode, err := classifyJSONValue(v)
+	if err != nil {
+		return err
+	}
+
+	// Null rows defer the mode decision. Flushed later, either when a
+	// non-null row arrives (via reconcileMode) or at WriteStatePrefix for
+	// all-null batches.
+	if mode == jsonModeAny && c.serializationVersion == JSONUnsetSerializationVersion {
+		c.pendingNullRows++
+		c.rows++
+		return nil
+	}
+
+	if err := c.reconcileMode(mode); err != nil {
+		return err
+	}
+
 	switch c.serializationVersion {
 	case JSONObjectSerializationVersion:
 		return c.appendRowObject(v)
 	case JSONStringSerializationVersion:
 		return c.appendRowString(v)
 	default:
-		// Unset serialization preference, try object first unless it's specifically string
-		switch v.(type) {
-		case chcol.JSON:
-			c.serializationVersion = JSONObjectSerializationVersion
-			return c.appendRowObject(v)
-		case *chcol.JSON:
-			c.serializationVersion = JSONObjectSerializationVersion
-			return c.appendRowObject(v)
-		case chcol.JSONSerializer:
-			c.serializationVersion = JSONObjectSerializationVersion
-			return c.appendRowObject(v)
-		case string, []byte:
-			c.serializationVersion = JSONStringSerializationVersion
-			return c.appendRowString(v)
-		}
-
-		// Also route other []byte-compatible types (e.g. json.RawMessage) to string serialization
-		if rv := reflect.ValueOf(v); rv.IsValid() && rv.Kind() == reflect.Slice && rv.Type().Elem().Kind() == reflect.Uint8 {
-			c.serializationVersion = JSONStringSerializationVersion
-			return c.appendRowString(v)
-		}
-
-		var err error
-		if err = c.appendRowObject(v); err == nil {
-			c.serializationVersion = JSONObjectSerializationVersion
-			return nil
-		} else if err = c.appendRowString(v); err == nil {
-			c.serializationVersion = JSONStringSerializationVersion
-			return nil
-		}
-
-		return fmt.Errorf("unsupported type \"%s\" for JSON column, must use string, []byte, *struct, map, or *clickhouse.JSON: %w", reflect.TypeOf(v).String(), err)
+		return fmt.Errorf("clickhouse: JSON column in unexpected serialization state %d", c.serializationVersion)
 	}
 }
 
@@ -462,9 +634,21 @@ func (c *JSON) appendRowObject(v any) error {
 		var err error
 		switch val := reflect.ValueOf(v); val.Kind() {
 		case reflect.Pointer:
-			if val.Elem().Kind() == reflect.Struct {
+			// A nil pointer, or a pointer whose target is a nil interface,
+			// represents a null row — normalize to nil so the tail handles it.
+			if val.IsNil() {
+				v = nil
+				break
+			}
+			elem := val.Elem()
+			switch elem.Kind() {
+			case reflect.Interface:
+				if elem.IsNil() {
+					v = nil
+				}
+			case reflect.Struct:
 				obj, err = structToJSON(v)
-			} else if val.Elem().Kind() == reflect.Map {
+			case reflect.Map:
 				obj, err = mapToJSON(v)
 			}
 		case reflect.Struct:
@@ -479,6 +663,15 @@ func (c *JSON) appendRowObject(v any) error {
 	}
 
 	if obj == nil {
+		// A nil value represents a null row (e.g. from Nullable(JSON)) — the
+		// null mask at the wrapper layer hides this payload, so emitting an
+		// empty object keeps typed/dynamic sub-column row counts in sync.
+		// For a non-nil value that reached this point, no branch above knew
+		// how to convert it; returning an error is essential to avoid silent
+		// data loss (caller sees a success and reads back `{}`).
+		if v != nil {
+			return fmt.Errorf("clickhouse: cannot append value of type %T to JSON column in object mode; use string, []byte, *clickhouse.JSON, a struct, a map, or a type implementing clickhouse.JSONSerializer", v)
+		}
 		obj = chcol.NewJSON()
 	}
 	valuesByPath := obj.ValuesByPath()
@@ -545,6 +738,15 @@ func (c *JSON) appendRowObject(v any) error {
 }
 
 func (c *JSON) appendRowString(v any) error {
+	// In String serialization the server parses every row's payload as JSON,
+	// even Nullable(JSON) rows that the null mask will later hide. An empty
+	// payload ("") fails server-side with "Cannot parse JSON object here"
+	// (code 117). For null-equivalent inputs we emit the JSON literal "null"
+	// instead — valid JSON that parses, then the null mask (when present)
+	// masks it back to NULL on read.
+	if isNullishForJSON(v) {
+		v = "null"
+	}
 	err := c.jsonStrings.AppendRow(v)
 	if err != nil {
 		return err
@@ -552,6 +754,30 @@ func (c *JSON) appendRowString(v any) error {
 
 	c.rows++
 	return nil
+}
+
+// isNullishForJSON returns true if v should be encoded as the JSON literal
+// "null" when written through the String column. This catches the common
+// null-equivalent spellings that the underlying String column would
+// otherwise write as "" (invalid JSON on the wire).
+func isNullishForJSON(v any) bool {
+	if v == nil {
+		return true
+	}
+	switch vv := v.(type) {
+	case sql.NullString:
+		return !vv.Valid
+	case *sql.NullString:
+		return vv == nil || !vv.Valid
+	}
+	rv := reflect.ValueOf(v)
+	if !rv.IsValid() {
+		return true
+	}
+	if rv.Kind() == reflect.Pointer && rv.IsNil() {
+		return true
+	}
+	return false
 }
 
 func (c *JSON) encodeObjectHeader(buffer *proto.Buffer) error {
@@ -594,6 +820,16 @@ func (c *JSON) encodeStringData(buffer *proto.Buffer) {
 }
 
 func (c *JSON) WriteStatePrefix(buffer *proto.Buffer) error {
+	// If the batch is entirely null rows (all deferred), latch to String
+	// now — it's the cheapest on-wire encoding — and flush the pending
+	// nulls as JSON "null" payloads so the server accepts the block.
+	if c.serializationVersion == JSONUnsetSerializationVersion && c.pendingNullRows > 0 {
+		c.serializationVersion = JSONStringSerializationVersion
+		if err := c.flushPendingNulls(); err != nil {
+			return err
+		}
+	}
+
 	switch c.serializationVersion {
 	case JSONObjectSerializationVersion:
 		if supportsFlatDynamicJSON(c.sc) {
@@ -609,7 +845,7 @@ func (c *JSON) WriteStatePrefix(buffer *proto.Buffer) error {
 		return nil
 	default:
 		// If the column is an array, it can be empty but still require a prefix.
-		// Use string encoding since it's smaller
+		// Use string encoding since it's smaller.
 		buffer.PutUInt64(JSONStringSerializationVersion)
 
 		return nil
@@ -644,6 +880,7 @@ func (c *JSON) ScanType() reflect.Type {
 
 func (c *JSON) Reset() {
 	c.rows = 0
+	c.pendingNullRows = 0
 
 	switch c.serializationVersion {
 	case JSONObjectSerializationVersion:

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -481,6 +481,17 @@ func classifyJSONValue(v any) (jsonMode, error) {
 		return jsonModeAny, nil
 	}
 
+	// Guard: a typed nil pointer carries no mode — same as untyped nil.
+	if rv := reflect.ValueOf(v); rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return jsonModeAny, nil
+		}
+		// can be *any. Should be treated as jsonModeAny and deferred as well.
+		if rv.Elem().Kind() == reflect.Interface && rv.Elem().IsNil() {
+			return jsonModeAny, nil
+		}
+	}
+
 	// Fast path for common exact types.
 	switch v.(type) {
 	case chcol.JSON, *chcol.JSON, chcol.JSONSerializer:
@@ -504,16 +515,7 @@ func classifyJSONValue(v any) (jsonMode, error) {
 		}
 
 	case reflect.Pointer:
-		// Typed nil pointer carries no mode preference — treat like untyped nil.
-		if rv.IsNil() {
-			return jsonModeAny, nil
-		}
 		switch rv.Elem().Kind() {
-		case reflect.Interface:
-			// *any holding nil is also a null row.
-			if rv.Elem().IsNil() {
-				return jsonModeAny, nil
-			}
 		case reflect.Struct, reflect.Map:
 			return jsonModeObject, nil
 		case reflect.String:

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -367,10 +367,23 @@ func (c *JSON) Append(v any) (nulls []uint8, err error) {
 		// the column's mode based on what the elements actually are — do
 		// not force a mode here, or all-null slices and []string would be
 		// miscategorized.
+		//
+		// If appendObject errors *after* writing some rows (e.g.
+		// []any{"str", someStruct{}} latches String on element 0 then
+		// errors on the mode-conflict at element 1), the appendString
+		// retry would re-iterate from the start and double-write the
+		// already-appended rows. Snapshot state and skip the retry if
+		// appendObject mutated anything.
+		rowsBefore := c.rows
+		versionBefore := c.serializationVersion
 		var err error
 		if _, err = c.appendObject(v); err == nil {
 			return nil, nil
-		} else if _, err = c.appendString(v); err == nil {
+		}
+		if c.rows != rowsBefore || c.serializationVersion != versionBefore {
+			return nil, err
+		}
+		if _, err = c.appendString(v); err == nil {
 			if c.serializationVersion == JSONUnsetSerializationVersion {
 				c.serializationVersion = JSONStringSerializationVersion
 			}

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -384,6 +384,10 @@ func (c *JSON) Append(v any) (nulls []uint8, err error) {
 			return nil, err
 		}
 		if _, err = c.appendString(v); err == nil {
+			// appendString iterates element-by-element through appendRowString,
+			// which never calls reconcileMode. For an empty or all-null slice
+			// the version stays Unset; latch String here so WriteStatePrefix
+			// emits the correct serialization for the rows we just wrote.
 			if c.serializationVersion == JSONUnsetSerializationVersion {
 				c.serializationVersion = JSONStringSerializationVersion
 			}
@@ -472,6 +476,10 @@ func (c *JSON) appendString(v any) (nulls []uint8, err error) {
 	nulls = make([]uint8, value.Len())
 	for i := 0; i < value.Len(); i++ {
 		elem := value.Index(i).Interface()
+		// Two separate concerns share the same predicate: the outer check
+		// records the element in the per-row null mask returned to the
+		// Nullable wrapper, while appendRowString rewrites null-equivalent
+		// inputs to the JSON literal "null" so the wire payload still parses.
 		if isNullishForJSON(elem) {
 			nulls[i] = 1
 		}
@@ -578,8 +586,8 @@ func (c *JSON) reconcileMode(m jsonMode) error {
 	}
 	return fmt.Errorf(
 		"clickhouse: JSON column is already using %s serialization after row %d; "+
-			"cannot append a value that requires %s serialization. "+
-			"The wire format allows only one serialization version per column per block — "+
+			"cannot append a value that requires %s serialization; "+
+			"the wire format allows only one serialization version per column per block — "+
 			"every row in a batch must use the same mode",
 		serializationVersionName(c.serializationVersion),
 		c.rows,
@@ -930,12 +938,16 @@ func (c *JSON) Reset() {
 		for _, col := range c.dynamicColumns {
 			col.Reset()
 		}
-
-		return
 	case JSONStringSerializationVersion:
 		c.jsonStrings.Reset()
-		return
 	}
+
+	// Clear the latched mode so the next batch starts unbiased. An all-null
+	// batch only latches String at WriteStatePrefix; without this reset, a
+	// subsequent batch of structs/maps would fail reconcileMode with a
+	// mode-conflict error even though no real value was ever appended in the
+	// previous batch.
+	c.serializationVersion = JSONUnsetSerializationVersion
 }
 
 func (c *JSON) decodeObjectHeader(reader *proto.Reader) error {

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -445,8 +445,7 @@ func (c *JSON) appendString(v any) (nulls []uint8, err error) {
 }
 
 // classifyJSONValue decides whether v should take the object or string
-// serialization path, or whether it carries no preference (null). Pure:
-// no state mutation, no I/O. Ordering:
+// serialization path, or whether it carries no preference (null).
 //  1. Untyped nil and typed-nil pointers → jsonModeAny (deferred).
 //  2. Known object-mode types (chcol.JSON, chcol.JSONSerializer, struct/map/ptr-to-either).
 //  3. Known string-mode types (string/[]byte and their pointers, json.RawMessage,

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -435,12 +435,37 @@ func (c *JSON) appendObject(v any) (nulls []uint8, err error) {
 }
 
 func (c *JSON) appendString(v any) (nulls []uint8, err error) {
-	nulls, err = c.jsonStrings.Append(v)
-	if err != nil {
-		return nil, err
+	// Iterate v element-wise and route each row through appendRowString.
+	// Delegating to String.Append directly would write "" for nil pointers
+	// and invalid sql.NullString values — both invalid JSON on the wire
+	// (server code 117) — and would panic on nil *json.RawMessage.
+	// appendRowString runs each element through isNullishForJSON, converting
+	// null-equivalent inputs to the JSON literal "null". Mirrors
+	// appendObject's reflective pattern.
+	//
+	// nulls mirrors the per-row null mask: 1 if the element was
+	// null-equivalent. Nullable(JSON).Append consumes this to populate its
+	// null bitmap; the underlying string still carries the "null" literal
+	// so the server's JSON parser does not reject the payload.
+	value := reflect.Indirect(reflect.ValueOf(v))
+	if value.Kind() != reflect.Slice {
+		return nil, &ColumnConverterError{
+			Op:   "Append",
+			To:   string(c.chType),
+			From: fmt.Sprintf("%T", v),
+			Hint: "value must be a slice",
+		}
 	}
-
-	c.rows = c.jsonStrings.Rows()
+	nulls = make([]uint8, value.Len())
+	for i := 0; i < value.Len(); i++ {
+		elem := value.Index(i).Interface()
+		if isNullishForJSON(elem) {
+			nulls[i] = 1
+		}
+		if err := c.appendRowString(elem); err != nil {
+			return nil, err
+		}
+	}
 	return nulls, nil
 }
 

--- a/lib/column/json_bench_test.go
+++ b/lib/column/json_bench_test.go
@@ -1,0 +1,217 @@
+package column
+
+import (
+	"database/sql"
+	"encoding/json"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+)
+
+// newBenchJSONColumn builds a fresh JSON column for each benchmark. The
+// column is reset inside the hot loop so the typed/dynamic sub-columns and
+// the jsonStrings String column do not grow unboundedly during a long -benchtime.
+// The server context is pinned to 25.6 so the flat dynamic JSON code path
+// (the current production layout) is exercised.
+func newBenchJSONColumn(b *testing.B) *JSON {
+	b.Helper()
+	sc := &ServerContext{VersionMajor: 25, VersionMinor: 6}
+	col, err := (&JSON{name: "bench"}).parse("JSON", sc)
+	if err != nil {
+		b.Fatalf("parse JSON column: %v", err)
+	}
+	return col
+}
+
+// resetEveryN clears column state every N iterations to keep the benchmark
+// measuring the append path rather than the cost of accumulating rows.
+const resetEveryN = 1024
+
+func benchLoop(b *testing.B, col *JSON, v any) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := col.AppendRow(v); err != nil {
+			b.Fatalf("AppendRow: %v", err)
+		}
+		if (i+1)%resetEveryN == 0 {
+			col.Reset()
+		}
+	}
+}
+
+func BenchmarkJSONAppendRow_String(b *testing.B) {
+	col := newBenchJSONColumn(b)
+	v := `{"id":1,"name":"Book","tags":["a","b"]}`
+	benchLoop(b, col, v)
+}
+
+func BenchmarkJSONAppendRow_StringPointer(b *testing.B) {
+	// Exercises the *string path — the exact Issue 1 reproducer.
+	col := newBenchJSONColumn(b)
+	s := `{"id":1,"name":"Book","tags":["a","b"]}`
+	v := &s
+	benchLoop(b, col, v)
+}
+
+func BenchmarkJSONAppendRow_Bytes(b *testing.B) {
+	col := newBenchJSONColumn(b)
+	v := []byte(`{"id":1,"name":"Book","tags":["a","b"]}`)
+	benchLoop(b, col, v)
+}
+
+func BenchmarkJSONAppendRow_BytesPointer(b *testing.B) {
+	col := newBenchJSONColumn(b)
+	bs := []byte(`{"id":1,"name":"Book","tags":["a","b"]}`)
+	v := &bs
+	benchLoop(b, col, v)
+}
+
+func BenchmarkJSONAppendRow_RawMessage(b *testing.B) {
+	col := newBenchJSONColumn(b)
+	v := json.RawMessage(`{"id":1,"name":"Book","tags":["a","b"]}`)
+	benchLoop(b, col, v)
+}
+
+func BenchmarkJSONAppendRow_NullString(b *testing.B) {
+	col := newBenchJSONColumn(b)
+	v := sql.NullString{Valid: true, String: `{"id":1,"name":"Book"}`}
+	benchLoop(b, col, v)
+}
+
+// benchStruct uses only string fields so the dynamic subcolumn path is
+// uniform across iterations. Mixed types (int+string) require a
+// real ClickHouse server to resolve type variants.
+type benchStruct struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func BenchmarkJSONAppendRow_Struct(b *testing.B) {
+	col := newBenchJSONColumn(b)
+	v := benchStruct{ID: "1", Name: "Book"}
+	benchLoop(b, col, v)
+}
+
+func BenchmarkJSONAppendRow_StructPointer(b *testing.B) {
+	col := newBenchJSONColumn(b)
+	v := &benchStruct{ID: "1", Name: "Book"}
+	benchLoop(b, col, v)
+}
+
+func BenchmarkJSONAppendRow_Map(b *testing.B) {
+	col := newBenchJSONColumn(b)
+	v := map[string]any{"id": "1", "name": "Book"}
+	benchLoop(b, col, v)
+}
+
+func BenchmarkJSONAppendRow_ChcolJSON(b *testing.B) {
+	col := newBenchJSONColumn(b)
+	obj := chcol.NewJSON()
+	obj.SetValueAtPath("id", "1")
+	obj.SetValueAtPath("name", "Book")
+	benchLoop(b, col, obj)
+}
+
+func BenchmarkJSONAppendRow_Nil(b *testing.B) {
+	col := newBenchJSONColumn(b)
+	benchLoop(b, col, nil)
+}
+
+// BenchmarkJSONAppendRow_AlternatingNilStruct mirrors a realistic
+// Nullable(JSON) insert pattern with mixed null and struct rows.
+func BenchmarkJSONAppendRow_AlternatingNilStruct(b *testing.B) {
+	col := newBenchJSONColumn(b)
+	s := benchStruct{ID: "1", Name: "Book"}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var v any
+		if i%2 == 0 {
+			v = nil
+		} else {
+			v = s
+		}
+		if err := col.AppendRow(v); err != nil {
+			b.Fatalf("AppendRow: %v", err)
+		}
+		if (i+1)%resetEveryN == 0 {
+			col.Reset()
+		}
+	}
+}
+
+// The benchmarks below exercise the plural Append (columnar bulk insert)
+// path — same code that W&B would hit when building a batch via
+// batch.Column(i).Append(slice).
+
+// Batch size per Append call in the bulk benchmarks. Each iteration
+// reports the per-slice cost, not per-row.
+const benchBatch = 64
+
+func BenchmarkJSONAppend_StringSlice(b *testing.B) {
+	col := newBenchJSONColumn(b)
+	slice := make([]string, benchBatch)
+	for i := range slice {
+		slice[i] = `{"id":1,"name":"Book"}`
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := col.Append(slice); err != nil {
+			b.Fatalf("Append: %v", err)
+		}
+		col.Reset()
+	}
+}
+
+func BenchmarkJSONAppend_StringPointerSlice(b *testing.B) {
+	// Before the fix: silent {} for every element via reflect.Value bug.
+	col := newBenchJSONColumn(b)
+	slice := make([]*string, benchBatch)
+	for i := range slice {
+		s := `{"id":1,"name":"Book"}`
+		slice[i] = &s
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := col.Append(slice); err != nil {
+			b.Fatalf("Append: %v", err)
+		}
+		col.Reset()
+	}
+}
+
+func BenchmarkJSONAppend_RawMessageSlice(b *testing.B) {
+	col := newBenchJSONColumn(b)
+	slice := make([]json.RawMessage, benchBatch)
+	for i := range slice {
+		slice[i] = json.RawMessage(`{"id":1,"name":"Book"}`)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := col.Append(slice); err != nil {
+			b.Fatalf("Append: %v", err)
+		}
+		col.Reset()
+	}
+}
+
+func BenchmarkJSONAppend_StructSlice(b *testing.B) {
+	// Before the fix: silent {} — every struct's exported fields dropped.
+	col := newBenchJSONColumn(b)
+	slice := make([]benchStruct, benchBatch)
+	for i := range slice {
+		slice[i] = benchStruct{ID: "1", Name: "Book"}
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := col.Append(slice); err != nil {
+			b.Fatalf("Append: %v", err)
+		}
+		col.Reset()
+	}
+}

--- a/lib/column/json_bench_test.go
+++ b/lib/column/json_bench_test.go
@@ -142,7 +142,7 @@ func BenchmarkJSONAppendRow_AlternatingNilStruct(b *testing.B) {
 }
 
 // The benchmarks below exercise the plural Append (columnar bulk insert)
-// path — same code that W&B would hit when building a batch via
+// path — same code that would hit when building a batch via
 // batch.Column(i).Append(slice).
 
 // Batch size per Append call in the bulk benchmarks. Each iteration

--- a/lib/column/json_bench_test.go
+++ b/lib/column/json_bench_test.go
@@ -166,7 +166,6 @@ func BenchmarkJSONAppend_StringSlice(b *testing.B) {
 }
 
 func BenchmarkJSONAppend_StringPointerSlice(b *testing.B) {
-	// Before the fix: silent {} for every element via reflect.Value bug.
 	col := newBenchJSONColumn(b)
 	slice := make([]*string, benchBatch)
 	for i := range slice {
@@ -200,7 +199,6 @@ func BenchmarkJSONAppend_RawMessageSlice(b *testing.B) {
 }
 
 func BenchmarkJSONAppend_StructSlice(b *testing.B) {
-	// Before the fix: silent {} — every struct's exported fields dropped.
 	col := newBenchJSONColumn(b)
 	slice := make([]benchStruct, benchBatch)
 	for i := range slice {

--- a/lib/column/json_test.go
+++ b/lib/column/json_test.go
@@ -332,7 +332,7 @@ func TestJSONAppendRowStringSerializationVersion(t *testing.T) {
 	}
 }
 
-// TestJSONAppendRowPointerAndStdlibStringTypes locks in the fix for the W&B
+// TestJSONAppendRowPointerAndStdlibStringTypes locks in the fix for the
 // report "*string stored as {}". Every value listed here must (a) latch
 // string serialization and (b) round-trip through the jsonStrings backing
 // column with the expected text. If any case regresses, the caller is
@@ -685,6 +685,33 @@ func TestJSONAppendStringReturnsNullsMask(t *testing.T) {
 				"nulls mask must have one entry per input row, with 1 for null-equivalent rows — Nullable(JSON) bulk insert depends on this")
 		})
 	}
+}
+
+// TestJSONAppendFallbackNoDoubleWrite locks in the no-double-write
+// invariant of Append's reflective fallback. Before the fix, the default
+// branch tried appendObject first; on a mixed []any like {"str", struct{}},
+// appendObject latched String mode and wrote "str" before erroring on the
+// mode-conflicting struct, then unconditionally retried with appendString,
+// which re-iterated from index 0 and wrote "str" a second time. Callers
+// who aborted on the error never observed the corruption, but the
+// underlying String column ended up with two copies of the first element.
+func TestJSONAppendFallbackNoDoubleWrite(t *testing.T) {
+	type s struct {
+		Name string `json:"name"`
+	}
+
+	col := newTestJSONColumn(t)
+	_, err := col.Append([]any{`{"a":1}`, s{Name: "Alice"}})
+	require.Error(t, err,
+		"mixed object/string modes in one slice must be rejected")
+
+	require.Equal(t, JSONStringSerializationVersion, col.serializationVersion,
+		"first element latches the column to String")
+	require.Equal(t, 1, col.Rows(),
+		"only the pre-error element should be present — the appendString retry must not re-write it")
+	require.Equal(t, 1, col.jsonStrings.Rows(),
+		"jsonStrings must hold exactly one entry; a second copy would mean the appendString fallback re-iterated")
+	assert.Equal(t, `{"a":1}`, col.jsonStrings.Row(0, false))
 }
 
 // TestJSONAppendRejectsNonSlice locks in that Append is slice-oriented.

--- a/lib/column/json_test.go
+++ b/lib/column/json_test.go
@@ -21,15 +21,15 @@ func newTestJSONColumn(t *testing.T) *JSON {
 	return col
 }
 
-// TestJSONAppendRowNilConsistency verifies the first-principles contract
-// for AppendRow(nil). Key rules:
-//   1. A nil row carries no mode preference — it does NOT latch the column.
-//      Instead it bumps pendingNullRows and c.rows.
-//   2. The first non-nil row latches the mode via reconcileMode, and flushes
-//      any pending nulls into the latched backing column at that moment.
-//   3. An all-null batch leaves the column Unset after AppendRow; it will be
-//      latched to String at WriteStatePrefix time and flushed with "null"
-//      payloads (covered by a separate test).
+// TestJSONAppendRowNilConsistency verifies the contract for AppendRow(nil).
+// Key rules:
+//  1. A nil row carries no mode preference — it does NOT latch the column.
+//     Instead it bumps pendingNullRows and c.rows.
+//  2. The first non-nil row latches the mode via reconcileMode, and flushes
+//     any pending nulls into the latched backing column at that moment.
+//  3. An all-null batch leaves the column Unset after AppendRow; it will be
+//     latched to String at WriteStatePrefix time and flushed with "null"
+//     payloads.
 func TestJSONAppendRowNilConsistency(t *testing.T) {
 	type testStruct struct {
 		Name string `json:"name"`
@@ -90,7 +90,7 @@ func TestJSONAppendRowNilConsistency(t *testing.T) {
 			expectedRows:    2,
 		},
 		{
-			// First-principles change: nil alone does NOT latch. It's
+			// nil alone does NOT latch. It's
 			// buffered as a pending null until a real row arrives or the
 			// batch reaches WriteStatePrefix.
 			name:                "nil only — defers (pending null, mode Unset)",
@@ -112,7 +112,7 @@ func TestJSONAppendRowNilConsistency(t *testing.T) {
 			expectedRows:    3,
 		},
 		{
-			// First-principles change: *interface{} with underlying nil is
+			// *interface{} with underlying nil is
 			// also a null row (normalized by classifyJSONValue). Both rows
 			// defer; mode stays Unset.
 			name: "nil then pointer to nil interface — both defer",
@@ -353,8 +353,7 @@ func TestJSONAppendRowPointerAndStdlibStringTypes(t *testing.T) {
 		{"*json.RawMessage", &raw, jsonText},
 		{"sql.NullString valid", sql.NullString{Valid: true, String: jsonText}, jsonText},
 		// Invalid NullString is null-equivalent — stored as the JSON literal
-		// "null" (see isNullishForJSON). Before this change the backing
-		// String column wrote "" which the server rejects in String mode.
+		// "null" (see isNullishForJSON).
 		{"sql.NullString invalid", sql.NullString{Valid: false}, "null"},
 		{"*sql.NullString valid", &sql.NullString{Valid: true, String: jsonText}, jsonText},
 	}
@@ -380,7 +379,7 @@ func TestJSONAppendRowPointerAndStdlibStringTypes(t *testing.T) {
 // (by an explicit object-mode or string-mode value), a row that would require
 // the other mode must error, not silently become {}.
 //
-// Before our redesign, nil itself could latch Object mode via a silent-{}
+// Before the refactoring in #1850 nil itself could latch Object mode via a silent-{}
 // fallback, which is why the old version of this test used nil as the first
 // row. With nil now deferred, we latch explicitly — struct for object,
 // string for string.
@@ -427,7 +426,7 @@ func TestJSONAppendRowMixedModesAreRejected(t *testing.T) {
 		},
 		{
 			// New test: string-first-then-struct was the biggest silent-data-
-			// loss path in PR 1771. Under first-principles it must loudly error.
+			// loss path in PR 1771. It must loudly error.
 			name:          "string latches string, then struct rejected",
 			latch:         `{"a":1}`,
 			wantLatch:     JSONStringSerializationVersion,
@@ -505,10 +504,6 @@ func TestJSONAllNullBatchEncodesAsStringWithNullPayload(t *testing.T) {
 	}
 }
 
-// TestJSONNullAfterStringLatchEncodesAsNullLiteral locks in the fix for
-// Scenario B of the W&B repro: once String mode is latched, a following
-// nil row must be stored as "null" (not ""). Before this change the server
-// returned "Cannot parse JSON object here" on Send.
 func TestJSONNullAfterStringLatchEncodesAsNullLiteral(t *testing.T) {
 	col := newTestJSONColumn(t)
 	require.NoError(t, col.AppendRow(`{"a":1}`))
@@ -521,9 +516,6 @@ func TestJSONNullAfterStringLatchEncodesAsNullLiteral(t *testing.T) {
 		"nil row after a String-mode latch must be the JSON literal \"null\"")
 }
 
-// TestJSONNullBeforeStringLatchFlushesAsNullLiteral is the exact W&B
-// Scenario A fix: nil first, string second, Nullable(JSON). The pending
-// null flushes into String mode as "null" when the string row latches.
 func TestJSONNullBeforeStringLatchFlushesAsNullLiteral(t *testing.T) {
 	col := newTestJSONColumn(t)
 	require.NoError(t, col.AppendRow(nil))
@@ -538,12 +530,6 @@ func TestJSONNullBeforeStringLatchFlushesAsNullLiteral(t *testing.T) {
 	assert.Equal(t, `{"a":1}`, col.jsonStrings.Row(1, false))
 }
 
-// TestJSONAppendSliceRoundTripsData locks in the fix for the silent-data-loss
-// bug in JSON.Append (plural). Before the fix, appendObject's reflect-based
-// fallback called c.AppendRow(value.Index(i)) — passing a reflect.Value struct,
-// not the underlying element. Every row was silently stored as an empty {}.
-// After the fix, .Interface() is called first so the real value flows through.
-// If any of these regress, Append is back to dropping entire batches.
 func TestJSONAppendSliceRoundTripsData(t *testing.T) {
 	type s struct {
 		Name string `json:"name"`
@@ -551,7 +537,7 @@ func TestJSONAppendSliceRoundTripsData(t *testing.T) {
 	jsonText := `{"id":1,"name":"Book"}`
 
 	t.Run("[]struct creates dynamic path and populates it", func(t *testing.T) {
-		// Before the fix: appendObject's reflect iteration passed a
+		// Before the #1850: appendObject's reflect iteration passed a
 		// reflect.Value to AppendRow, which sent it through structToJSON.
 		// reflect.Value is a struct with only unexported fields, so every
 		// row became an empty chcol.JSON{} — no dynamic paths were created.

--- a/lib/column/json_test.go
+++ b/lib/column/json_test.go
@@ -644,6 +644,49 @@ func TestJSONAppendSliceRoundTripsData(t *testing.T) {
 	})
 }
 
+// TestJSONAppendStringReturnsNullsMask locks the Append-string contract that
+// Nullable(JSON) bulk insert depends on: every row in the input slice must
+// produce one entry in the returned `nulls` mask, and null-equivalent rows
+// (nil pointers, invalid sql.NullString, etc.) must be marked with 1.
+//
+// Nullable(JSON).Append (lib/column/nullable.go) iterates this mask to
+// populate its null bitmap. If the mask is the wrong length the bitmap
+// drifts out of sync with the data column and the wire payload corrupts.
+// A previous refactor returned `nil` here and no unit test caught it
+// because the existing Nullable(JSON) integration test
+// (tests/issues/1638_test.go) only exercises AppendRow, not the bulk
+// slice path.
+func TestJSONAppendStringReturnsNullsMask(t *testing.T) {
+	a, b := `{"x":1}`, `{"x":2}`
+	rawA := json.RawMessage(a)
+	rawB := json.RawMessage(b)
+	validA := &sql.NullString{Valid: true, String: a}
+	validB := &sql.NullString{Valid: true, String: b}
+	invalid := &sql.NullString{Valid: false}
+
+	tests := []struct {
+		name      string
+		v         any
+		wantNulls []uint8
+	}{
+		{"[]string — no nulls", []string{a, b}, []uint8{0, 0}},
+		{"[]*string with nil middle", []*string{&a, nil, &b}, []uint8{0, 1, 0}},
+		{"[]json.RawMessage — no nulls", []json.RawMessage{rawA, rawB}, []uint8{0, 0}},
+		{"[]*json.RawMessage with nil middle", []*json.RawMessage{&rawA, nil, &rawB}, []uint8{0, 1, 0}},
+		{"[]sql.NullString invalid is null", []sql.NullString{{Valid: true, String: a}, {Valid: false}}, []uint8{0, 1}},
+		{"[]*sql.NullString nil-pointer and !Valid both null", []*sql.NullString{validA, nil, invalid, validB}, []uint8{0, 1, 1, 0}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			col := newTestJSONColumn(t)
+			nulls, err := col.Append(tt.v)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantNulls, nulls,
+				"nulls mask must have one entry per input row, with 1 for null-equivalent rows — Nullable(JSON) bulk insert depends on this")
+		})
+	}
+}
+
 // TestJSONAppendRejectsNonSlice locks in that Append is slice-oriented.
 // The previous code had unreachable single-value type-switch cases (string,
 // []byte routed to appendString which only accepts slices). Callers wanting

--- a/lib/column/json_test.go
+++ b/lib/column/json_test.go
@@ -568,36 +568,67 @@ func TestJSONAppendSliceRoundTripsData(t *testing.T) {
 		assert.Equal(t, `{"x":2}`, col.jsonStrings.Row(1, false))
 	})
 
-	t.Run("[]*string stores dereferenced text", func(t *testing.T) {
+	t.Run("[]*string stores dereferenced text and nil as JSON null", func(t *testing.T) {
 		col := newTestJSONColumn(t)
 		a, b := jsonText, `{"x":2}`
-		_, err := col.Append([]*string{&a, &b})
+		_, err := col.Append([]*string{&a, nil, &b})
 		require.NoError(t, err)
-		require.Equal(t, 2, col.Rows())
+		require.Equal(t, 3, col.Rows())
 		require.Equal(t, JSONStringSerializationVersion, col.serializationVersion)
 		assert.Equal(t, jsonText, col.jsonStrings.Row(0, false))
-		assert.Equal(t, `{"x":2}`, col.jsonStrings.Row(1, false))
+		assert.Equal(t, "null", col.jsonStrings.Row(1, false))
+		assert.Equal(t, `{"x":2}`, col.jsonStrings.Row(2, false))
 	})
 
 	t.Run("[]json.RawMessage stores text", func(t *testing.T) {
 		col := newTestJSONColumn(t)
 		_, err := col.Append([]json.RawMessage{json.RawMessage(jsonText)})
 		require.NoError(t, err)
+		require.Equal(t, 1, col.Rows())
 		require.Equal(t, JSONStringSerializationVersion, col.serializationVersion)
 		assert.Equal(t, jsonText, col.jsonStrings.Row(0, false))
 	})
 
-	t.Run("[]sql.NullString stores text of Valid rows", func(t *testing.T) {
+	t.Run("[]*json.RawMessage stores text and nil as JSON null", func(t *testing.T) {
+		col := newTestJSONColumn(t)
+		a := json.RawMessage(jsonText)
+		b := json.RawMessage(`{"x":2}`)
+		_, err := col.Append([]*json.RawMessage{&a, nil, &b})
+		require.NoError(t, err)
+		require.Equal(t, 3, col.Rows())
+		require.Equal(t, JSONStringSerializationVersion, col.serializationVersion)
+		assert.Equal(t, jsonText, col.jsonStrings.Row(0, false))
+		assert.Equal(t, "null", col.jsonStrings.Row(1, false))
+		assert.Equal(t, `{"x":2}`, col.jsonStrings.Row(2, false))
+	})
+
+	t.Run("[]sql.NullString stores text of Valid rows and JSON null for invalid rows", func(t *testing.T) {
 		col := newTestJSONColumn(t)
 		_, err := col.Append([]sql.NullString{
 			{Valid: true, String: jsonText},
 			{Valid: false},
 		})
 		require.NoError(t, err)
+		require.Equal(t, 2, col.Rows())
 		require.Equal(t, JSONStringSerializationVersion, col.serializationVersion)
 		assert.Equal(t, jsonText, col.jsonStrings.Row(0, false))
+		assert.Equal(t, "null", col.jsonStrings.Row(1, false))
 	})
 
+	t.Run("[]*sql.NullString stores text and null-equivalent pointers as JSON null", func(t *testing.T) {
+		col := newTestJSONColumn(t)
+		validA := &sql.NullString{Valid: true, String: jsonText}
+		invalid := &sql.NullString{Valid: false}
+		validB := &sql.NullString{Valid: true, String: `{"x":2}`}
+		_, err := col.Append([]*sql.NullString{validA, nil, invalid, validB})
+		require.NoError(t, err)
+		require.Equal(t, 4, col.Rows())
+		require.Equal(t, JSONStringSerializationVersion, col.serializationVersion)
+		assert.Equal(t, jsonText, col.jsonStrings.Row(0, false))
+		assert.Equal(t, "null", col.jsonStrings.Row(1, false))
+		assert.Equal(t, "null", col.jsonStrings.Row(2, false))
+		assert.Equal(t, `{"x":2}`, col.jsonStrings.Row(3, false))
+	})
 	t.Run("[]any containing structs populates dynamic paths", func(t *testing.T) {
 		col := newTestJSONColumn(t)
 		_, err := col.Append([]any{s{Name: "Alice"}, s{Name: "Bob"}})

--- a/lib/column/json_test.go
+++ b/lib/column/json_test.go
@@ -1,8 +1,11 @@
 package column
 
 import (
+	"database/sql"
+	"encoding/json"
 	"testing"
 
+	"github.com/ClickHouse/ch-go/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -18,106 +21,123 @@ func newTestJSONColumn(t *testing.T) *JSON {
 	return col
 }
 
+// TestJSONAppendRowNilConsistency verifies the first-principles contract
+// for AppendRow(nil). Key rules:
+//   1. A nil row carries no mode preference — it does NOT latch the column.
+//      Instead it bumps pendingNullRows and c.rows.
+//   2. The first non-nil row latches the mode via reconcileMode, and flushes
+//      any pending nulls into the latched backing column at that moment.
+//   3. An all-null batch leaves the column Unset after AppendRow; it will be
+//      latched to String at WriteStatePrefix time and flushed with "null"
+//      payloads (covered by a separate test).
 func TestJSONAppendRowNilConsistency(t *testing.T) {
 	type testStruct struct {
 		Name string `json:"name"`
 	}
 
+	// jsonUnset is math.MaxUint64; the parse() helper initializes every
+	// fresh JSON column to this sentinel.
+	const jsonUnset = JSONUnsetSerializationVersion
+
 	tests := []struct {
-		name            string
-		rows            []any
-		wantErr         bool
-		expectedVersion uint64
-		expectedRows    int
+		name                string
+		rows                []any
+		wantErr             bool
+		expectedVersion     uint64
+		expectedRows        int
+		expectedPendingNull int
 	}{
 		{
-			name:            "nil then struct - should use object version",
+			name:            "nil then struct — struct latches object, nil flushes",
 			rows:            []any{nil, testStruct{Name: "Alice"}},
-			wantErr:         false,
 			expectedVersion: JSONObjectSerializationVersion,
 			expectedRows:    2,
 		},
 		{
-			name:            "struct then nil - should use object version",
+			name:            "struct then nil — struct latches object, nil appends empty JSON",
 			rows:            []any{testStruct{Name: "Alice"}, nil},
-			wantErr:         false,
 			expectedVersion: JSONObjectSerializationVersion,
 			expectedRows:    2,
 		},
 		{
-			name:            "nil then map - should use object version",
+			name:            "nil then map — map latches object, nil flushes",
 			rows:            []any{nil, map[string]any{"key": "value"}},
-			wantErr:         false,
 			expectedVersion: JSONObjectSerializationVersion,
 			expectedRows:    2,
 		},
 		{
-			name:            "map then nil - should use object version",
+			name:            "map then nil — map latches object",
 			rows:            []any{map[string]any{"key": "value"}, nil},
-			wantErr:         false,
 			expectedVersion: JSONObjectSerializationVersion,
 			expectedRows:    2,
 		},
 		{
-			name:            "nil then *chcol.JSON - should use object version",
+			name:            "nil then *chcol.JSON — *chcol.JSON latches object, nil flushes",
 			rows:            []any{nil, chcol.NewJSON()},
-			wantErr:         false,
 			expectedVersion: JSONObjectSerializationVersion,
 			expectedRows:    2,
 		},
 		{
-			name:            "*chcol.JSON then nil - should use object version",
+			name:            "*chcol.JSON then nil — *chcol.JSON latches object",
 			rows:            []any{chcol.NewJSON(), nil},
-			wantErr:         false,
 			expectedVersion: JSONObjectSerializationVersion,
 			expectedRows:    2,
 		},
 		{
-			name:            "nil then struct pointer - should use object version",
+			name:            "nil then struct pointer — pointer-to-struct latches object",
 			rows:            []any{nil, &testStruct{Name: "Bob"}},
-			wantErr:         false,
 			expectedVersion: JSONObjectSerializationVersion,
 			expectedRows:    2,
 		},
 		{
-			name:            "nil only - should use object version",
-			rows:            []any{nil},
-			wantErr:         false,
-			expectedVersion: JSONObjectSerializationVersion,
-			expectedRows:    1,
+			// First-principles change: nil alone does NOT latch. It's
+			// buffered as a pending null until a real row arrives or the
+			// batch reaches WriteStatePrefix.
+			name:                "nil only — defers (pending null, mode Unset)",
+			rows:                []any{nil},
+			expectedVersion:     jsonUnset,
+			expectedRows:        1,
+			expectedPendingNull: 1,
 		},
 		{
-			name:            "multiple nils then struct - should use object version",
+			name:            "multiple nils then struct — pendings flushed into object",
 			rows:            []any{nil, nil, testStruct{Name: "Alice"}},
-			wantErr:         false,
 			expectedVersion: JSONObjectSerializationVersion,
 			expectedRows:    3,
 		},
 		{
-			name:            "nil between structs - should use object version",
+			name:            "struct nil struct — object throughout",
 			rows:            []any{testStruct{Name: "Alice"}, nil, testStruct{Name: "Bob"}},
-			wantErr:         false,
 			expectedVersion: JSONObjectSerializationVersion,
 			expectedRows:    3,
 		},
 		{
-			name: "nil then pointer to nil interface - should use object version",
+			// First-principles change: *interface{} with underlying nil is
+			// also a null row (normalized by classifyJSONValue). Both rows
+			// defer; mode stays Unset.
+			name: "nil then pointer to nil interface — both defer",
 			rows: func() []any {
 				var s any
 				return []any{s, &s}
 			}(),
-			wantErr:         false,
-			expectedVersion: JSONObjectSerializationVersion,
-			expectedRows:    2,
+			expectedVersion:     jsonUnset,
+			expectedRows:        2,
+			expectedPendingNull: 2,
 		},
 		{
-			name: "pointer to nil interface then nil - should use object version",
+			name: "pointer to nil interface then nil — both defer",
 			rows: func() []any {
 				var s any
 				return []any{&s, s}
 			}(),
-			wantErr:         false,
-			expectedVersion: JSONObjectSerializationVersion,
+			expectedVersion:     jsonUnset,
+			expectedRows:        2,
+			expectedPendingNull: 2,
+		},
+		{
+			name:            "nil then JSON string — string latches, nil flushes as \"null\"",
+			rows:            []any{nil, `{"a":1}`},
+			expectedVersion: JSONStringSerializationVersion,
 			expectedRows:    2,
 		},
 	}
@@ -139,8 +159,9 @@ func TestJSONAppendRowNilConsistency(t *testing.T) {
 			} else {
 				require.NoError(t, lastErr)
 				assert.Equal(t, tt.expectedRows, col.Rows())
+				assert.Equal(t, tt.expectedPendingNull, col.pendingNullRows,
+					"pendingNullRows mismatch — pending nulls should be 0 after a non-nil row latches the mode")
 			}
-
 			assert.Equal(t, tt.expectedVersion, col.serializationVersion)
 		})
 	}
@@ -187,41 +208,50 @@ func TestJSONAppendNilConsistency(t *testing.T) {
 			expectedRows:    2,
 		},
 		{
-			name:            "multiple nils slice - should use object version",
+			// All-null batch: nil does not latch. Mode stays Unset after
+			// Append; WriteStatePrefix latches String on encode and
+			// flushes the pendings as "null" payloads.
+			name:            "multiple nils slice - defers (mode Unset)",
 			input:           []any{nil, nil, nil},
 			wantErr:         false,
-			expectedVersion: JSONObjectSerializationVersion,
+			expectedVersion: JSONUnsetSerializationVersion,
 			expectedRows:    3,
 		},
 		{
-			name:            "nil then string slice - should use object version",
+			// []string is JSON text — must use string serialization, not
+			// silently be stored as empty {} via the reflect.Value bug.
+			name:            "[]string containing empty + json - should use string version",
 			input:           []string{"", `{"a":1}`},
 			wantErr:         false,
-			expectedVersion: JSONObjectSerializationVersion,
+			expectedVersion: JSONStringSerializationVersion,
 			expectedRows:    2,
 		},
 		{
-			name:            "pure string slice - should use object version",
+			// []string is JSON text — string mode, period.
+			name:            "pure string slice - should use string version",
 			input:           []string{`{"a":1}`, `{"b":2}`},
 			wantErr:         false,
-			expectedVersion: JSONObjectSerializationVersion,
+			expectedVersion: JSONStringSerializationVersion,
 			expectedRows:    2,
 		},
 		{
-			name:            "string then struct slice - should fallback to object",
-			input:           []any{`{"a":1}`, testStruct{Name: "Bob"}},
-			wantErr:         false,
-			expectedVersion: JSONObjectSerializationVersion,
-			expectedRows:    2,
+			// Mixed-mode inside one Append is not legal on the wire (one
+			// serialization version per column per block). First element
+			// latches string mode; the struct then rightly errors.
+			// Previously this silently stored both rows as {}.
+			name:    "mixed string + struct slice - must error, not silently drop data",
+			input:   []any{`{"a":1}`, testStruct{Name: "Bob"}},
+			wantErr: true,
 		},
 		{
-			name: "nil interface slice",
+			// All elements normalize to null — mode stays Unset.
+			name: "nil + pointer-to-nil-interface slice - defers",
 			input: func() []any {
 				var v any
 				return []any{v, &v}
 			}(),
 			wantErr:         false,
-			expectedVersion: JSONObjectSerializationVersion,
+			expectedVersion: JSONUnsetSerializationVersion,
 			expectedRows:    2,
 		},
 	}
@@ -298,6 +328,325 @@ func TestJSONAppendRowStringSerializationVersion(t *testing.T) {
 
 			assert.Equal(t, tt.expectedRows, col.Rows())
 			assert.Equal(t, tt.expectedVersion, col.serializationVersion)
+		})
+	}
+}
+
+// TestJSONAppendRowPointerAndStdlibStringTypes locks in the fix for the W&B
+// report "*string stored as {}". Every value listed here must (a) latch
+// string serialization and (b) round-trip through the jsonStrings backing
+// column with the expected text. If any case regresses, the caller is
+// silently losing data.
+func TestJSONAppendRowPointerAndStdlibStringTypes(t *testing.T) {
+	jsonText := `{"id":1,"name":"Book","tags":["a","b"]}`
+	bs := []byte(jsonText)
+	raw := json.RawMessage(jsonText)
+
+	tests := []struct {
+		name   string
+		input  any
+		stored string
+	}{
+		{"*string (Issue 1 repro)", &jsonText, jsonText},
+		{"*[]byte", &bs, jsonText},
+		{"json.RawMessage (explicit type-switch)", raw, jsonText},
+		{"*json.RawMessage", &raw, jsonText},
+		{"sql.NullString valid", sql.NullString{Valid: true, String: jsonText}, jsonText},
+		// Invalid NullString is null-equivalent — stored as the JSON literal
+		// "null" (see isNullishForJSON). Before this change the backing
+		// String column wrote "" which the server rejects in String mode.
+		{"sql.NullString invalid", sql.NullString{Valid: false}, "null"},
+		{"*sql.NullString valid", &sql.NullString{Valid: true, String: jsonText}, jsonText},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			col := newTestJSONColumn(t)
+
+			require.NoError(t, col.AppendRow(tt.input))
+			require.Equal(t, 1, col.Rows())
+			require.Equal(t, JSONStringSerializationVersion, col.serializationVersion,
+				"value must latch string serialization — hitting the object path means data is being silently stored as {}")
+
+			got := col.jsonStrings.Row(0, false)
+			assert.Equal(t, tt.stored, got,
+				"stored text must match the input — if this is {}, the *string regression is back")
+		})
+	}
+}
+
+// TestJSONAppendRowMixedModesAreRejected locks in the wire-format constraint:
+// one serialization version per column per block. Once a column is latched
+// (by an explicit object-mode or string-mode value), a row that would require
+// the other mode must error, not silently become {}.
+//
+// Before our redesign, nil itself could latch Object mode via a silent-{}
+// fallback, which is why the old version of this test used nil as the first
+// row. With nil now deferred, we latch explicitly — struct for object,
+// string for string.
+func TestJSONAppendRowMixedModesAreRejected(t *testing.T) {
+	type goodStruct struct {
+		Name string `json:"name"`
+	}
+	strPtr := func(s string) *string { return &s }
+
+	tests := []struct {
+		name          string
+		latch         any
+		wantLatch     uint64
+		incompatible  any
+		wantTypeInMsg string
+	}{
+		{
+			name:          "struct latches object, then string row rejected",
+			latch:         goodStruct{Name: "Alice"},
+			wantLatch:     JSONObjectSerializationVersion,
+			incompatible:  `{"should":"fail"}`,
+			wantTypeInMsg: "string",
+		},
+		{
+			name:          "struct latches object, then *string rejected",
+			latch:         goodStruct{Name: "Alice"},
+			wantLatch:     JSONObjectSerializationVersion,
+			incompatible:  strPtr(`{"x":1}`),
+			wantTypeInMsg: "string",
+		},
+		{
+			name:          "struct latches object, then []byte rejected",
+			latch:         goodStruct{Name: "Alice"},
+			wantLatch:     JSONObjectSerializationVersion,
+			incompatible:  []byte(`{"x":1}`),
+			wantTypeInMsg: "string",
+		},
+		{
+			name:          "map latches object, then int rejected",
+			latch:         map[string]any{"name": "Alice"},
+			wantLatch:     JSONObjectSerializationVersion,
+			incompatible:  42,
+			wantTypeInMsg: "int",
+		},
+		{
+			// New test: string-first-then-struct was the biggest silent-data-
+			// loss path in PR 1771. Under first-principles it must loudly error.
+			name:          "string latches string, then struct rejected",
+			latch:         `{"a":1}`,
+			wantLatch:     JSONStringSerializationVersion,
+			incompatible:  goodStruct{Name: "Alice"},
+			wantTypeInMsg: "object",
+		},
+		{
+			name:          "string latches string, then *chcol.JSON rejected",
+			latch:         `{"a":1}`,
+			wantLatch:     JSONStringSerializationVersion,
+			incompatible:  chcol.NewJSON(),
+			wantTypeInMsg: "object",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			col := newTestJSONColumn(t)
+
+			require.NoError(t, col.AppendRow(tt.latch))
+			require.Equal(t, tt.wantLatch, col.serializationVersion)
+			rowsAfterLatch := col.Rows()
+
+			err := col.AppendRow(tt.incompatible)
+			require.Error(t, err, "mixed-mode row MUST return an error — silent {} would be the regression")
+			assert.Contains(t, err.Error(), tt.wantTypeInMsg,
+				"error message must describe the mode conflict so callers can fix their batch")
+			assert.Equal(t, rowsAfterLatch, col.Rows(),
+				"row count must not advance when AppendRow fails — partial writes corrupt batches")
+		})
+	}
+}
+
+// TestJSONAppendRowPointerToNilInterfaceDefers locks in that *any-with-nil is
+// normalized to null by the classifier (same as plain nil), so it defers
+// instead of latching any mode.
+func TestJSONAppendRowPointerToNilInterfaceDefers(t *testing.T) {
+	col := newTestJSONColumn(t)
+
+	var s any // nil
+	require.NoError(t, col.AppendRow(&s), "pointer to nil interface must be treated as a null row")
+	require.Equal(t, 1, col.Rows())
+	assert.Equal(t, 1, col.pendingNullRows)
+	assert.Equal(t, JSONUnsetSerializationVersion, col.serializationVersion)
+}
+
+// TestJSONAllNullBatchEncodesAsStringWithNullPayload locks in the new
+// encode-time contract for all-null batches: the column stays Unset through
+// every AppendRow(nil), and at WriteStatePrefix it latches String mode and
+// flushes the pending nulls as the JSON literal "null". This is the root fix
+// for issue #1707 / #1768 — writing "" in String mode made the server reject
+// the block with "Cannot parse JSON object here" (code 117).
+func TestJSONAllNullBatchEncodesAsStringWithNullPayload(t *testing.T) {
+	col := newTestJSONColumn(t)
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, col.AppendRow(nil))
+	}
+	require.Equal(t, 3, col.Rows())
+	require.Equal(t, 3, col.pendingNullRows)
+	require.Equal(t, JSONUnsetSerializationVersion, col.serializationVersion)
+
+	// Trigger encode-time flush.
+	buf := &proto.Buffer{}
+	require.NoError(t, col.WriteStatePrefix(buf))
+
+	require.Equal(t, JSONStringSerializationVersion, col.serializationVersion,
+		"WriteStatePrefix must latch String for an all-null batch")
+	require.Equal(t, 0, col.pendingNullRows, "pending nulls must be flushed after latching")
+	require.Equal(t, 3, col.Rows(), "row count must be preserved across the flush")
+
+	for i := 0; i < 3; i++ {
+		assert.Equal(t, "null", col.jsonStrings.Row(i, false),
+			"each flushed null must be the JSON literal \"null\" (NOT \"\" — that crashes the server)")
+	}
+}
+
+// TestJSONNullAfterStringLatchEncodesAsNullLiteral locks in the fix for
+// Scenario B of the W&B repro: once String mode is latched, a following
+// nil row must be stored as "null" (not ""). Before this change the server
+// returned "Cannot parse JSON object here" on Send.
+func TestJSONNullAfterStringLatchEncodesAsNullLiteral(t *testing.T) {
+	col := newTestJSONColumn(t)
+	require.NoError(t, col.AppendRow(`{"a":1}`))
+	require.Equal(t, JSONStringSerializationVersion, col.serializationVersion)
+	require.NoError(t, col.AppendRow(nil))
+
+	require.Equal(t, 2, col.Rows())
+	assert.Equal(t, `{"a":1}`, col.jsonStrings.Row(0, false))
+	assert.Equal(t, "null", col.jsonStrings.Row(1, false),
+		"nil row after a String-mode latch must be the JSON literal \"null\"")
+}
+
+// TestJSONNullBeforeStringLatchFlushesAsNullLiteral is the exact W&B
+// Scenario A fix: nil first, string second, Nullable(JSON). The pending
+// null flushes into String mode as "null" when the string row latches.
+func TestJSONNullBeforeStringLatchFlushesAsNullLiteral(t *testing.T) {
+	col := newTestJSONColumn(t)
+	require.NoError(t, col.AppendRow(nil))
+	require.Equal(t, 1, col.pendingNullRows)
+	require.NoError(t, col.AppendRow(`{"a":1}`))
+
+	require.Equal(t, JSONStringSerializationVersion, col.serializationVersion)
+	require.Equal(t, 0, col.pendingNullRows)
+	require.Equal(t, 2, col.Rows())
+	assert.Equal(t, "null", col.jsonStrings.Row(0, false),
+		"deferred null flushed on latch must be the JSON literal \"null\"")
+	assert.Equal(t, `{"a":1}`, col.jsonStrings.Row(1, false))
+}
+
+// TestJSONAppendSliceRoundTripsData locks in the fix for the silent-data-loss
+// bug in JSON.Append (plural). Before the fix, appendObject's reflect-based
+// fallback called c.AppendRow(value.Index(i)) — passing a reflect.Value struct,
+// not the underlying element. Every row was silently stored as an empty {}.
+// After the fix, .Interface() is called first so the real value flows through.
+// If any of these regress, Append is back to dropping entire batches.
+func TestJSONAppendSliceRoundTripsData(t *testing.T) {
+	type s struct {
+		Name string `json:"name"`
+	}
+	jsonText := `{"id":1,"name":"Book"}`
+
+	t.Run("[]struct creates dynamic path and populates it", func(t *testing.T) {
+		// Before the fix: appendObject's reflect iteration passed a
+		// reflect.Value to AppendRow, which sent it through structToJSON.
+		// reflect.Value is a struct with only unexported fields, so every
+		// row became an empty chcol.JSON{} — no dynamic paths were created.
+		// After the fix: the real struct is passed, its exported "Name"
+		// field is picked up, and a dynamic path "name" appears.
+		col := newTestJSONColumn(t)
+		_, err := col.Append([]s{{Name: "Alice"}, {Name: "Bob"}})
+		require.NoError(t, err)
+		require.Equal(t, 2, col.Rows())
+		require.Equal(t, JSONObjectSerializationVersion, col.serializationVersion)
+
+		require.Contains(t, col.dynamicPaths, "name",
+			"struct fields must create dynamic paths — empty dynamicPaths means the reflect.Value bug is back")
+
+		nameIdx := col.dynamicPathsIndex["name"]
+		require.Equal(t, 2, col.dynamicColumns[nameIdx].Rows(),
+			"both struct rows' Name values must be present in the dynamic column")
+	})
+
+	t.Run("[]string latches string mode and stores text", func(t *testing.T) {
+		col := newTestJSONColumn(t)
+		_, err := col.Append([]string{jsonText, `{"x":2}`})
+		require.NoError(t, err)
+		require.Equal(t, 2, col.Rows())
+		require.Equal(t, JSONStringSerializationVersion, col.serializationVersion,
+			"[]string is JSON text — must use string serialization")
+		assert.Equal(t, jsonText, col.jsonStrings.Row(0, false))
+		assert.Equal(t, `{"x":2}`, col.jsonStrings.Row(1, false))
+	})
+
+	t.Run("[]*string stores dereferenced text", func(t *testing.T) {
+		col := newTestJSONColumn(t)
+		a, b := jsonText, `{"x":2}`
+		_, err := col.Append([]*string{&a, &b})
+		require.NoError(t, err)
+		require.Equal(t, 2, col.Rows())
+		require.Equal(t, JSONStringSerializationVersion, col.serializationVersion)
+		assert.Equal(t, jsonText, col.jsonStrings.Row(0, false))
+		assert.Equal(t, `{"x":2}`, col.jsonStrings.Row(1, false))
+	})
+
+	t.Run("[]json.RawMessage stores text", func(t *testing.T) {
+		col := newTestJSONColumn(t)
+		_, err := col.Append([]json.RawMessage{json.RawMessage(jsonText)})
+		require.NoError(t, err)
+		require.Equal(t, JSONStringSerializationVersion, col.serializationVersion)
+		assert.Equal(t, jsonText, col.jsonStrings.Row(0, false))
+	})
+
+	t.Run("[]sql.NullString stores text of Valid rows", func(t *testing.T) {
+		col := newTestJSONColumn(t)
+		_, err := col.Append([]sql.NullString{
+			{Valid: true, String: jsonText},
+			{Valid: false},
+		})
+		require.NoError(t, err)
+		require.Equal(t, JSONStringSerializationVersion, col.serializationVersion)
+		assert.Equal(t, jsonText, col.jsonStrings.Row(0, false))
+	})
+
+	t.Run("[]any containing structs populates dynamic paths", func(t *testing.T) {
+		col := newTestJSONColumn(t)
+		_, err := col.Append([]any{s{Name: "Alice"}, s{Name: "Bob"}})
+		require.NoError(t, err)
+		require.Equal(t, 2, col.Rows())
+		require.Equal(t, JSONObjectSerializationVersion, col.serializationVersion)
+
+		require.Contains(t, col.dynamicPaths, "name",
+			"structs inside an []any must still flow through to dynamic paths")
+
+		nameIdx := col.dynamicPathsIndex["name"]
+		require.Equal(t, 2, col.dynamicColumns[nameIdx].Rows())
+	})
+}
+
+// TestJSONAppendRejectsNonSlice locks in that Append is slice-oriented.
+// The previous code had unreachable single-value type-switch cases (string,
+// []byte routed to appendString which only accepts slices). Callers wanting
+// a single-row insert should use AppendRow.
+func TestJSONAppendRejectsNonSlice(t *testing.T) {
+	tests := []struct {
+		name string
+		v    any
+	}{
+		{"single string", `{"a":1}`},
+		{"single *string", func() *string { s := `{"a":1}`; return &s }()},
+		{"single int", 42},
+		{"single struct", struct{ Name string }{Name: "Alice"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			col := newTestJSONColumn(t)
+			_, err := col.Append(tt.v)
+			require.Error(t, err,
+				"Append is columnar — single values must be an error, not a silent 0-row success")
 		})
 	}
 }

--- a/tests/issues/1841_test.go
+++ b/tests/issues/1841_test.go
@@ -16,181 +16,229 @@ import (
 // shipped while fixing issue #1841. Each subtest pins a previously-broken
 // case from the PR description so a future refactor cannot silently
 // regress it.
+//
+// The column-layer mode-latch logic is protocol-agnostic — both Native
+// (TCP) and HTTP go through the same Append/AppendRow code paths and the
+// same WriteStatePrefix encoder for native blocks — so we run every
+// subtest on both protocols.
 func TestIssue1841_JSONSerializationVersion(t *testing.T) {
-	ctx := context.Background()
+	clickhouse_tests.TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
+		ctx := context.Background()
 
-	conn, err := clickhouse_tests.GetConnectionTCP("issues", clickhouse.Settings{
-		"allow_experimental_variant_type": true,
-		"allow_experimental_dynamic_type": true,
-		"allow_experimental_json_type":    true,
-		// `toString(JSON)` quotes 64-bit integers by default on ClickHouse < 25.4
-		// and emits them unquoted on newer servers. Pin the setting so the
-		// round-trip assertions don't depend on server version.
-		"output_format_json_quote_64bit_integers": false,
-	}, nil, nil)
-	require.NoError(t, err, "open clickhouse")
+		conn, err := clickhouse_tests.GetConnection("issues", t, protocol, clickhouse.Settings{
+			"allow_experimental_variant_type": true,
+			"allow_experimental_dynamic_type": true,
+			"allow_experimental_json_type":    true,
+			// `toString(JSON)` quotes 64-bit integers by default on ClickHouse < 25.4
+			// and emits them unquoted on newer servers. Pin the setting so the
+			// round-trip assertions don't depend on server version.
+			"output_format_json_quote_64bit_integers": false,
+		}, nil, nil)
+		require.NoError(t, err, "open clickhouse")
 
-	const jsonText = `{"id":1234,"name":"Book","tags":["a","b"]}`
+		const jsonText = `{"id":1234,"name":"Book","tags":["a","b"]}`
 
-	// 1. *string holding JSON text is preserved end-to-end.
-	// PR #1850 §1: previously the pointer was misclassified as object mode
-	// and stored as "{}" — silent data loss.
-	t.Run("string pointer round-trips JSON content", func(t *testing.T) {
-		if !clickhouse_tests.CheckMinServerServerVersion(conn, 24, 8, 0) {
-			t.Skip("JSON unsupported on this server version")
+		// 1. *string holding JSON text is preserved end-to-end.
+		// PR #1850 §1: previously the pointer was misclassified as object mode
+		// and stored as "{}" — silent data loss.
+		t.Run("string pointer round-trips JSON content", func(t *testing.T) {
+			if !clickhouse_tests.CheckMinServerServerVersion(conn, 24, 8, 0) {
+				t.Skip("JSON unsupported on this server version")
+			}
+			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_string_ptr"))
+			require.NoError(t, conn.Exec(ctx, `
+				CREATE TABLE test_1841_string_ptr (product JSON)
+				ENGINE = MergeTree ORDER BY tuple()
+			`))
+			t.Cleanup(func() { _ = conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_string_ptr") })
+
+			ptr := jsonText
+			batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_1841_string_ptr (product)")
+			require.NoError(t, err)
+			require.NoError(t, batch.Append(&ptr))
+			require.NoError(t, batch.Send())
+
+			var stored string
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT toString(product) FROM test_1841_string_ptr").Scan(&stored))
+			require.Equal(t, jsonText, stored,
+				"*string content must round-trip — PR #1850 §1 fix; previously stored as {}")
+		})
+
+		// 2. Append(nil) does not latch the serialization mode, so either
+		// ordering — nil first or string first — succeeds. PR #1850 §2.
+		for _, tc := range []struct {
+			name        string
+			nilFirst    bool
+			expectFirst string
+			expectLast  string
+		}{
+			{"nil then string", true, "", jsonText},
+			{"string then nil", false, jsonText, ""},
+		} {
+			t.Run("ordering — "+tc.name, func(t *testing.T) {
+				if !clickhouse_tests.CheckMinServerServerVersion(conn, 25, 2, 0) {
+					t.Skip("Nullable(JSON) requires server 25.2+")
+				}
+				tableName := "test_1841_order_" + strings.ReplaceAll(tc.name, " ", "_")
+				require.NoError(t, conn.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)))
+				require.NoError(t, conn.Exec(ctx, fmt.Sprintf(`
+					CREATE TABLE %s (id UInt32, product Nullable(JSON))
+					ENGINE = MergeTree ORDER BY id
+				`, tableName)))
+				t.Cleanup(func() { _ = conn.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)) })
+
+				batch, err := conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s (id, product)", tableName))
+				require.NoError(t, err)
+
+				if tc.nilFirst {
+					require.NoError(t, batch.Append(uint32(1), nil))
+					require.NoError(t, batch.Append(uint32(2), jsonText))
+				} else {
+					require.NoError(t, batch.Append(uint32(1), jsonText))
+					require.NoError(t, batch.Append(uint32(2), nil))
+				}
+				require.NoError(t, batch.Send(),
+					"Append(nil) must not pre-latch the serialization mode — PR #1850 §2")
+
+				rows, err := conn.Query(ctx, fmt.Sprintf("SELECT id, toString(product) FROM %s ORDER BY id", tableName))
+				require.NoError(t, err)
+				defer rows.Close()
+
+				gotByID := map[uint32]string{}
+				for rows.Next() {
+					var id uint32
+					var s *string
+					require.NoError(t, rows.Scan(&id, &s))
+					if s == nil {
+						gotByID[id] = ""
+					} else {
+						gotByID[id] = *s
+					}
+				}
+				require.NoError(t, rows.Err())
+				require.Equal(t, tc.expectFirst, gotByID[1], "row id=1")
+				require.Equal(t, tc.expectLast, gotByID[2], "row id=2")
+			})
 		}
-		require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_string_ptr"))
-		require.NoError(t, conn.Exec(ctx, `
-			CREATE TABLE test_1841_string_ptr (product JSON)
-			ENGINE = MergeTree ORDER BY tuple()
-		`))
-		t.Cleanup(func() { _ = conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_string_ptr") })
 
-		ptr := jsonText
-		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_1841_string_ptr (product)")
-		require.NoError(t, err)
-		require.NoError(t, batch.Append(&ptr))
-		require.NoError(t, batch.Send())
+		// 3. Mixing object and string modes in one block returns an error.
+		// PR #1850 §3: previously the second value was silently lost.
+		t.Run("mixed object then string errors", func(t *testing.T) {
+			if !clickhouse_tests.CheckMinServerServerVersion(conn, 24, 8, 0) {
+				t.Skip("JSON unsupported on this server version")
+			}
+			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_mixed"))
+			require.NoError(t, conn.Exec(ctx, `
+				CREATE TABLE test_1841_mixed (id UInt32, product JSON)
+				ENGINE = MergeTree ORDER BY id
+			`))
+			t.Cleanup(func() { _ = conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_mixed") })
 
-		var stored string
-		require.NoError(t, conn.QueryRow(ctx,
-			"SELECT toString(product) FROM test_1841_string_ptr").Scan(&stored))
-		require.Equal(t, jsonText, stored,
-			"*string content must round-trip — PR #1850 §1 fix; previously stored as {}")
-	})
+			batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_1841_mixed (id, product)")
+			require.NoError(t, err)
 
-	// 2. Append(nil) does not latch the serialization mode, so either
-	// ordering — nil first or string first — succeeds. PR #1850 §2.
-	for _, tc := range []struct {
-		name        string
-		nilFirst    bool
-		expectFirst string
-		expectLast  string
-	}{
-		{"nil then string", true, "", jsonText},
-		{"string then nil", false, jsonText, ""},
-	} {
-		t.Run("ordering — "+tc.name, func(t *testing.T) {
+			obj := struct {
+				Name string
+				ID   int32
+			}{"kavi", 3}
+			require.NoError(t, batch.Append(uint32(1), obj))
+
+			err = batch.Append(uint32(2), jsonText)
+			require.Error(t, err,
+				"mixing object and string modes in the same block must return an error — "+
+					"PR #1850 §3; previously the second value was silently lost")
+			require.Contains(t, err.Error(), "serialization",
+				"error must explain the mode-conflict")
+		})
+
+		// 4. Columnar bulk insert of []*string with a nil element round-trips.
+		// Locks the regression fixed alongside this test: previously the bulk
+		// path stored "" (server rejects with code 117) or panicked on nil
+		// *json.RawMessage; the null mask returned to the Nullable wrapper
+		// also has to be the correct length so the bitmap matches the data.
+		t.Run("bulk Column.Append([]*string) with nil round-trips", func(t *testing.T) {
 			if !clickhouse_tests.CheckMinServerServerVersion(conn, 25, 2, 0) {
 				t.Skip("Nullable(JSON) requires server 25.2+")
 			}
-			tableName := "test_1841_order_" + strings.ReplaceAll(tc.name, " ", "_")
-			require.NoError(t, conn.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)))
-			require.NoError(t, conn.Exec(ctx, fmt.Sprintf(`
-				CREATE TABLE %s (id UInt32, product Nullable(JSON))
+			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_bulk"))
+			require.NoError(t, conn.Exec(ctx, `
+				CREATE TABLE test_1841_bulk (id UInt32, product Nullable(JSON))
 				ENGINE = MergeTree ORDER BY id
-			`, tableName)))
-			t.Cleanup(func() { _ = conn.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)) })
+			`))
+			t.Cleanup(func() { _ = conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_bulk") })
 
-			batch, err := conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s (id, product)", tableName))
+			batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_1841_bulk (id, product)")
 			require.NoError(t, err)
 
-			if tc.nilFirst {
-				require.NoError(t, batch.Append(uint32(1), nil))
-				require.NoError(t, batch.Append(uint32(2), jsonText))
-			} else {
-				require.NoError(t, batch.Append(uint32(1), jsonText))
-				require.NoError(t, batch.Append(uint32(2), nil))
-			}
-			require.NoError(t, batch.Send(),
-				"Append(nil) must not pre-latch the serialization mode — PR #1850 §2")
+			a, b := jsonText, `{"x":2}`
+			require.NoError(t, batch.Column(0).Append([]uint32{1, 2, 3}))
+			require.NoError(t, batch.Column(1).Append([]*string{&a, nil, &b}),
+				"bulk Append must accept []*string with nil elements")
+			require.NoError(t, batch.Send())
 
-			rows, err := conn.Query(ctx, fmt.Sprintf("SELECT id, toString(product) FROM %s ORDER BY id", tableName))
+			rows, err := conn.Query(ctx, "SELECT id, toString(product) FROM test_1841_bulk ORDER BY id")
 			require.NoError(t, err)
 			defer rows.Close()
 
-			gotByID := map[uint32]string{}
+			want := map[uint32]*string{1: &a, 2: nil, 3: &b}
+			seen := 0
 			for rows.Next() {
 				var id uint32
 				var s *string
 				require.NoError(t, rows.Scan(&id, &s))
-				if s == nil {
-					gotByID[id] = ""
+				expected := want[id]
+				if expected == nil {
+					require.Nil(t, s, "row id=%d should be NULL on the wire (null mask must mark it)", id)
 				} else {
-					gotByID[id] = *s
+					require.NotNil(t, s, "row id=%d must not be NULL", id)
+					require.Equal(t, *expected, *s, "row id=%d content", id)
 				}
+				seen++
 			}
 			require.NoError(t, rows.Err())
-			require.Equal(t, tc.expectFirst, gotByID[1], "row id=1")
-			require.Equal(t, tc.expectLast, gotByID[2], "row id=2")
+			require.Equal(t, 3, seen)
 		})
-	}
 
-	// 3. Mixing object and string modes in one block returns an error.
-	// PR #1850 §3: previously the second value was silently lost.
-	t.Run("mixed object then string errors", func(t *testing.T) {
-		if !clickhouse_tests.CheckMinServerServerVersion(conn, 24, 8, 0) {
-			t.Skip("JSON unsupported on this server version")
-		}
-		require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_mixed"))
-		require.NoError(t, conn.Exec(ctx, `
-			CREATE TABLE test_1841_mixed (id UInt32, product JSON)
-			ENGINE = MergeTree ORDER BY id
-		`))
-		t.Cleanup(func() { _ = conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_mixed") })
-
-		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_1841_mixed (id, product)")
-		require.NoError(t, err)
-
-		obj := struct {
-			Name string
-			ID   int32
-		}{"kavi", 3}
-		require.NoError(t, batch.Append(uint32(1), obj))
-
-		err = batch.Append(uint32(2), jsonText)
-		require.Error(t, err,
-			"mixing object and string modes in the same block must return an error — "+
-				"PR #1850 §3; previously the second value was silently lost")
-		require.Contains(t, err.Error(), "serialization",
-			"error must explain the mode-conflict")
-	})
-
-	// 4. Columnar bulk insert of []*string with a nil element round-trips.
-	// Locks the regression fixed alongside this test: previously the bulk
-	// path stored "" (server rejects with code 117) or panicked on nil
-	// *json.RawMessage; the null mask returned to the Nullable wrapper
-	// also has to be the correct length so the bitmap matches the data.
-	t.Run("bulk Column.Append([]*string) with nil round-trips", func(t *testing.T) {
-		if !clickhouse_tests.CheckMinServerServerVersion(conn, 25, 2, 0) {
-			t.Skip("Nullable(JSON) requires server 25.2+")
-		}
-		require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_bulk"))
-		require.NoError(t, conn.Exec(ctx, `
-			CREATE TABLE test_1841_bulk (id UInt32, product Nullable(JSON))
-			ENGINE = MergeTree ORDER BY id
-		`))
-		t.Cleanup(func() { _ = conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_bulk") })
-
-		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_1841_bulk (id, product)")
-		require.NoError(t, err)
-
-		a, b := jsonText, `{"x":2}`
-		require.NoError(t, batch.Column(0).Append([]uint32{1, 2, 3}))
-		require.NoError(t, batch.Column(1).Append([]*string{&a, nil, &b}),
-			"bulk Append must accept []*string with nil elements")
-		require.NoError(t, batch.Send())
-
-		rows, err := conn.Query(ctx, "SELECT id, toString(product) FROM test_1841_bulk ORDER BY id")
-		require.NoError(t, err)
-		defer rows.Close()
-
-		want := map[uint32]*string{1: &a, 2: nil, 3: &b}
-		seen := 0
-		for rows.Next() {
-			var id uint32
-			var s *string
-			require.NoError(t, rows.Scan(&id, &s))
-			expected := want[id]
-			if expected == nil {
-				require.Nil(t, s, "row id=%d should be NULL on the wire (null mask must mark it)", id)
-			} else {
-				require.NotNil(t, s, "row id=%d must not be NULL", id)
-				require.Equal(t, *expected, *s, "row id=%d content", id)
+		// 5. After an all-null batch, Reset() must clear the latched
+		// serialization mode so a follow-up batch of struct/map values
+		// is not rejected with a mode-conflict error. Pre-fix: the all-null
+		// batch latched String at WriteStatePrefix and Reset() left
+		// serializationVersion at String, breaking the next batch.
+		t.Run("Reset clears mode after all-null batch", func(t *testing.T) {
+			if !clickhouse_tests.CheckMinServerServerVersion(conn, 25, 2, 0) {
+				t.Skip("Nullable(JSON) requires server 25.2+")
 			}
-			seen++
-		}
-		require.NoError(t, rows.Err())
-		require.Equal(t, 3, seen)
+			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_reset"))
+			require.NoError(t, conn.Exec(ctx, `
+				CREATE TABLE test_1841_reset (id UInt32, product Nullable(JSON))
+				ENGINE = MergeTree ORDER BY id
+			`))
+			t.Cleanup(func() { _ = conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_reset") })
+
+			// First batch: only nulls — latches String at WriteStatePrefix.
+			batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_1841_reset (id, product)")
+			require.NoError(t, err)
+			require.NoError(t, batch.Append(uint32(1), nil))
+			require.NoError(t, batch.Send())
+
+			// Second batch: a struct value — must succeed because Reset()
+			// clears serializationVersion between sends.
+			batch, err = conn.PrepareBatch(ctx, "INSERT INTO test_1841_reset (id, product)")
+			require.NoError(t, err)
+			obj := struct {
+				Name string
+				Qty  int32
+			}{"book", 7}
+			require.NoError(t, batch.Append(uint32(2), obj),
+				"after an all-null batch, the next batch must accept struct values — PR #1850 review fix")
+			require.NoError(t, batch.Send())
+
+			var nulls, total uint64
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT countIf(product IS NULL), count() FROM test_1841_reset").Scan(&nulls, &total))
+			require.EqualValues(t, 1, nulls)
+			require.EqualValues(t, 2, total)
+		})
 	})
 }

--- a/tests/issues/1841_test.go
+++ b/tests/issues/1841_test.go
@@ -1,0 +1,192 @@
+package issues
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+)
+
+// TestIssue1841_JSONSerializationVersion locks the behaviors PR #1850
+// shipped while fixing issue #1841. Each subtest pins a previously-broken
+// case from the PR description so a future refactor cannot silently
+// regress it.
+func TestIssue1841_JSONSerializationVersion(t *testing.T) {
+	ctx := context.Background()
+
+	conn, err := clickhouse_tests.GetConnectionTCP("issues", clickhouse.Settings{
+		"allow_experimental_variant_type": true,
+		"allow_experimental_dynamic_type": true,
+		"allow_experimental_json_type":    true,
+	}, nil, nil)
+	require.NoError(t, err, "open clickhouse")
+
+	const jsonText = `{"id":1234,"name":"Book","tags":["a","b"]}`
+
+	// 1. *string holding JSON text is preserved end-to-end.
+	// PR #1850 §1: previously the pointer was misclassified as object mode
+	// and stored as "{}" — silent data loss.
+	t.Run("string pointer round-trips JSON content", func(t *testing.T) {
+		if !clickhouse_tests.CheckMinServerServerVersion(conn, 24, 8, 0) {
+			t.Skip("JSON unsupported on this server version")
+		}
+		require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_string_ptr"))
+		require.NoError(t, conn.Exec(ctx, `
+			CREATE TABLE test_1841_string_ptr (product JSON)
+			ENGINE = MergeTree ORDER BY tuple()
+		`))
+		t.Cleanup(func() { _ = conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_string_ptr") })
+
+		ptr := jsonText
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_1841_string_ptr (product)")
+		require.NoError(t, err)
+		require.NoError(t, batch.Append(&ptr))
+		require.NoError(t, batch.Send())
+
+		var stored string
+		require.NoError(t, conn.QueryRow(ctx,
+			"SELECT toString(product) FROM test_1841_string_ptr").Scan(&stored))
+		require.Equal(t, jsonText, stored,
+			"*string content must round-trip — PR #1850 §1 fix; previously stored as {}")
+	})
+
+	// 2. Append(nil) does not latch the serialization mode, so either
+	// ordering — nil first or string first — succeeds. PR #1850 §2.
+	for _, tc := range []struct {
+		name        string
+		nilFirst    bool
+		expectFirst string
+		expectLast  string
+	}{
+		{"nil then string", true, "", jsonText},
+		{"string then nil", false, jsonText, ""},
+	} {
+		t.Run("ordering — "+tc.name, func(t *testing.T) {
+			if !clickhouse_tests.CheckMinServerServerVersion(conn, 25, 2, 0) {
+				t.Skip("Nullable(JSON) requires server 25.2+")
+			}
+			tableName := "test_1841_order_" + strings.ReplaceAll(tc.name, " ", "_")
+			require.NoError(t, conn.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)))
+			require.NoError(t, conn.Exec(ctx, fmt.Sprintf(`
+				CREATE TABLE %s (id UInt32, product Nullable(JSON))
+				ENGINE = MergeTree ORDER BY id
+			`, tableName)))
+			t.Cleanup(func() { _ = conn.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)) })
+
+			batch, err := conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s (id, product)", tableName))
+			require.NoError(t, err)
+
+			if tc.nilFirst {
+				require.NoError(t, batch.Append(uint32(1), nil))
+				require.NoError(t, batch.Append(uint32(2), jsonText))
+			} else {
+				require.NoError(t, batch.Append(uint32(1), jsonText))
+				require.NoError(t, batch.Append(uint32(2), nil))
+			}
+			require.NoError(t, batch.Send(),
+				"Append(nil) must not pre-latch the serialization mode — PR #1850 §2")
+
+			rows, err := conn.Query(ctx, fmt.Sprintf("SELECT id, toString(product) FROM %s ORDER BY id", tableName))
+			require.NoError(t, err)
+			defer rows.Close()
+
+			gotByID := map[uint32]string{}
+			for rows.Next() {
+				var id uint32
+				var s *string
+				require.NoError(t, rows.Scan(&id, &s))
+				if s == nil {
+					gotByID[id] = ""
+				} else {
+					gotByID[id] = *s
+				}
+			}
+			require.NoError(t, rows.Err())
+			require.Equal(t, tc.expectFirst, gotByID[1], "row id=1")
+			require.Equal(t, tc.expectLast, gotByID[2], "row id=2")
+		})
+	}
+
+	// 3. Mixing object and string modes in one block returns an error.
+	// PR #1850 §3: previously the second value was silently lost.
+	t.Run("mixed object then string errors", func(t *testing.T) {
+		if !clickhouse_tests.CheckMinServerServerVersion(conn, 24, 8, 0) {
+			t.Skip("JSON unsupported on this server version")
+		}
+		require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_mixed"))
+		require.NoError(t, conn.Exec(ctx, `
+			CREATE TABLE test_1841_mixed (id UInt32, product JSON)
+			ENGINE = MergeTree ORDER BY id
+		`))
+		t.Cleanup(func() { _ = conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_mixed") })
+
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_1841_mixed (id, product)")
+		require.NoError(t, err)
+
+		obj := struct {
+			Name string
+			ID   int32
+		}{"kavi", 3}
+		require.NoError(t, batch.Append(uint32(1), obj))
+
+		err = batch.Append(uint32(2), jsonText)
+		require.Error(t, err,
+			"mixing object and string modes in the same block must return an error — "+
+				"PR #1850 §3; previously the second value was silently lost")
+		require.Contains(t, err.Error(), "serialization",
+			"error must explain the mode-conflict")
+	})
+
+	// 4. Columnar bulk insert of []*string with a nil element round-trips.
+	// Locks the regression fixed alongside this test: previously the bulk
+	// path stored "" (server rejects with code 117) or panicked on nil
+	// *json.RawMessage; the null mask returned to the Nullable wrapper
+	// also has to be the correct length so the bitmap matches the data.
+	t.Run("bulk Column.Append([]*string) with nil round-trips", func(t *testing.T) {
+		if !clickhouse_tests.CheckMinServerServerVersion(conn, 25, 2, 0) {
+			t.Skip("Nullable(JSON) requires server 25.2+")
+		}
+		require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_bulk"))
+		require.NoError(t, conn.Exec(ctx, `
+			CREATE TABLE test_1841_bulk (id UInt32, product Nullable(JSON))
+			ENGINE = MergeTree ORDER BY id
+		`))
+		t.Cleanup(func() { _ = conn.Exec(ctx, "DROP TABLE IF EXISTS test_1841_bulk") })
+
+		batch, err := conn.PrepareBatch(ctx, "INSERT INTO test_1841_bulk (id, product)")
+		require.NoError(t, err)
+
+		a, b := jsonText, `{"x":2}`
+		require.NoError(t, batch.Column(0).Append([]uint32{1, 2, 3}))
+		require.NoError(t, batch.Column(1).Append([]*string{&a, nil, &b}),
+			"bulk Append must accept []*string with nil elements")
+		require.NoError(t, batch.Send())
+
+		rows, err := conn.Query(ctx, "SELECT id, toString(product) FROM test_1841_bulk ORDER BY id")
+		require.NoError(t, err)
+		defer rows.Close()
+
+		want := map[uint32]*string{1: &a, 2: nil, 3: &b}
+		seen := 0
+		for rows.Next() {
+			var id uint32
+			var s *string
+			require.NoError(t, rows.Scan(&id, &s))
+			expected := want[id]
+			if expected == nil {
+				require.Nil(t, s, "row id=%d should be NULL on the wire (null mask must mark it)", id)
+			} else {
+				require.NotNil(t, s, "row id=%d must not be NULL", id)
+				require.Equal(t, *expected, *s, "row id=%d content", id)
+			}
+			seen++
+		}
+		require.NoError(t, rows.Err())
+		require.Equal(t, 3, seen)
+	})
+}

--- a/tests/issues/1841_test.go
+++ b/tests/issues/1841_test.go
@@ -23,6 +23,10 @@ func TestIssue1841_JSONSerializationVersion(t *testing.T) {
 		"allow_experimental_variant_type": true,
 		"allow_experimental_dynamic_type": true,
 		"allow_experimental_json_type":    true,
+		// `toString(JSON)` quotes 64-bit integers by default on ClickHouse < 25.4
+		// and emits them unquoted on newer servers. Pin the setting so the
+		// round-trip assertions don't depend on server version.
+		"output_format_json_quote_64bit_integers": false,
 	}, nil, nil)
 	require.NoError(t, err, "open clickhouse")
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

JSON is a complex type in ClickHouse. In the native protocol, choosing "how to serialize" (server call it `serialization version`) is a subtle problem. Two things needs to be understood.

#### 1. Serialization version in JSON

ClickHouse server supports multiple ways to serialize it. Two types are explicitly available at the Native format way. String or Object. [In server terms it's STRING and FLATTEN](https://github.com/ClickHouse/ClickHouse/blob/644c366011ddcd97122dcf43511967701463e43f/src/DataTypes/Serializations/SerializationObject.h?plain=1#L46-L57). In the client these are called String and Object serialization version.

With String - the whole JSON is represented as plain string. Each row you send to or receive from the server is a String type.

With Object - the whole response is more complex Dynamic/Variant type of JSON that is represented as Blocks.

Go client doesn't make user to "choose" which one to use for serialization, instead it chooses based on the value.

This change refactored to make this choosing more explicit.

#### 2. Serialization version per block per column.

Each block is a collection of column of same type in Native format. So [ClickHouse have to choose single "way" to serialize the whole block columns.](https://github.com/ClickHouse/ClickHouse/blob/644c366011ddcd97122dcf43511967701463e43f/src/DataTypes/Serializations/SerializationObject.cpp?plain=1#L265-L275) For types like JSON, this is tricky because both String based and Object JSON are valid values for each row in same column in same block, but ClickHouse have to "choose" one serialization version for it.
That's why it's enforced during Append.

fixes: #https://github.com/ClickHouse/clickhouse-go/issues/1841

### Behavior changes before and after the patch

#### 1. *string pointer usage

Say we have code like following
```go
	jsonText := `{"id":1234,"name":"Book","tags":["a","b"]}`
	ptr := &jsonText

	batch, err := conn.PrepareBatch(ctx, "INSERT INTO go_json_repro_issue1 (product)")
	if err != nil {
		return err
	}
	if err := batch.Append(ptr); err != nil {
		return fmt.Errorf("append returned an error (would be preferable): %w", err)
	}
	if err := batch.Send(); err != nil {
		return err
	}

	var stored string
	if err := conn.QueryRow(ctx,
		"SELECT toString(product) FROM go_json_repro_issue1").Scan(&stored); err != nil {
		return err
	}

	fmt.Printf("  input (*string):  %s\n", jsonText)
	fmt.Printf("  stored value:     %s\n", stored)
	fmt.Printf("  data lost:        %t\n", stored != jsonText)
```

Before the patch (`*string` data is lost silently)
```bash
$ go run examples/json_repro_issues/main.go
Issue 1: *string holding JSON is silently stored as {}
  input (*string):  {"id":1234,"name":"Book","tags":["a","b"]}
  stored value:     {}
  data lost:        true

```

After the patch (data is not lost)
```bash
$ go run examples/json_repro_issues/main.go
Issue 1: *string holding JSON is silently stored as {}
  input (*string):  {"id":1234,"name":"Book","tags":["a","b"]}
  stored value:     {"id":1234,"name":"Book","tags":["a","b"]}
  data lost:        false

```

#### 2. nil usage with both string and object value

Say you have code like following
```go
	jsonText := `{"id":2,"name":"Book"}`

	// Scenario A: nil first, then a JSON string.
	// Fixed behavior: nil defers, string latches String mode, nil flushes as
	// the JSON literal "null" — both rows round-trip correctly.
	fmt.Println("  Scenario A: Append(nil) then Append(jsonString)")
	batch, err := conn.PrepareBatch(ctx, "INSERT INTO go_json_repro_issue2 (id, product)")
	if err != nil {
		return err
	}
	if err := batch.Append(uint32(1), nil); err != nil {
		return fmt.Errorf("append nil: %w", err)
	}
	if err := batch.Append(uint32(2), jsonText); err != nil {
		return fmt.Errorf("append string: %w", err)
	}
	if err := batch.Send(); err != nil {
		return fmt.Errorf("send: %w", err)
	}
	if err := dumpRows(ctx, conn, "go_json_repro_issue2"); err != nil {
		return err
	}

	// Scenario B: same rows, reordered (string first, then nil).
	fmt.Println("  Scenario B: Append(jsonString) then Append(nil) — reordered")
	if err := conn.Exec(ctx, "TRUNCATE TABLE go_json_repro_issue2"); err != nil {
		return err
	}
	batch, err = conn.PrepareBatch(ctx, "INSERT INTO go_json_repro_issue2 (id, product)")
	if err != nil {
		return err
	}
	if err := batch.Append(uint32(2), jsonText); err != nil {
		return err
	}
	if err := batch.Append(uint32(1), nil); err != nil {
		return err
	}
	if err := batch.Send(); err != nil {
		return fmt.Errorf("send (reordered): %w", err)
	}
	if err := dumpRows(ctx, conn, "go_json_repro_issue2"); err != nil {
		return err
	}

```

Before the patch 
1. appending `nil` first choose `object` serialization version and appending string next lost data silently
2. appending `string` first choose `string` serialization version and appending `nil` next cause error because `nil` cannot be serialized as string before.
```bash
$ go run examples/json_repro_issues/main.go
Issue 2: nil-first on Nullable(JSON) — previously locked object mode
  Scenario A: Append(nil) then Append(jsonString)
    id=1  product=
    id=2  product={}
  Scenario B: Append(jsonString) then Append(nil) — reordered
2026/04/22 22:32:58 issue 2 repro failed: send (reordered): code: 117, message: Cannot parse JSON object here:
```

After the patch
1. `nil` doesn't have any serialization version. It's deferred to the time of flushing based on first non-null value.
2. so both scenarios (`nil` then `string`, `string` then `nil` both works)
```bash
$ go run examples/json_repro_issues/main.go
Issue 2: nil-first on Nullable(JSON) — previously locked object mode
  Scenario A: Append(nil) then Append(jsonString)
    id=1  product=
    id=2  product={"id":2,"name":"Book"}
  Scenario B: Append(jsonString) then Append(nil) — reordered
    id=1  product=
    id=2  product={"id":2,"name":"Book"}

```

#### 3. Mixing serialization mode in same block

Say you have following code
```go
	jsonText := `{"id":2,"name":"Book"}`

	jsonObj1 := struct {
		Name string
		Id   int32
	}{"kavi", 3}

	batch, err := conn.PrepareBatch(ctx, "INSERT INTO go_json_repro_issue2 (id, product)")
	if err != nil {
		return err
	}
	if err := batch.Append(uint32(1), jsonObj1); err != nil {
		return fmt.Errorf("append object: %w", err)
	}
	if err := batch.Append(uint32(2), jsonText); err != nil {
		return fmt.Errorf("append string: %w", err)
	}
	if err := batch.Send(); err != nil {
		return fmt.Errorf("send: %w", err)
	}
	if err := dumpRows(ctx, conn, "go_json_repro_issue2"); err != nil {
		return err
	}
	return nil

```

Before the patch
 It picks the serializaiton mode whatever inserted first and second append silently lost data
```bash
$ go run examples/json_repro_issues/main.go
Mixed serialization mode: use String mode and Object mode in same block
    id=1  product={"Id":3,"Name":"kavi"}
    id=2  product={} # data lost
```

After the patch
It throws error saying you cannot have different serialization version per single block.
```bash
$ go run examples/json_repro_issues/main.go
Mixed serialization mode: use String mode and Object mode in same block
2026/04/22 22:44:26 mixed mode error: append string: clickhouse [AppendRow]: product clickhouse: JSON column is already using object serialization after row 1; cannot append a value that requires string serialization. The wire format allows only one serialization version per column per block — every row in a batch must use the same mode

```

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
