### PR TITLE
chore: update the version matrix

### DIFF
--- a/.github/workflows/run-tests-cloud.yml
+++ b/.github/workflows/run-tests-cloud.yml
@@ -22,6 +22,7 @@ jobs:
     strategy:
       matrix:
         go:
+          - "1.26"
           - "1.25"
     steps:
       - name: Checkout

--- a/.github/workflows/run-tests-head.yml
+++ b/.github/workflows/run-tests-head.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'pull_request'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && github.event.label_name == 'tests:run-head')
     runs-on: [self-hosted, style-checker-aarch64]
     strategy:
       matrix:

--- a/.github/workflows/run-tests-head.yml
+++ b/.github/workflows/run-tests-head.yml
@@ -29,6 +29,12 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
+      - name: Pull latest clickhouse-server:${{ matrix.clickhouse }} image
+        # The `head` tag is mutable: it is re-tagged on every upstream build.
+        # Self-hosted runners cache images by tag, so without an explicit pull
+        # the job would keep running against whichever `head` was first cached.
+        run: docker pull clickhouse/clickhouse-server:${{ matrix.clickhouse }}
+
       - name: Tests
         env:
           TESTCONTAINERS_RYUK_DISABLED: "true"

--- a/.github/workflows/run-tests-head.yml
+++ b/.github/workflows/run-tests-head.yml
@@ -18,8 +18,6 @@ jobs:
         go:
           - "1.26"
           - "1.25"
-        clickhouse:
-          - "head"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,15 +27,18 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
-      - name: Pull latest clickhouse-server:${{ matrix.clickhouse }} image
+      - name: Delete any existing `head` image
+        run: docker rmi clickhouse/clickhouse-server:head -f
+
+      - name: Pull latest clickhouse-server:head image
         # The `head` tag is mutable: it is re-tagged on every upstream build.
         # Self-hosted runners cache images by tag, so without an explicit pull
         # the job would keep running against whichever `head` was first cached.
-        run: docker pull clickhouse/clickhouse-server:${{ matrix.clickhouse }}
+        run: docker pull clickhouse/clickhouse-server:head
 
       - name: Tests
         env:
           TESTCONTAINERS_RYUK_DISABLED: "true"
           GOTOOLCHAIN: "local"
         run: |
-          CLICKHOUSE_VERSION=${{ matrix.clickhouse }} make test
+          CLICKHOUSE_VERSION=head make test

--- a/.github/workflows/run-tests-head.yml
+++ b/.github/workflows/run-tests-head.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         go:
+          - "1.26"
           - "1.25"
         clickhouse:
           - "head"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,13 +17,13 @@ jobs:
       fail-fast: false
       matrix:
         go:
+          - "1.26"
           - "1.25"
-          - "1.24"
         clickhouse: # https://github.com/ClickHouse/ClickHouse/blob/master/SECURITY.md#scope-and-supported-versions
-          - "25.10"
-          - "25.9"
-          - "25.8"
-          - "25.3"
+          - "26.4"
+          - "26.3"
+          - "26.2"
+          - "25.8" # LTS
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -141,9 +141,10 @@ func CreateClickHouseTestEnvironment(testSet string) (ClickHouseTestEnvironment,
 	containerName := fmt.Sprintf("clickhouse-go-%x", md5.Sum(buf.Bytes()))
 
 	req := testcontainers.ContainerRequest{
-		Image:        fmt.Sprintf("clickhouse/clickhouse-server:%s", GetClickHouseTestVersion()),
-		Name:         containerName,
-		ExposedPorts: []string{"9000/tcp", "8123/tcp", "9440/tcp", "8443/tcp"},
+		Image:           fmt.Sprintf("clickhouse/clickhouse-server:%s", GetClickHouseTestVersion()),
+		AlwaysPullImage: true,
+		Name:            containerName,
+		ExposedPorts:    []string{"9000/tcp", "8123/tcp", "9440/tcp", "8443/tcp"},
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort("9000/tcp"),
 			wait.ForListeningPort("8123/tcp"),


### PR DESCRIPTION
1. Include go1.26 and remove go1.24
2. Update the ClickHouse versions based on scope and supported version https://github.com/ClickHouse/ClickHouse/blob/master/SECURITY.md#scope-and-supported-versions

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
