### PR TITLE
perf(column): bulk-append fast paths for Array and LowCardinality

### DIFF
--- a/lib/column/array.go
+++ b/lib/column/array.go
@@ -2,6 +2,7 @@ package column
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -101,6 +102,11 @@ func (col *Array) Row(i int, ptr bool) any {
 }
 
 func (col *Array) Append(v any) (nulls []uint8, err error) {
+	if col.depth == 1 {
+		if handled, err := col.appendBulkPlain(v); handled || err != nil {
+			return nil, err
+		}
+	}
 	value := reflect.Indirect(reflect.ValueOf(v))
 	if value.Kind() != reflect.Slice {
 		return nil, &ColumnConverterError{
@@ -151,6 +157,19 @@ func (col *Array) appendRowDefault(v any) error {
 
 func appendRowPlain[T any](col *Array, arr []T) error {
 	col.appendOffset(0, uint64(len(arr)))
+	_, err := col.values.Append(arr)
+	if err == nil {
+		return nil
+	}
+
+	// Append rejects unknown slice types up-front via ColumnConverterError
+	// without mutating column state. AppendRow has a reflection-based
+	// conversion fallback that accepts e.g. []int into Array(Int64); preserve
+	// that by retrying per-item.
+	var convErr *ColumnConverterError
+	if !errors.As(err, &convErr) {
+		return err
+	}
 	for _, item := range arr {
 		if err := col.values.AppendRow(item); err != nil {
 			return err
@@ -161,14 +180,108 @@ func appendRowPlain[T any](col *Array, arr []T) error {
 
 func appendNullableRowPlain[T any](col *Array, arr []*T) error {
 	col.appendOffset(0, uint64(len(arr)))
+	_, err := col.values.Append(arr)
+	if err == nil {
+		return nil
+	}
+
+	var convErr *ColumnConverterError
+	if !errors.As(err, &convErr) {
+		return err
+	}
+
 	for _, item := range arr {
-		var err error
 		if item == nil {
-			err = col.values.AppendRow(nil)
-		} else {
-			err = col.values.AppendRow(item)
+			if err := col.values.AppendRow(nil); err != nil {
+				return err
+			}
+			continue
 		}
-		if err != nil {
+		if err := col.values.AppendRow(item); err != nil {
+			return err
+		}
+	}
+	return nil
+
+}
+
+// appendBulkPlain is the bulk equivalent of appendRowPlain for depth-1 Array
+// columns. Flattens arr into a single inner Append call so the inner column's
+// growth/loop preamble runs once instead of N times.
+//
+// Mirrors appendRowPlain's retry semantics: inner Append rejects unknown slice
+// types up-front via ColumnConverterError without mutating its state, so on
+// that error we retry per-item with AppendRow from the flat slice.
+func appendBulkPlain[T any](col *Array, arr [][]T) error {
+	if len(arr) == 0 {
+		return nil
+	}
+
+	total := 0
+	for _, row := range arr {
+		total += len(row)
+	}
+
+	flat := make([]T, 0, total)
+	for _, row := range arr {
+		col.appendOffset(0, uint64(len(row)))
+		flat = append(flat, row...)
+	}
+
+	_, err := col.values.Append(flat)
+	if err == nil {
+		return nil
+	}
+
+	var convErr *ColumnConverterError
+	if !errors.As(err, &convErr) {
+		return err
+	}
+
+	for _, item := range flat {
+		if err := col.values.AppendRow(item); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func appendNullableBulkPlain[T any](col *Array, arr [][]*T) error {
+	if len(arr) == 0 {
+		return nil
+	}
+	total := 0
+	for _, row := range arr {
+		total += len(row)
+	}
+
+	flat := make([]*T, 0, total)
+	for _, row := range arr {
+		col.appendOffset(0, uint64(len(row)))
+		flat = append(flat, row...)
+	}
+
+	_, err := col.values.Append(flat)
+	if err == nil {
+		return nil
+	}
+
+	var convErr *ColumnConverterError
+
+	if !errors.As(err, &convErr) {
+		return err
+	}
+
+	for _, item := range flat {
+		if item == nil {
+			if err := col.values.AppendRow(nil); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := col.values.AppendRow(item); err != nil {
 			return err
 		}
 	}

--- a/lib/column/array_gen.go
+++ b/lib/column/array_gen.go
@@ -164,3 +164,142 @@ func (col *Array) appendRowPlain(v any) error {
 		return col.appendRowDefault(v)
 	}
 }
+
+// appendBulkPlain dispatches typed [][]T inputs (one slice per row of a depth-1
+// Array column) through the inner column's typed Append fast path, avoiding
+// the reflection loop in Array.Append. Returns (true, err) when a typed case
+// matched, (false, nil) to signal the caller should fall through to reflection.
+func (col *Array) appendBulkPlain(v any) (bool, error) {
+	switch tv := v.(type) {
+	case [][]float32:
+		return true, appendBulkPlain(col, tv)
+	case [][]*float32:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]float64:
+		return true, appendBulkPlain(col, tv)
+	case [][]*float64:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]int8:
+		return true, appendBulkPlain(col, tv)
+	case [][]*int8:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]int16:
+		return true, appendBulkPlain(col, tv)
+	case [][]*int16:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]int32:
+		return true, appendBulkPlain(col, tv)
+	case [][]*int32:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]int64:
+		return true, appendBulkPlain(col, tv)
+	case [][]*int64:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]uint8:
+		return true, appendBulkPlain(col, tv)
+	case [][]*uint8:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]uint16:
+		return true, appendBulkPlain(col, tv)
+	case [][]*uint16:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]uint32:
+		return true, appendBulkPlain(col, tv)
+	case [][]*uint32:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]uint64:
+		return true, appendBulkPlain(col, tv)
+	case [][]*uint64:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]string:
+		return true, appendBulkPlain(col, tv)
+	case [][]*string:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][][]byte:
+		return true, appendBulkPlain(col, tv)
+	case [][]*[]byte:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]sql.NullString:
+		return true, appendBulkPlain(col, tv)
+	case [][]*sql.NullString:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]int:
+		return true, appendBulkPlain(col, tv)
+	case [][]*int:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]uint:
+		return true, appendBulkPlain(col, tv)
+	case [][]*uint:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]big.Int:
+		return true, appendBulkPlain(col, tv)
+	case [][]*big.Int:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]decimal.Decimal:
+		return true, appendBulkPlain(col, tv)
+	case [][]*decimal.Decimal:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]bool:
+		return true, appendBulkPlain(col, tv)
+	case [][]*bool:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]sql.NullBool:
+		return true, appendBulkPlain(col, tv)
+	case [][]*sql.NullBool:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]time.Time:
+		return true, appendBulkPlain(col, tv)
+	case [][]*time.Time:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]sql.NullTime:
+		return true, appendBulkPlain(col, tv)
+	case [][]*sql.NullTime:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]uuid.UUID:
+		return true, appendBulkPlain(col, tv)
+	case [][]*uuid.UUID:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]netip.Addr:
+		return true, appendBulkPlain(col, tv)
+	case [][]*netip.Addr:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]net.IP:
+		return true, appendBulkPlain(col, tv)
+	case [][]*net.IP:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]proto.IPv6:
+		return true, appendBulkPlain(col, tv)
+	case [][]*proto.IPv6:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][][16]byte:
+		return true, appendBulkPlain(col, tv)
+	case [][]*[16]byte:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]orb.LineString:
+		return true, appendBulkPlain(col, tv)
+	case [][]*orb.LineString:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]orb.MultiLineString:
+		return true, appendBulkPlain(col, tv)
+	case [][]*orb.MultiLineString:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]orb.MultiPolygon:
+		return true, appendBulkPlain(col, tv)
+	case [][]*orb.MultiPolygon:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]orb.Point:
+		return true, appendBulkPlain(col, tv)
+	case [][]*orb.Point:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]orb.Polygon:
+		return true, appendBulkPlain(col, tv)
+	case [][]*orb.Polygon:
+		return true, appendNullableBulkPlain(col, tv)
+	case [][]orb.Ring:
+		return true, appendBulkPlain(col, tv)
+	case [][]*orb.Ring:
+		return true, appendNullableBulkPlain(col, tv)
+	default:
+		return false, nil
+	}
+}

--- a/lib/column/array_test.go
+++ b/lib/column/array_test.go
@@ -1,0 +1,109 @@
+package column
+
+import (
+	"strconv"
+	"testing"
+)
+
+const arrayBenchResetEveryN = 1024
+
+func newBenchArrayColumn(b *testing.B, chType string) *Array {
+	b.Helper()
+	col, err := Type(chType).Column("bench", nil)
+	if err != nil {
+		b.Fatalf("parse %s: %v", chType, err)
+	}
+	arr, ok := col.(*Array)
+	if !ok {
+		b.Fatalf("expected *Array, got %T", col)
+	}
+	return arr
+}
+
+func benchArrayAppend(b *testing.B, col *Array, data any) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := col.Append(data); err != nil {
+			b.Fatalf("Append: %v", err)
+		}
+		if (i+1)%arrayBenchResetEveryN == 0 {
+			col.Reset()
+		}
+	}
+}
+
+func makeInt64Rows(rows, perRow int) [][]int64 {
+	out := make([][]int64, rows)
+	for i := range out {
+		row := make([]int64, perRow)
+		for j := range row {
+			row[j] = int64(i*perRow + j)
+		}
+		out[i] = row
+	}
+	return out
+}
+
+func makeStringRows(rows, perRow int) [][]string {
+	out := make([][]string, rows)
+	for i := range out {
+		row := make([]string, perRow)
+		for j := range row {
+			row[j] = "v_" + strconv.Itoa(i*perRow+j)
+		}
+		out[i] = row
+	}
+	return out
+}
+
+func makeNullableInt64Rows(rows, perRow int) [][]*int64 {
+	out := make([][]*int64, rows)
+	for i := range out {
+		row := make([]*int64, perRow)
+		for j := range row {
+			if j%4 == 0 {
+				continue
+			}
+			v := int64(i*perRow + j)
+			row[j] = &v
+		}
+		out[i] = row
+	}
+	return out
+}
+
+func BenchmarkArrayAppend_Int64_100x10(b *testing.B) {
+	col := newBenchArrayColumn(b, "Array(Int64)")
+	benchArrayAppend(b, col, makeInt64Rows(100, 10))
+}
+
+func BenchmarkArrayAppend_Int64_1000x10(b *testing.B) {
+	col := newBenchArrayColumn(b, "Array(Int64)")
+	benchArrayAppend(b, col, makeInt64Rows(1000, 10))
+}
+
+func BenchmarkArrayAppend_Int64_100x100(b *testing.B) {
+	col := newBenchArrayColumn(b, "Array(Int64)")
+	benchArrayAppend(b, col, makeInt64Rows(100, 100))
+}
+
+func BenchmarkArrayAppend_String_100x10(b *testing.B) {
+	col := newBenchArrayColumn(b, "Array(String)")
+	benchArrayAppend(b, col, makeStringRows(100, 10))
+}
+
+func BenchmarkArrayAppend_String_1000x10(b *testing.B) {
+	col := newBenchArrayColumn(b, "Array(String)")
+	benchArrayAppend(b, col, makeStringRows(1000, 10))
+}
+
+func BenchmarkArrayAppend_NullableInt64_100x10(b *testing.B) {
+	col := newBenchArrayColumn(b, "Array(Nullable(Int64))")
+	benchArrayAppend(b, col, makeNullableInt64Rows(100, 10))
+}
+
+func BenchmarkArrayAppend_NullableInt64_1000x10(b *testing.B) {
+	col := newBenchArrayColumn(b, "Array(Nullable(Int64))")
+	benchArrayAppend(b, col, makeNullableInt64Rows(1000, 10))
+}

--- a/lib/column/array_test.go
+++ b/lib/column/array_test.go
@@ -3,7 +3,132 @@ package column
 import (
 	"strconv"
 	"testing"
+
+	chproto "github.com/ClickHouse/ch-go/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func encodeColumnBytes(t *testing.T, col Interface) []byte {
+	t.Helper()
+	var buf chproto.Buffer
+	col.Encode(&buf)
+	out := make([]byte, len(buf.Buf))
+	copy(out, buf.Buf)
+	return out
+}
+
+func newArrayColumn(t *testing.T, chType string) *Array {
+	t.Helper()
+	col, err := Type(chType).Column("test", nil)
+	require.NoError(t, err)
+	arr, ok := col.(*Array)
+	require.True(t, ok, "expected *Array, got %T", col)
+	return arr
+}
+
+func TestArrayAppendBulk_Int64_MatchesRowByRow(t *testing.T) {
+	rows := [][]int64{{1, 2, 3}, {}, {4, 5}, {6}}
+
+	bulk := newArrayColumn(t, "Array(Int64)")
+	_, err := bulk.Append(rows)
+	require.NoError(t, err)
+
+	rowByRow := newArrayColumn(t, "Array(Int64)")
+	for _, r := range rows {
+		require.NoError(t, rowByRow.AppendRow(r))
+	}
+
+	require.Equal(t, len(rows), bulk.Rows())
+	require.Equal(t, bulk.Rows(), rowByRow.Rows())
+	for i := range rows {
+		assert.Equal(t, rowByRow.Row(i, false), bulk.Row(i, false), "row %d", i)
+	}
+	assert.Equal(t, encodeColumnBytes(t, rowByRow), encodeColumnBytes(t, bulk))
+}
+
+func TestArrayAppendBulk_ConvertibleIntSlice(t *testing.T) {
+	rows := [][]int{{1, 2, 3}, {4, 5}}
+
+	col := newArrayColumn(t, "Array(Int64)")
+	_, err := col.Append(rows)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, col.Rows())
+	require.Equal(t, 5, col.values.Rows())
+	assert.Equal(t, []int64{1, 2, 3}, col.Row(0, false))
+	assert.Equal(t, []int64{4, 5}, col.Row(1, false))
+}
+
+func TestArrayAppendRow_ConvertibleIntSlice(t *testing.T) {
+	rows := [][]int{{1, 2, 3}, {4, 5}}
+
+	col := newArrayColumn(t, "Array(Int64)")
+	for _, r := range rows {
+		require.NoError(t, col.AppendRow(r))
+	}
+
+	require.Equal(t, 2, col.Rows())
+	require.Equal(t, 5, col.values.Rows())
+	assert.Equal(t, []int64{1, 2, 3}, col.Row(0, false))
+	assert.Equal(t, []int64{4, 5}, col.Row(1, false))
+}
+
+func TestArrayAppendBulk_NullableInt64_MixedNils(t *testing.T) {
+	p := func(v int64) *int64 { return &v }
+	rows := [][]*int64{{p(1), nil, p(2)}, {nil}, {p(3), p(4)}}
+
+	bulk := newArrayColumn(t, "Array(Nullable(Int64))")
+	_, err := bulk.Append(rows)
+	require.NoError(t, err)
+
+	rowByRow := newArrayColumn(t, "Array(Nullable(Int64))")
+	for _, r := range rows {
+		require.NoError(t, rowByRow.AppendRow(r))
+	}
+
+	require.Equal(t, len(rows), bulk.Rows())
+	require.Equal(t, bulk.Rows(), rowByRow.Rows())
+
+	for i := range rows {
+		gotBulk, gotRow := bulk.Row(i, false), rowByRow.Row(i, false)
+		assert.Equal(t, gotRow, gotBulk, "row %d", i)
+
+		got, ok := gotBulk.([]*int64)
+		require.True(t, ok, "expected []*int64 for row %d, got %T", i, gotBulk)
+		require.Equal(t, len(rows[i]), len(got))
+		for j, want := range rows[i] {
+			if want == nil {
+				assert.Nil(t, got[j], "row %d col %d", i, j)
+				continue
+			}
+			require.NotNil(t, got[j], "row %d col %d", i, j)
+			assert.Equal(t, *want, *got[j], "row %d col %d", i, j)
+		}
+	}
+
+	assert.Equal(t, encodeColumnBytes(t, rowByRow), encodeColumnBytes(t, bulk))
+}
+
+func TestArrayAppendBulk_StringMatchesRowByRow(t *testing.T) {
+	rows := [][]string{{"a", "b"}, {}, {"c"}}
+
+	bulk := newArrayColumn(t, "Array(String)")
+	_, err := bulk.Append(rows)
+	require.NoError(t, err)
+
+	rowByRow := newArrayColumn(t, "Array(String)")
+	for _, r := range rows {
+		require.NoError(t, rowByRow.AppendRow(r))
+	}
+
+	require.Equal(t, len(rows), bulk.Rows())
+	require.Equal(t, bulk.Rows(), rowByRow.Rows())
+	for i := range rows {
+		assert.Equal(t, rowByRow.Row(i, false), bulk.Row(i, false), "row %d", i)
+	}
+	assert.Equal(t, encodeColumnBytes(t, rowByRow), encodeColumnBytes(t, bulk))
+}
 
 const arrayBenchResetEveryN = 1024
 

--- a/lib/column/codegen/array.tpl
+++ b/lib/column/codegen/array.tpl
@@ -43,3 +43,20 @@ func (col *Array) appendRowPlain(v any) error {
 		return col.appendRowDefault(v)
 	}
 }
+
+// appendBulkPlain dispatches typed [][]T inputs (one slice per row of a depth-1
+// Array column) through the inner column's typed Append fast path, avoiding
+// the reflection loop in Array.Append. Returns (true, err) when a typed case
+// matched, (false, nil) to signal the caller should fall through to reflection.
+func (col *Array) appendBulkPlain(v any) (bool, error) {
+	switch tv := v.(type) {
+	{{- range . }}
+	case [][]{{ . }}:
+		return true, appendBulkPlain(col, tv)
+	case [][]*{{ . }}:
+		return true, appendNullableBulkPlain(col, tv)
+	{{- end }}
+	default:
+		return false, nil
+	}
+}

--- a/lib/column/lowcardinality.go
+++ b/lib/column/lowcardinality.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"slices"
 	"time"
 
 	"github.com/ClickHouse/ch-go/proto"
@@ -109,6 +110,12 @@ func (col *LowCardinality) ScanRow(dest any, row int) error {
 }
 
 func (col *LowCardinality) Append(v any) (nulls []uint8, err error) {
+	switch arr := v.(type) {
+	case []string:
+		return nil, appendLC(col, arr)
+	case []*string:
+		return nil, appendLCPtr(col, arr)
+	}
 	value := reflect.Indirect(reflect.ValueOf(v))
 	if value.Kind() != reflect.Slice {
 		return nil, &ColumnConverterError{
@@ -117,7 +124,10 @@ func (col *LowCardinality) Append(v any) (nulls []uint8, err error) {
 			From: fmt.Sprintf("%T", v),
 		}
 	}
-	for i := 0; i < value.Len(); i++ {
+	col.initIndex()
+	n := value.Len()
+	col.append.keys = slices.Grow(col.append.keys, n)
+	for i := 0; i < n; i++ {
 		if err := col.AppendRow(value.Index(i).Interface()); err != nil {
 			return nil, err
 		}
@@ -125,16 +135,72 @@ func (col *LowCardinality) Append(v any) (nulls []uint8, err error) {
 	return
 }
 
-func (col *LowCardinality) AppendRow(v any) error {
-	col.rows++
+// appendLC bulk-appends a typed slice to a LowCardinality column without
+// reflection. Allocations only happen when the dictionary actually grows.
+func appendLC[T comparable](col *LowCardinality, arr []T) error {
+	col.initIndex()
+	col.append.keys = slices.Grow(col.append.keys, len(arr))
+
+	for _, v := range arr {
+		idx, found := col.append.index[v]
+		if !found {
+			if err := col.index.AppendRow(v); err != nil {
+				return err
+			}
+
+			idx = col.index.Rows() - 1
+			col.append.index[v] = idx
+		}
+
+		col.append.keys = append(col.append.keys, idx)
+	}
+
+	col.rows += len(arr)
+	return nil
+}
+
+func appendLCPtr[T comparable](col *LowCardinality, arr []*T) error {
+	col.initIndex()
+	col.append.keys = slices.Grow(col.append.keys, len(arr))
+	for _, p := range arr {
+		if p == nil {
+			col.append.keys = append(col.append.keys, 0)
+			continue
+		}
+
+		v := *p
+		idx, found := col.append.index[v]
+		if !found {
+			if err := col.index.AppendRow(v); err != nil {
+				return err
+			}
+			idx = col.index.Rows() - 1
+			col.append.index[v] = idx
+		}
+		col.append.keys = append(col.append.keys, idx)
+	}
+
+	col.rows += len(arr)
+	return nil
+}
+
+func (col *LowCardinality) initIndex() {
 	if col.append.index == nil {
 		col.append.index = make(map[any]int)
 	}
-	if col.index.Rows() == 0 { // init
-		if col.index.AppendRow(nil); col.nullable {
-			col.index.AppendRow(nil)
-		}
+	if col.index.Rows() != 0 {
+		return
 	}
+
+	col.index.AppendRow(nil)
+	if col.nullable {
+		col.index.AppendRow(nil)
+	}
+}
+
+func (col *LowCardinality) AppendRow(v any) error {
+	col.rows++
+	col.initIndex()
 	// second check is unfortunate - but we could be passed a *type(nil) e.g. via LowCardinality(Nullable(String))
 	if v == nil || (reflect.ValueOf(v).Kind() == reflect.Ptr && reflect.ValueOf(v).IsNil()) {
 		col.append.keys = append(col.append.keys, 0)
@@ -144,13 +210,15 @@ func (col *LowCardinality) AppendRow(v any) error {
 	case time.Time:
 		v = x.Truncate(time.Second)
 	}
-	if _, found := col.append.index[v]; !found {
+	idx, found := col.append.index[v]
+	if !found {
 		if err := col.index.AppendRow(v); err != nil {
 			return err
 		}
-		col.append.index[v] = col.index.Rows() - 1
+		idx = col.index.Rows() - 1
+		col.append.index[v] = idx
 	}
-	col.append.keys = append(col.append.keys, col.append.index[v])
+	col.append.keys = append(col.append.keys, idx)
 	return nil
 }
 

--- a/lib/column/lowcardinality_test.go
+++ b/lib/column/lowcardinality_test.go
@@ -1,6 +1,7 @@
 package column
 
 import (
+	"strconv"
 	"testing"
 
 	chproto "github.com/ClickHouse/ch-go/proto"
@@ -127,4 +128,91 @@ func TestLowCardinalityAppendManyRowsWithoutPanic(t *testing.T) {
 	}
 
 	assert.Equal(t, 1000, lc.Rows())
+}
+
+const lcBenchResetEveryN = 1024
+
+func newBenchLowCardinalityColumn(b *testing.B, chType string) *LowCardinality {
+	b.Helper()
+	col, err := Type(chType).Column("bench", nil)
+	if err != nil {
+		b.Fatalf("parse %s: %v", chType, err)
+	}
+	lc, ok := col.(*LowCardinality)
+	if !ok {
+		b.Fatalf("expected *LowCardinality, got %T", col)
+	}
+	return lc
+}
+
+func benchLowCardinalityAppend(b *testing.B, col *LowCardinality, data any) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := col.Append(data); err != nil {
+			b.Fatalf("Append: %v", err)
+		}
+		if (i+1)%lcBenchResetEveryN == 0 {
+			col.Reset()
+		}
+	}
+}
+
+func makeLCStrings(n, unique int) []string {
+	dict := make([]string, unique)
+	for i := range dict {
+		dict[i] = "value_" + strconv.Itoa(i)
+	}
+	out := make([]string, n)
+	for i := range out {
+		out[i] = dict[i%unique]
+	}
+	return out
+}
+
+func makeLCStringPtrs(n, unique int, nullEvery int) []*string {
+	dict := make([]string, unique)
+	for i := range dict {
+		dict[i] = "value_" + strconv.Itoa(i)
+	}
+	out := make([]*string, n)
+	for i := range out {
+		if nullEvery > 0 && i%nullEvery == 0 {
+			continue
+		}
+		s := dict[i%unique]
+		out[i] = &s
+	}
+	return out
+}
+
+func BenchmarkLowCardinalityAppend_String_1000x26(b *testing.B) {
+	col := newBenchLowCardinalityColumn(b, "LowCardinality(String)")
+	benchLowCardinalityAppend(b, col, makeLCStrings(1000, 26))
+}
+
+func BenchmarkLowCardinalityAppend_String_1000x1000(b *testing.B) {
+	// All-unique stress case: every row grows the dictionary.
+	col := newBenchLowCardinalityColumn(b, "LowCardinality(String)")
+	benchLowCardinalityAppend(b, col, makeLCStrings(1000, 1000))
+}
+
+func BenchmarkLowCardinalityAppend_String_10000x26(b *testing.B) {
+	col := newBenchLowCardinalityColumn(b, "LowCardinality(String)")
+	benchLowCardinalityAppend(b, col, makeLCStrings(10000, 26))
+}
+
+func BenchmarkLowCardinalityAppend_StringPtr_1000x26(b *testing.B) {
+	col := newBenchLowCardinalityColumn(b, "LowCardinality(Nullable(String))")
+	benchLowCardinalityAppend(b, col, makeLCStringPtrs(1000, 26, 0))
+}
+
+func BenchmarkLowCardinalityAppend_StringPtr_1000x26_WithNulls(b *testing.B) {
+	col := newBenchLowCardinalityColumn(b, "LowCardinality(Nullable(String))")
+	benchLowCardinalityAppend(b, col, makeLCStringPtrs(1000, 26, 4))
+}
+
+func BenchmarkLowCardinalityAppend_StringPtr_10000x26(b *testing.B) {
+	col := newBenchLowCardinalityColumn(b, "LowCardinality(Nullable(String))")
+	benchLowCardinalityAppend(b, col, makeLCStringPtrs(10000, 26, 0))
 }

--- a/lib/column/lowcardinality_test.go
+++ b/lib/column/lowcardinality_test.go
@@ -130,6 +130,68 @@ func TestLowCardinalityAppendManyRowsWithoutPanic(t *testing.T) {
 	assert.Equal(t, 1000, lc.Rows())
 }
 
+func TestLowCardinalityAppend_StringBulkMatchesRowByRow(t *testing.T) {
+	data := []string{"a", "a", "b", "c", "a"}
+
+	bulkCol, err := Type("LowCardinality(String)").Column("test", nil)
+	require.NoError(t, err)
+	bulk := bulkCol.(*LowCardinality)
+	_, err = bulk.Append(data)
+	require.NoError(t, err)
+
+	rowCol, err := Type("LowCardinality(String)").Column("test", nil)
+	require.NoError(t, err)
+	rowByRow := rowCol.(*LowCardinality)
+	for _, v := range data {
+		require.NoError(t, rowByRow.AppendRow(v))
+	}
+
+	require.Equal(t, len(data), bulk.Rows())
+	require.Equal(t, bulk.Rows(), rowByRow.Rows())
+	require.Equal(t, len(rowByRow.append.index), len(bulk.append.index))
+	require.Equal(t, 3, len(bulk.append.index), "dictionary should hold the 3 distinct values")
+
+	assert.Equal(t, encodeColumnBytes(t, rowByRow), encodeColumnBytes(t, bulk))
+}
+
+func TestLowCardinalityAppend_StringPtrEmbeddedNils(t *testing.T) {
+	p := func(s string) *string { return &s }
+	a1, a2 := p("a"), p("a")
+	data := []*string{a1, nil, a2, p("b"), nil}
+
+	col, err := Type("LowCardinality(Nullable(String))").Column("test", nil)
+	require.NoError(t, err)
+	lc := col.(*LowCardinality)
+
+	_, err = lc.Append(data)
+	require.NoError(t, err)
+
+	require.Equal(t, 5, lc.Rows())
+	assert.Equal(t, 2, len(lc.append.index),
+		"appendLCPtr should dedupe by value, not by *string identity")
+
+	var buf chproto.Buffer
+	lc.Encode(&buf)
+
+	deref := func(v any) any {
+		if v == nil {
+			return nil
+		}
+		if p, ok := v.(*string); ok {
+			if p == nil {
+				return nil
+			}
+			return *p
+		}
+		return v
+	}
+	assert.Equal(t, "a", deref(lc.Row(0, false)))
+	assert.Nil(t, deref(lc.Row(1, false)))
+	assert.Equal(t, "a", deref(lc.Row(2, false)))
+	assert.Equal(t, "b", deref(lc.Row(3, false)))
+	assert.Nil(t, deref(lc.Row(4, false)))
+}
+
 const lcBenchResetEveryN = 1024
 
 func newBenchLowCardinalityColumn(b *testing.B, chType string) *LowCardinality {


### PR DESCRIPTION
## Summary
When doing Append for Array or LowCardinality column types, the library  calls AppendRow for each element, which in turn causes a new allocation  per element. This PR fixes the issue by introducing a typed appendBulk  methods, reducing the number of allocations per Append call to a constant.
````
goos: darwin
goarch: arm64
pkg: github.com/ClickHouse/clickhouse-go/v2/lib/column
cpu: Apple M3 Pro
                                                    │ /tmp/bench_baseline.txt │      /tmp/bench_optimized.txt      │
                                                    │         sec/op          │   sec/op     vs base               │
ArrayAppend_Int64_100x10-12                                     18.364µ ± 10%   2.578µ ± 2%  -85.96% (p=0.002 n=6)
ArrayAppend_Int64_1000x10-12                                    194.71µ ±  5%   25.74µ ± 5%  -86.78% (p=0.002 n=6)
ArrayAppend_Int64_100x100-12                                    163.62µ ±  3%   22.84µ ± 1%  -86.04% (p=0.002 n=6)
ArrayAppend_String_100x10-12                                    24.577µ ±  2%   4.708µ ± 7%  -80.85% (p=0.002 n=6)
ArrayAppend_String_1000x10-12                                   281.07µ ±  2%   49.80µ ± 3%  -82.28% (p=0.002 n=6)
ArrayAppend_NullableInt64_100x10-12                             14.964µ ±  1%   4.441µ ± 1%  -70.32% (p=0.002 n=6)
ArrayAppend_NullableInt64_1000x10-12                            161.76µ ±  3%   48.15µ ± 5%  -70.24% (p=0.002 n=6)
LowCardinalityAppend_String_1000x26-12                           40.59µ ±  8%   12.47µ ± 3%  -69.28% (p=0.002 n=6)
LowCardinalityAppend_String_1000x1000-12                         39.85µ ±  0%   11.68µ ± 3%  -70.69% (p=0.002 n=6)
LowCardinalityAppend_String_10000x26-12                          421.0µ ±  5%   125.1µ ± 6%  -70.29% (p=0.002 n=6)
LowCardinalityAppend_StringPtr_1000x26-12                        22.20µ ±  1%   12.37µ ± 1%  -44.31% (p=0.002 n=6)
LowCardinalityAppend_StringPtr_1000x26_WithNulls-12             21.647µ ±  2%   9.736µ ± 1%  -55.02% (p=0.002 n=6)
LowCardinalityAppend_StringPtr_10000x26-12                       286.5µ ±  1%   133.1µ ± 7%  -53.53% (p=0.002 n=6)
geomean                                                          69.71µ         18.09µ       -74.05%

                                                    │ /tmp/bench_baseline.txt │       /tmp/bench_optimized.txt        │
                                                    │          B/op           │     B/op       vs base                │
ArrayAppend_Int64_100x10-12                                     12.430Ki ± 2%   9.370Ki ±  0%   -24.62% (p=0.002 n=6)
ArrayAppend_Int64_1000x10-12                                     391.6Ki ± 5%   130.2Ki ±  1%   -66.75% (p=0.002 n=6)
ArrayAppend_Int64_100x100-12                                     305.2Ki ± 5%   122.5Ki ±  1%   -59.87% (p=0.002 n=6)
ArrayAppend_String_100x10-12                                     25.97Ki ± 0%   18.68Ki ±  1%   -28.07% (p=0.002 n=6)
ArrayAppend_String_1000x10-12                                   1121.4Ki ± 2%   348.3Ki ±  2%   -68.94% (p=0.002 n=6)
ArrayAppend_NullableInt64_100x10-12                              4.446Ki ± 1%   9.676Ki ±  0%  +117.63% (p=0.002 n=6)
ArrayAppend_NullableInt64_1000x10-12                             291.1Ki ± 9%   169.9Ki ±  3%   -41.63% (p=0.002 n=6)
LowCardinalityAppend_String_1000x26-12                          20.407Ki ± 4%   1.520Ki ±  4%   -92.55% (p=0.002 n=6)
LowCardinalityAppend_String_1000x1000-12                        20.406Ki ± 1%   1.604Ki ±  4%   -92.14% (p=0.002 n=6)
LowCardinalityAppend_String_10000x26-12                          604.9Ki ± 2%   185.4Ki ±  5%   -69.35% (p=0.002 n=6)
LowCardinalityAppend_StringPtr_1000x26-12                        2.639Ki ± 3%   1.544Ki ±  4%   -41.48% (p=0.002 n=6)
LowCardinalityAppend_StringPtr_1000x26_WithNulls-12              2.511Ki ± 2%   1.188Ki ±  2%   -52.66% (p=0.002 n=6)
LowCardinalityAppend_StringPtr_10000x26-12                       396.6Ki ± 2%   185.1Ki ± 10%   -53.33% (p=0.002 n=6)
geomean                                                          54.46Ki        21.76Ki         -60.04%

                                                    │ /tmp/bench_baseline.txt │         /tmp/bench_optimized.txt         │
                                                    │        allocs/op        │  allocs/op    vs base                    │
ArrayAppend_Int64_100x10-12                                   1100.000 ± 0%      3.000 ±  0%   -99.73% (p=0.002 n=6)
ArrayAppend_Int64_1000x10-12                                 11000.000 ± 0%      3.000 ±  0%   -99.97% (p=0.002 n=6)
ArrayAppend_Int64_100x100-12                                 10100.000 ± 0%      3.000 ±  0%   -99.97% (p=0.002 n=6)
ArrayAppend_String_100x10-12                                  1100.000 ± 0%      3.000 ±  0%   -99.73% (p=0.002 n=6)
ArrayAppend_String_1000x10-12                                11000.000 ± 0%      3.000 ±  0%   -99.97% (p=0.002 n=6)
ArrayAppend_NullableInt64_100x10-12                            100.000 ± 0%      3.000 ±  0%   -97.00% (p=0.002 n=6)
ArrayAppend_NullableInt64_1000x10-12                          1000.000 ± 0%      3.000 ±  0%   -99.70% (p=0.002 n=6)
LowCardinalityAppend_String_1000x26-12                          1.000k ± 0%     0.000k ±  0%  -100.00% (p=0.002 n=6)
LowCardinalityAppend_String_1000x1000-12                      1000.000 ± 0%      1.500 ± 33%   -99.85% (p=0.002 n=6)
LowCardinalityAppend_String_10000x26-12                         10.00k ± 0%      0.00k ±  0%  -100.00% (p=0.002 n=6)
LowCardinalityAppend_StringPtr_1000x26-12                        0.000 ± 0%      0.000 ±  0%         ~ (p=1.000 n=6) ¹
LowCardinalityAppend_StringPtr_1000x26_WithNulls-12              0.000 ± 0%      0.000 ±  0%         ~ (p=1.000 n=6) ¹
LowCardinalityAppend_StringPtr_10000x26-12                       0.000 ± 0%      0.000 ±  0%         ~ (p=1.000 n=6) ¹
geomean                                                                     ²                 ?                      ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

```