### PR TITLE
chore: make Test1229 less flaky

### DIFF
--- a/tests/issues/1229_test.go
+++ b/tests/issues/1229_test.go
@@ -15,13 +15,19 @@ import (
 )
 
 func Test1229(t *testing.T) {
-	const queryTimeout = 2 * time.Second
+	const (
+		queryTimeout = 2 * time.Second
+		concurrency  = 100
+	)
 
 	var (
-		conn, err = clickhouse_tests.GetConnectionTCP("issues", clickhouse.Settings{
+		conn, err = clickhouse_tests.GetConnectionTCPWithOptions("issues", clickhouse.Settings{
 			"max_execution_time": 60,
 		}, nil, &clickhouse.Compression{
 			Method: clickhouse.CompressionLZ4,
+		}, func(o *clickhouse.Options) {
+			o.MaxOpenConns = concurrency
+			o.MaxIdleConns = concurrency
 		})
 	)
 	require.NoError(t, err)
@@ -34,7 +40,7 @@ func Test1229(t *testing.T) {
 	}()
 
 	const insertQuery = "INSERT INTO test_1229 VALUES ('test1value%d', 'test2value%d')"
-	for i := 0; i < 100; i++ {
+	for i := 0; i < concurrency; i++ {
 		withTimeoutCtx, cancel := context.WithTimeout(ctx, queryTimeout)
 		require.NoError(t, conn.Exec(withTimeoutCtx, fmt.Sprintf(insertQuery, i, i)))
 		cancel()
@@ -42,15 +48,16 @@ func Test1229(t *testing.T) {
 
 	wg := new(sync.WaitGroup)
 	const selectQuery = "SELECT test1, test2 FROM test_1229"
-	for i := 0; i < 100; i++ {
+	errTestQueryTimeout := fmt.Errorf("Test1229: query budget %s exceeded", queryTimeout)
+	for i := 0; i < concurrency; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			withTimeoutCtx, cancel := context.WithTimeout(ctx, queryTimeout)
+			withTimeoutCtx, cancel := context.WithTimeoutCause(ctx, queryTimeout, errTestQueryTimeout)
 			defer cancel()
 			rows, err := conn.Query(withTimeoutCtx, selectQuery)
-			require.NoError(t, err)
-			require.NoError(t, rows.Close())
+			require.NoErrorf(t, err, "query failed; ctx cause=%v", context.Cause(withTimeoutCtx))
+			require.NoErrorf(t, rows.Close(), "rows.Close failed; ctx cause=%v", context.Cause(withTimeoutCtx))
 		}()
 	}
 

--- a/tests/issues/1229_test.go
+++ b/tests/issues/1229_test.go
@@ -16,7 +16,7 @@ import (
 
 func Test1229(t *testing.T) {
 	const (
-		queryTimeout = 2 * time.Second
+		queryTimeout = 4 * time.Second
 		concurrency  = 100
 	)
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -371,6 +371,18 @@ func GetConnectionTCP(testSet string, settings clickhouse.Settings, tlsConfig *t
 	return getConnection(env, env.Database, settings, tlsConfig, compression)
 }
 
+// GetConnectionTCPWithOptions is like GetConnectionTCP but allows the caller to mutate
+// the final clickhouse.Options before the connection is opened — useful for adjusting
+// pool sizing, timeouts, or any field not already exposed by the helper signature.
+func GetConnectionTCPWithOptions(testSet string, settings clickhouse.Settings, tlsConfig *tls.Config, compression *clickhouse.Compression, mutate func(*clickhouse.Options)) (driver.Conn, error) {
+	env, err := GetTestEnvironment(testSet)
+	if err != nil {
+		return nil, err
+	}
+
+	return getConnectionWithMutator(env, env.Database, settings, tlsConfig, compression, mutate)
+}
+
 func GetConnectionHTTP(testSet string, sessionName string, settings clickhouse.Settings, tlsConfig *tls.Config, compression *clickhouse.Compression) (driver.Conn, error) {
 	env, err := GetTestEnvironment(testSet)
 	if err != nil {
@@ -410,6 +422,10 @@ func GetConnectionWithOptions(options *clickhouse.Options) (driver.Conn, error) 
 }
 
 func getConnection(env ClickHouseTestEnvironment, database string, settings clickhouse.Settings, tlsConfig *tls.Config, compression *clickhouse.Compression) (driver.Conn, error) {
+	return getConnectionWithMutator(env, database, settings, tlsConfig, compression, nil)
+}
+
+func getConnectionWithMutator(env ClickHouseTestEnvironment, database string, settings clickhouse.Settings, tlsConfig *tls.Config, compression *clickhouse.Compression, mutate func(*clickhouse.Options)) (driver.Conn, error) {
 	useSSL, err := strconv.ParseBool(GetEnv("CLICKHOUSE_USE_SSL", "false"))
 	if err != nil {
 		panic(err)
@@ -448,7 +464,7 @@ func getConnection(env ClickHouseTestEnvironment, database string, settings clic
 		return nil, err
 	}
 
-	conn, err := clickhouse.Open(&clickhouse.Options{
+	opts := &clickhouse.Options{
 		Protocol: clickhouse.Native,
 		Addr:     []string{fmt.Sprintf("%s:%d", env.Host, port)},
 		Settings: settings,
@@ -460,8 +476,11 @@ func getConnection(env ClickHouseTestEnvironment, database string, settings clic
 		TLS:         tlsConfig,
 		Compression: compression,
 		DialTimeout: time.Duration(timeout) * time.Second,
-	})
-	return conn, err
+	}
+	if mutate != nil {
+		mutate(opts)
+	}
+	return clickhouse.Open(opts)
 }
 
 func getHTTPConnection(env ClickHouseTestEnvironment, sessionName string, database string, settings clickhouse.Settings, tlsConfig *tls.Config, compression *clickhouse.Compression) (driver.Conn, error) {


### PR DESCRIPTION


## Summary
<!-- A short description of the changes with a link to an open issue. -->
Once in a while I see this test case is failing on CI make it bit annoying and forcing to retry.

The source of the flakiness I think comes from connection pool exhatusion.
1. We start 100 goroutines
2. Each with 2 seconds query timeout

But our default max connections is 10. So every other goroutine has to wait before even schedule inflight query. There is high change some of those can go timeout before even start executing.

This PR is an attempt to make it less flaky.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
