### PR TITLE
chore: refactor agent SKILL for code review

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: review-pr
-description: Review a pull request for correctness, API safety, Go idioms, and protocol coverage, then post inline comments plus one updating summary. Use when the user wants to review a PR or diff.
+description: Review a numbered GitHub pull request for correctness, API safety, Go idioms, and protocol coverage, then post inline comments plus one updating summary. Use only when the user asks to review an open PR by number. For a local or pre-PR diff, do not use this skill — apply review-core.md in this directory instead.
 argument-hint: "<PR-number>"
 allowed-tools: Read, Glob, Grep, Bash(grep:*), Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh api:*), Bash(python3:*), Write
 ---
 
-# clickhouse-go Code Review Skill
+# clickhouse-go PR Review Skill
 
-You are a senior `clickhouse-go` maintainer performing a **strict, high-signal review** of a
-pull request. Your job is to catch **real problems** — correctness, resource leaks, concurrency,
-API misuse, protocol gaps, missing tests — and give concise, actionable, line-anchored feedback.
-Avoid noisy comments about style or trivial cleanups.
+Reviews an open GitHub pull request and posts the findings. The review criteria — the review
+gates, the clickhouse-go supporting checks, and the severity model — live in
+[`review-core.md`](review-core.md) in this directory. **Read `review-core.md` first and apply
+it**; this file adds only the GitHub plumbing: fetching the PR, the findings JSON schema, and
+posting.
+
+Reviewing a local diff with no PR (e.g. before opening one)? Use `review-core.md` directly and
+report findings as plain text — none of the JSON/posting machinery below applies.
 
 ## Arguments
 
@@ -34,7 +38,7 @@ If `existing-threads.json` is present (the CI workflow writes it; create it for 
 with `python3 .claude/skills/review-pr/post_review.py fetch --repo ClickHouse/clickhouse-go --pr "$0" > existing-threads.json`),
 `Read` it. It lists the review threads you already started, each with its prior comment(s), any
 author replies, and `is_resolved`/`is_outdated` state. For **every** open (`is_resolved: false`)
-thread, decide an action (section 5, `thread_actions`):
+thread, decide an action (section 3, `thread_actions`):
 
 - The author replied with a question or pushback that still stands → **reply** addressing it.
 - The concern is now addressed (the current code satisfies it, or the author's reply adequately
@@ -45,69 +49,13 @@ thread, decide an action (section 5, `thread_actions`):
 Do **not** raise a brand-new `findings` entry for a line that already has one of your threads — use
 a `thread_actions` reply instead, or the poster will skip it as a duplicate.
 
-## 2. Review gates
+## 2. Review the change
 
-These are the questions you must answer before settling on a verdict. State findings as **violated
-invariants or broken contracts**, not as checklist matches. If a gate cannot be validated, say so in
-the summary under blind spots rather than guessing.
+Work through the review gates and the clickhouse-go supporting checks from
+[`review-core.md`](review-core.md), and grade each finding with its severity model. Anchor each
+finding to a specific changed line where possible.
 
-1. **Contract** — Derive what the PR promises from its title, description, tests, and code shape.
-   A `Bug Fix` promises the bug is fixed *and* covered by a regression test; a perf change promises a
-   measured benefit. Frame findings as "X promises Y, but Z breaks it."
-2. **Impacted surface** — Follow the changed behavior through unchanged callers/callees, both the
-   **native (`Open`)** and **`database/sql` (`OpenDB`)** surfaces, and both the **native TCP** and
-   **HTTP** protocol paths. A change to one path that should apply to the other is a finding.
-3. **Failure & lifecycle** — Check error paths, cancellation, and resource lifecycle: is every
-   `Rows`, `Batch`, and `Conn` closed/aborted on **every** path including errors? Is the `Batch`
-   lifecycle (`Append` → `Send`/`Abort`) preserved? Is `context.Context` the first parameter and
-   never stored in a struct?
-4. **Evidence** — Map each material claim to proof. Correctness fixes need a regression test in
-   `tests/issues/issue_<N>_test.go`; new type support needs a column impl + round-trip test +
-   example. Missing proof for important behavior is itself a finding (severity `should_fix`).
-
-When you find one serious invariant failure, fan out **once** through sibling paths sharing the same
-cause (other column types, the other protocol, the other API surface) before concluding.
-
-**Use concrete traces.** If callee logic looks suspicious, trace a minimal input through it with
-concrete values. Do not dismiss it with abstract reasoning ("probably safe because…"). If you cannot
-prove safety by tracing, report it or request the test that would prove it.
-
-## 3. clickhouse-go supporting checks
-
-Use these to surface project-specific invariants; the finding should name the broken behavior, not
-just cite the rule.
-
-- **Errors** — never swallowed with `_`; wrapped with `%w` to preserve the chain; strings lowercase,
-  no trailing punctuation; no `panic` outside `init()`-style invariant checks; messages actionable
-  for the end user.
-- **Concurrency** — no unsynchronized shared state; a struct holding a mutex (e.g. `batch`) is never
-  copied by value; goroutines have a documented exit/stop path.
-- **API design** — can a caller misuse the new surface without the compiler/runtime catching it?
-  Does it silently break existing callers (prefer deprecation over removal)? Are new exported
-  symbols necessary, or expressible with existing primitives? Do new interfaces sit at the point of
-  consumption? Is the zero value of new structs safe / a sensible default?
-- **Go idioms** — acronyms keep case (`URL`, `HTTP`, `ID`); short receiver names, never `self`/`this`;
-  `mixedCaps` not `ALL_CAPS` for unexported constants; imports grouped stdlib → external → internal.
-- **Tests** — would the test have caught the bug? Are they table-driven with messages stating
-  input / expected / got? **No mocking** of `driver.Conn`/`driver.Rows` in `/tests/` — use a real
-  ClickHouse via testcontainers. Cover **both** TCP and HTTP, and **both** native and `std` APIs.
-- **Docs** — new exported symbols have full-sentence doc comments beginning with the symbol name;
-  SQL types/functions in prose wrapped in backticks; examples added/updated for new behavior. Do not
-  flag missing error handling in *example* code inside comments.
-
-## 4. Severity model
-
-- `must_fix` — incorrectness, data loss, resource/goroutine leaks, data races/deadlocks, silent
-  breaking changes to a public API or protocol, security issues.
-- `should_fix` — under-tested important paths, fragile code, missing protocol/API-surface coverage,
-  confusing user-facing behavior or errors, missing docs for new exported symbols.
-- `nit` — minor clarity/naming/idiom issues. Prefix the body with `nit:`. Keep these rare; do not let
-  them crowd out real findings.
-
-Omit speculative refactors, pure formatting, and bikeshedding. Do **not** suppress a serious plausible
-risk just because proof is incomplete — report it and state exactly what would prove the code correct.
-
-## 5. Output: write the findings JSON
+## 3. Output: write the findings JSON
 
 Anchor every finding you can to a specific changed line so it becomes an **inline** comment. Write
 the result to `claude-review.json` (in the repo root) with this exact schema:
@@ -217,7 +165,7 @@ Rules for the JSON:
 - If there are no findings, emit empty arrays and an `approve` verdict with a one-line summary.
 - Do not invent line numbers. When unsure of the exact line, use `general_findings`.
 
-## 6. Post the review
+## 4. Post the review
 
 The CI workflow posts the JSON automatically as a separate step. When running **interactively**, post
 it yourself:

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -114,7 +114,7 @@ the result to `claude-review.json` (in the repo root) with this exact schema:
 
 ```json
 {
-  "summary": "One short paragraph: what the PR does and your high-level verdict. Note any blind spots.",
+  "summary": "Structured markdown (see 'Writing the summary' below): a short intro line, then short paragraphs and/or bullet lists. Use `\\n` for line breaks. Cover what the PR does, the high-level verdict, and any blind spots.",
   "verdict": "approve | request_changes | needs_discussion",
   "findings": [
     {
@@ -146,6 +146,34 @@ the result to `claude-review.json` (in the repo root) with this exact schema:
 `thread_actions` is only for re-reviews where `existing-threads.json` listed open threads; copy
 `thread_id` and `root_comment_id` verbatim from that file. Omit the array (or leave it empty) on a
 first review. The poster skips replies it has already posted, so re-running is safe.
+
+### Writing the summary
+
+The `summary` string is rendered verbatim as markdown in the PR comment, so format it for fast
+scanning — **never a single dense paragraph**. Keep it tight; the inline comments carry the detail.
+
+- Lead with **one or two sentences** stating what the PR does and the overall verdict.
+- Break the rest into **short paragraphs** (2–3 sentences each) separated by a blank line (`\n\n`),
+  one idea per paragraph.
+- Use a **bullet list** (`\n` between `- ` items) whenever you are enumerating things — affected
+  surfaces, blind spots, follow-ups, or the key issues driving the verdict. Bullets beat prose for
+  any list of two or more items.
+- Bold short inline labels (e.g. `**Blind spots:**`) to anchor sections when it aids skimming.
+- Do not restate every inline finding here; reference them collectively and highlight only what
+  shapes the verdict.
+
+Example shape (adapt freely):
+
+```
+Adds `DateTime64` scale handling to the native path. The core change is sound, but the HTTP
+path is left uncovered.
+
+**Key concerns:**
+- Scale > 9 silently overflows (see inline on `lib/column/datetime64.go`).
+- No regression test for the `std` API surface.
+
+**Blind spots:** could not validate the HTTP round-trip without a live server.
+```
 
 Rules for the JSON:
 - `line` is the line number in the **new** version of the file, and **must** be a line that appears

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -122,7 +122,7 @@ the result to `claude-review.json` (in the repo root) with this exact schema:
       "line": 142,
       "severity": "must_fix",
       "title": "short imperative title",
-      "body": "What invariant is broken and its impact. Include a minimal suggested fix as a ```suggestion``` block or diff when helpful."
+      "body": "Structured markdown (see 'Writing inline comments' below): lead with one sentence naming the broken invariant and its impact, then bullets when there is more than one point, then a ```suggestion``` block or diff for the fix. Use `\\n` for line breaks. Keep it short."
     }
   ],
   "general_findings": [
@@ -174,6 +174,39 @@ path is left uncovered.
 
 **Blind spots:** could not validate the HTTP round-trip without a live server.
 ```
+
+### Writing inline comments
+
+Each finding's `body` renders as markdown directly beneath a bold severity + title header that
+the poster prepends (`**❌ Must fix** — <title>`), so do **not** repeat the title or severity in the
+body. Apply the same scan-first discipline as the summary: a reviewer reading the comment on the line
+should grasp the problem and the fix in one pass. **Never a single dense block of prose.**
+
+- Lead with **one sentence** naming the broken invariant and its concrete impact — e.g. "Scale > 9
+  overflows the `int32` multiplier, so sub-second values silently truncate." No preamble ("I noticed
+  that…", "It looks like…"); state the problem directly.
+- Keep the whole comment **tight** (aim for under ~6 lines). The reviewer needs the bug and the fix,
+  not exhaustive reasoning — push deep rationale to the summary or omit it.
+- When the body has **more than one distinct point** (root cause, an affected sibling path, a test
+  gap), use a **short bullet list** (`\n` between `- ` items) instead of stringing them into one
+  paragraph. One point → one sentence is fine; don't pad it into bullets.
+- Put any concrete fix in a ```suggestion``` block (GitHub applies it in one click) or a fenced diff,
+  separated from the prose by a blank line (`\n\n`). Suggestion blocks must contain only the
+  replacement line(s) for the commented range.
+
+Example shape (indented here to show the literal markdown, including a nested suggestion block):
+
+    `Send()` doesn't reset `b.sent` under the lock, so a concurrent `Append` races the flag and
+    can slip a row into an already-sent batch.
+
+    - The read in `Append` (line 88) is unsynchronized against this write.
+    - The `std` wrapper hits the same path via `ExecContext`.
+
+    ```suggestion
+        b.mu.Lock()
+        b.sent = true
+        b.mu.Unlock()
+    ```
 
 Rules for the JSON:
 - `line` is the line number in the **new** version of the file, and **must** be a line that appears

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,78 +1,141 @@
 ---
 name: review-pr
-description: Review a pull request and post structured feedback as a comment.
+description: Review a pull request for correctness, API safety, Go idioms, and protocol coverage, then post inline comments plus one updating summary. Use when the user wants to review a PR or diff.
 argument-hint: "<PR-number>"
-allowed-tools: Read, Glob, Bash(grep:*), Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr comment:*)
+allowed-tools: Read, Glob, Grep, Bash(grep:*), Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh api:*), Bash(python3:*), Write
 ---
 
-Review the pull request and provide structured feedback.
+# clickhouse-go Code Review Skill
 
-## How to fetch the PR
+You are a senior `clickhouse-go` maintainer performing a **strict, high-signal review** of a
+pull request. Your job is to catch **real problems** — correctness, resource leaks, concurrency,
+API misuse, protocol gaps, missing tests — and give concise, actionable, line-anchored feedback.
+Avoid noisy comments about style or trivial cleanups.
 
-If given a PR number or URL, use `gh pr diff <number>` to get the diff and `gh pr view <number>` to get the description. Read any referenced issues for context.
+## Arguments
 
-## Review structure
+- `$0` (required): PR number (e.g. `1869`).
 
-Return feedback in this order:
+## 1. Obtain the diff and context
 
-1. **Summary** — one paragraph: what the PR does, why it exists, whether the approach is sound.
-2. **Must fix** — blocking issues; the PR should not merge until these are resolved.
-3. **Should fix** — non-blocking but important (correctness risks, API design concerns, missing tests).
-4. **Nits** — style, naming, minor clarity improvements. Prefix each with `nit:`.
-5. **Verdict** — one of: `Approve`, `Request changes`, or `Needs discussion`.
+```bash
+gh pr view "$0" --json title,body,headRefName,baseRefName,author,url
+gh pr diff "$0"
+```
 
-If a section has no items, omit it.
+- Read the title, description, and any linked issues for the intended behavior.
+- For each changed file, `Read` the surrounding code when the diff alone is insufficient to judge
+  the change — a finding is only valid if you understand the code it touches.
+- If the diff is large (>2000 lines), use the `Explore` agent to analyze parts in parallel.
 
----
+## 2. Review gates
 
-## Checklist
+These are the questions you must answer before settling on a verdict. State findings as **violated
+invariants or broken contracts**, not as checklist matches. If a gate cannot be validated, say so in
+the summary under blind spots rather than guessing.
 
-Work through each category before writing the review.
+1. **Contract** — Derive what the PR promises from its title, description, tests, and code shape.
+   A `Bug Fix` promises the bug is fixed *and* covered by a regression test; a perf change promises a
+   measured benefit. Frame findings as "X promises Y, but Z breaks it."
+2. **Impacted surface** — Follow the changed behavior through unchanged callers/callees, both the
+   **native (`Open`)** and **`database/sql` (`OpenDB`)** surfaces, and both the **native TCP** and
+   **HTTP** protocol paths. A change to one path that should apply to the other is a finding.
+3. **Failure & lifecycle** — Check error paths, cancellation, and resource lifecycle: is every
+   `Rows`, `Batch`, and `Conn` closed/aborted on **every** path including errors? Is the `Batch`
+   lifecycle (`Append` → `Send`/`Abort`) preserved? Is `context.Context` the first parameter and
+   never stored in a struct?
+4. **Evidence** — Map each material claim to proof. Correctness fixes need a regression test in
+   `tests/issues/issue_<N>_test.go`; new type support needs a column impl + round-trip test +
+   example. Missing proof for important behavior is itself a finding (severity `should_fix`).
 
-### Correctness
-- [ ] Does the logic handle error cases? Are errors returned (not swallowed with `_`)?
-- [ ] Are all `Rows`, `Batch`, and `Conn` values closed on every code path, including error paths?
-- [ ] Are there data races? Does any shared state lack synchronisation?
-- [ ] Does the `Batch` lifecycle (`Append` → `Send` or `Abort`) hold on every path?
-- [ ] Is `context.Context` propagated correctly (first param, never stored in a struct)?
+When you find one serious invariant failure, fan out **once** through sibling paths sharing the same
+cause (other column types, the other protocol, the other API surface) before concluding.
 
-### API design — easy to use correctly, hard to use incorrectly
-- [ ] Can a caller misuse the new API without the compiler or runtime catching it?
-- [ ] Does the change silently break any existing callers? Prefer deprecation over removal.
-- [ ] Are new exported types/functions/methods necessary? Could this be done with existing primitives?
-- [ ] Do new interfaces belong at the point of consumption, not implementation?
-- [ ] Is the zero value of any new struct useful or at least safe?
+**Use concrete traces.** If callee logic looks suspicious, trace a minimal input through it with
+concrete values. Do not dismiss it with abstract reasoning ("probably safe because…"). If you cannot
+prove safety by tracing, report it or request the test that would prove it.
 
-### Go idioms
-- [ ] Error strings: lowercase, no trailing punctuation.
-- [ ] Acronyms in names: `URL`, `HTTP`, `ID` — not `Url`, `Http`, `Id`.
-- [ ] Receiver names: short abbreviation, never `self` or `this`.
-- [ ] No `context.Context` stored in struct fields.
-- [ ] No `panic` outside of `init()`-style invariant checks.
-- [ ] Imports: stdlib → external → internal, blank line between groups.
-- [ ] New types that contain a mutex are not copied by value.
-- [ ] `mixedCaps` for unexported constants, not `ALL_CAPS`.
+## 3. clickhouse-go supporting checks
 
-### Tests
-- [ ] Is there a test that would have caught the bug being fixed?
-- [ ] Bug fixes: is there a regression test in `tests/issues/issue_<N>_test.go`?
-- [ ] New ClickHouse type support: column implementation + round-trip test + example?
-- [ ] Do test failure messages say what was wrong, what input triggered it, and what was expected vs. got?
-- [ ] Are tests table-driven where there are multiple cases?
-- [ ] No test mocking of `driver.Conn` or `driver.Rows` for integrations tests inside root `/tests/` — use a real ClickHouse via testcontainers.
-- [ ] Make sure tests are covered for both TCP and HTTP protocol cases.
-- [ ] Make sure tests are covered for both `clickhouse_native` (Open() api returns) api and `std` api (OpenDB() api returns).
+Use these to surface project-specific invariants; the finding should name the broken behavior, not
+just cite the rule.
 
-### Performance & protocol
-- [ ] Does the change avoid unnecessary allocations in hot paths (encoding/decoding columns)?
-- [ ] Are new `Options` fields safe to ignore when unset (i.e., the zero value is the sensible default)?
-- [ ] Does the change affect both the native TCP and HTTP protocol paths? If so, are both covered?
+- **Errors** — never swallowed with `_`; wrapped with `%w` to preserve the chain; strings lowercase,
+  no trailing punctuation; no `panic` outside `init()`-style invariant checks; messages actionable
+  for the end user.
+- **Concurrency** — no unsynchronized shared state; a struct holding a mutex (e.g. `batch`) is never
+  copied by value; goroutines have a documented exit/stop path.
+- **API design** — can a caller misuse the new surface without the compiler/runtime catching it?
+  Does it silently break existing callers (prefer deprecation over removal)? Are new exported
+  symbols necessary, or expressible with existing primitives? Do new interfaces sit at the point of
+  consumption? Is the zero value of new structs safe / a sensible default?
+- **Go idioms** — acronyms keep case (`URL`, `HTTP`, `ID`); short receiver names, never `self`/`this`;
+  `mixedCaps` not `ALL_CAPS` for unexported constants; imports grouped stdlib → external → internal.
+- **Tests** — would the test have caught the bug? Are they table-driven with messages stating
+  input / expected / got? **No mocking** of `driver.Conn`/`driver.Rows` in `/tests/` — use a real
+  ClickHouse via testcontainers. Cover **both** TCP and HTTP, and **both** native and `std` APIs.
+- **Docs** — new exported symbols have full-sentence doc comments beginning with the symbol name;
+  SQL types/functions in prose wrapped in backticks; examples added/updated for new behavior. Do not
+  flag missing error handling in *example* code inside comments.
 
-### Documentation
-- [ ] Are new exported symbols documented with a full-sentence doc comment beginning with the symbol name?
-- [ ] ClickHouse SQL types and function names wrapped in backticks in any prose.
-- [ ] Make sure existing docs and examples are updated.
-- [ ] Make sure new docs and examples are added if needed for new features or bug fixes.
-- [ ] Make sure the docs are covered for both TCP and HTTP protocol cases.
-- [ ] Make sure the docs are covered for both `clickhouse_native` (Open() api returns) api and `std` api (OpenDB() api returns).
-- [ ] If a comment or doc comment includes usage examples (e.g. inline code blocks), it is acceptable to omit error checking. Do not flag missing error handling in example code. 
+## 4. Severity model
+
+- `must_fix` — incorrectness, data loss, resource/goroutine leaks, data races/deadlocks, silent
+  breaking changes to a public API or protocol, security issues.
+- `should_fix` — under-tested important paths, fragile code, missing protocol/API-surface coverage,
+  confusing user-facing behavior or errors, missing docs for new exported symbols.
+- `nit` — minor clarity/naming/idiom issues. Prefix the body with `nit:`. Keep these rare; do not let
+  them crowd out real findings.
+
+Omit speculative refactors, pure formatting, and bikeshedding. Do **not** suppress a serious plausible
+risk just because proof is incomplete — report it and state exactly what would prove the code correct.
+
+## 5. Output: write the findings JSON
+
+Anchor every finding you can to a specific changed line so it becomes an **inline** comment. Write
+the result to `claude-review.json` (in the repo root) with this exact schema:
+
+```json
+{
+  "summary": "One short paragraph: what the PR does and your high-level verdict. Note any blind spots.",
+  "verdict": "approve | request_changes | needs_discussion",
+  "findings": [
+    {
+      "path": "lib/column/date.go",
+      "line": 142,
+      "severity": "must_fix",
+      "title": "short imperative title",
+      "body": "What invariant is broken and its impact. Include a minimal suggested fix as a ```suggestion``` block or diff when helpful."
+    }
+  ],
+  "general_findings": [
+    {
+      "severity": "should_fix",
+      "title": "missing HTTP-path regression test",
+      "body": "Findings that are NOT anchorable to a changed line (cross-cutting, or about code outside the diff). These render in the summary comment."
+    }
+  ]
+}
+```
+
+Rules for the JSON:
+- `line` is the line number in the **new** version of the file, and **must** be a line that appears
+  in the diff (added or context). If a finding concerns code not in the diff, put it in
+  `general_findings` instead — the poster will reject off-diff inline lines and demote them anyway,
+  but placing them correctly keeps the output clean.
+- One finding per distinct issue. Group issues that share a single root cause into one finding.
+- If there are no findings, emit empty arrays and an `approve` verdict with a one-line summary.
+- Do not invent line numbers. When unsure of the exact line, use `general_findings`.
+
+## 6. Post the review
+
+The CI workflow posts the JSON automatically as a separate step. When running **interactively**, post
+it yourself:
+
+```bash
+python3 .claude/skills/review-pr/post_review.py --repo ClickHouse/clickhouse-go --pr "$0" --input claude-review.json
+```
+
+`post_review.py` is idempotent: it attaches inline comments to the relevant lines, skips findings it
+already posted (so re-reviews do not duplicate), demotes any off-diff finding into the summary, and
+updates a single summary comment in place instead of stacking new ones.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -8,10 +8,12 @@ allowed-tools: Read, Glob, Grep, Bash(grep:*), Bash(gh pr view:*), Bash(gh pr di
 # clickhouse-go PR Review Skill
 
 Reviews an open GitHub pull request and posts the findings. The review criteria — the review
-gates, the clickhouse-go supporting checks, and the severity model — live in
-[`review-core.md`](review-core.md) in this directory. **Read `review-core.md` first and apply
-it**; this file adds only the GitHub plumbing: fetching the PR, the findings JSON schema, and
-posting.
+gates, the clickhouse-go supporting checks, and the severity model — are defined in
+@.claude/skills/review-pr/review-core.md. When this skill is invoked as `/review-pr` from the
+repo root, that reference injects the file into context automatically; if the core content is
+not already in your context (e.g. you were pointed at this file directly), `Read` that path
+before reviewing. Apply it in full — this file adds only the GitHub plumbing: fetching the PR,
+the findings JSON schema, and posting.
 
 Reviewing a local diff with no PR (e.g. before opening one)? Use `review-core.md` directly and
 report findings as plain text — none of the JSON/posting machinery below applies.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -28,6 +28,23 @@ gh pr diff "$0"
   the change — a finding is only valid if you understand the code it touches.
 - If the diff is large (>2000 lines), use the `Explore` agent to analyze parts in parallel.
 
+### Existing review threads (re-review)
+
+If `existing-threads.json` is present (the CI workflow writes it; create it for interactive runs
+with `python3 .claude/skills/review-pr/post_review.py fetch --repo ClickHouse/clickhouse-go --pr "$0" > existing-threads.json`),
+`Read` it. It lists the review threads you already started, each with its prior comment(s), any
+author replies, and `is_resolved`/`is_outdated` state. For **every** open (`is_resolved: false`)
+thread, decide an action (section 5, `thread_actions`):
+
+- The author replied with a question or pushback that still stands → **reply** addressing it.
+- The concern is now addressed (the current code satisfies it, or the author's reply adequately
+  resolves/declines it) → **resolve** (optionally with a short closing reply).
+- The concern still stands and there is no new author activity → **keep** (no new comment).
+- The thread is `is_outdated` and the underlying concern no longer applies → **resolve**.
+
+Do **not** raise a brand-new `findings` entry for a line that already has one of your threads — use
+a `thread_actions` reply instead, or the poster will skip it as a duplicate.
+
 ## 2. Review gates
 
 These are the questions you must answer before settling on a verdict. State findings as **violated
@@ -114,9 +131,21 @@ the result to `claude-review.json` (in the repo root) with this exact schema:
       "title": "missing HTTP-path regression test",
       "body": "Findings that are NOT anchorable to a changed line (cross-cutting, or about code outside the diff). These render in the summary comment."
     }
+  ],
+  "thread_actions": [
+    {
+      "thread_id": "PRRT_kwDO...",
+      "root_comment_id": 3421542714,
+      "action": "reply | resolve | keep",
+      "reply_body": "Required for action=reply. Optional closing note for action=resolve. Omit for keep."
+    }
   ]
 }
 ```
+
+`thread_actions` is only for re-reviews where `existing-threads.json` listed open threads; copy
+`thread_id` and `root_comment_id` verbatim from that file. Omit the array (or leave it empty) on a
+first review. The poster skips replies it has already posted, so re-running is safe.
 
 Rules for the JSON:
 - `line` is the line number in the **new** version of the file, and **must** be a line that appears
@@ -133,9 +162,10 @@ The CI workflow posts the JSON automatically as a separate step. When running **
 it yourself:
 
 ```bash
-python3 .claude/skills/review-pr/post_review.py --repo ClickHouse/clickhouse-go --pr "$0" --input claude-review.json
+python3 .claude/skills/review-pr/post_review.py post --repo ClickHouse/clickhouse-go --pr "$0" --input claude-review.json
 ```
 
-`post_review.py` is idempotent: it attaches inline comments to the relevant lines, skips findings it
-already posted (so re-reviews do not duplicate), demotes any off-diff finding into the summary, and
-updates a single summary comment in place instead of stacking new ones.
+`post_review.py post` is idempotent: it attaches inline comments to the relevant lines, skips
+findings it already posted (so re-reviews do not duplicate), demotes any off-diff finding into the
+summary, replies into existing threads, resolves addressed/outdated threads, and updates a single
+summary comment in place instead of stacking new ones.

--- a/.claude/skills/review-pr/post_review.py
+++ b/.claude/skills/review-pr/post_review.py
@@ -1,22 +1,34 @@
 #!/usr/bin/env python3
-"""Post a Claude PR review as inline comments plus one updating summary comment.
+"""Deterministic posting half of the clickhouse-go review skill.
 
-This script is the deterministic half of the review skill: Claude produces a
-findings JSON (see SKILL.md for the schema), and this script turns it into a
-GitHub Pull Request *review* with line-anchored inline comments, plus a single
-summary comment that is updated in place on every re-run.
+Claude produces a findings JSON (see SKILL.md for the schema); this script turns
+it into a GitHub Pull Request *review* with line-anchored inline comments, a
+single summary comment that is updated in place, replies into existing comment
+threads, and resolution of threads whose concern has been addressed.
+
+Two subcommands:
+
+  fetch  Dump the review threads this bot already owns on the PR (its prior
+         inline comments plus any human replies, with resolve/outdated state)
+         as JSON. The review step reads this so it can decide, per open thread,
+         whether to reply, resolve, or leave it alone.
+
+  post   Apply a findings JSON: post new inline comments (deduped), update the
+         summary comment in place, reply into threads, and resolve addressed or
+         outdated threads.
 
 Why a script instead of letting the model call the API directly:
   - The Reviews API rejects the *entire* review if any inline comment points at
-    a line that is not part of the diff. The model cannot reliably know which
-    lines are commentable, so we validate every finding against the diff hunks
+    a line not in the diff, so we validate every finding against the diff hunks
     here and demote off-diff findings into the summary instead of failing.
-  - Re-running the review must not spam the PR. We embed a hidden marker in
-    every comment body and skip findings whose marker already exists, and we
-    PATCH the existing summary comment rather than creating a new one.
+  - Re-running must not spam the PR. Every comment carries a hidden marker; we
+    skip findings/replies already posted, PATCH the existing summary rather than
+    stacking a new one, and reply into threads instead of duplicating them.
+  - Resolving a review thread is only possible via the GraphQL
+    `resolveReviewThread` mutation; the REST API cannot do it.
 
-It shells out to `gh api`, which must be authenticated (the workflow provides
-GH_TOKEN). Standard library only — no third-party dependencies.
+Shells out to `gh` (must be authenticated; the workflow provides GH_TOKEN).
+Standard library only — no third-party dependencies.
 """
 
 import argparse
@@ -28,6 +40,9 @@ import sys
 
 SUMMARY_MARKER = "<!-- claude-review:summary -->"
 INLINE_MARKER_RE = re.compile(r"<!-- claude-review:inline:([0-9a-f]{12}) -->")
+REPLY_MARKER_RE = re.compile(r"<!-- claude-review:reply:([0-9a-f]{12}) -->")
+# A thread is "ours" if its root comment carries an inline marker.
+OURS_RE = re.compile(r"<!-- claude-review:(inline|reply):[0-9a-f]{12} -->")
 
 VALID_SEVERITIES = ("must_fix", "should_fix", "nit")
 SEVERITY_LABELS = {
@@ -45,8 +60,8 @@ VERDICT_LABELS = {
 def gh(args, payload=None):
     """Run a `gh` command, optionally piping a JSON payload to stdin.
 
-    Returns parsed JSON when the command emits any, else None. Raises
-    CalledProcessError on failure so the caller can decide whether to abort.
+    Returns parsed JSON when the command emits any, else None. Raises on failure
+    so the caller can decide whether to abort.
     """
     proc = subprocess.run(
         ["gh", *args],
@@ -66,11 +81,10 @@ def gh(args, payload=None):
 
 
 def diff_commentable_lines(repo, pr):
-    """Return {path: set(new_file_line_numbers)} for lines commentable on RIGHT.
+    """Return {path: set(new_file_line_numbers)} commentable on the RIGHT side.
 
-    Parses the unified diff and tracks new-file line numbers for added (`+`) and
-    context (` `) lines. Removed lines (`-`) do not advance the new-file counter
-    and are not commentable on the RIGHT side.
+    Tracks new-file line numbers for added (`+`) and context (` `) lines. Removed
+    lines do not advance the new-file counter and are not commentable on RIGHT.
     """
     proc = subprocess.run(
         ["gh", "pr", "diff", str(pr), "--repo", repo],
@@ -100,14 +114,64 @@ def diff_commentable_lines(repo, pr):
         if raw.startswith("+"):
             commentable[path].add(new_line)
             new_line += 1
-        elif raw.startswith("-"):
-            pass
-        elif raw.startswith("\\"):  # "\ No newline at end of file"
+        elif raw.startswith("-") or raw.startswith("\\"):
             pass
         else:  # context line
             commentable[path].add(new_line)
             new_line += 1
     return commentable
+
+
+def fetch_threads(repo, pr):
+    """Return our review threads on the PR (those whose root comment is ours)."""
+    owner, name = repo.split("/", 1)
+    query = (
+        "query($owner:String!,$name:String!,$number:Int!,$cursor:String){"
+        "repository(owner:$owner,name:$name){pullRequest(number:$number){"
+        "reviewThreads(first:100,after:$cursor){"
+        "pageInfo{hasNextPage endCursor}"
+        "nodes{id isResolved isOutdated path line "
+        "comments(first:50){nodes{databaseId body author{login}}}}}}}}"
+    )
+    threads = []
+    cursor = None
+    while True:
+        args = [
+            "api", "graphql",
+            "-f", f"query={query}",
+            "-f", f"owner={owner}",
+            "-f", f"name={name}",
+            "-F", f"number={pr}",
+        ]
+        if cursor:
+            args += ["-f", f"cursor={cursor}"]
+        data = gh(args)
+        rt = data["data"]["repository"]["pullRequest"]["reviewThreads"]
+        for node in rt["nodes"]:
+            comments = node["comments"]["nodes"]
+            if not comments:
+                continue
+            root = comments[0]
+            if not OURS_RE.search(root.get("body", "")):
+                continue  # not our thread
+            threads.append({
+                "thread_id": node["id"],
+                "root_comment_id": root["databaseId"],
+                "path": node.get("path"),
+                "line": node.get("line"),
+                "is_resolved": node["isResolved"],
+                "is_outdated": node["isOutdated"],
+                "comments": [
+                    {"author": c["author"]["login"] if c.get("author") else None,
+                     "body": OURS_RE.sub("", c.get("body", "")).strip()}
+                    for c in comments
+                ],
+            })
+        if rt["pageInfo"]["hasNextPage"]:
+            cursor = rt["pageInfo"]["endCursor"]
+        else:
+            break
+    return {"threads": threads}
 
 
 def inline_key(path, line, body):
@@ -117,15 +181,27 @@ def inline_key(path, line, body):
     return digest[:12]
 
 
-def existing_inline_keys(repo, pr):
+def reply_key(root_comment_id, body):
+    normalized = " ".join(body.split())
+    digest = hashlib.sha1(f"{root_comment_id}:{normalized}".encode()).hexdigest()
+    return digest[:12]
+
+
+def existing_markers(repo, pr):
+    """Return (inline_keys, reply_keys, {(path,line): bool}) already present."""
     comments = gh(
         ["api", f"repos/{repo}/pulls/{pr}/comments", "--paginate"]
     ) or []
-    keys = set()
+    inline_keys, reply_keys, threaded_lines = set(), set(), set()
     for c in comments:
-        for m in INLINE_MARKER_RE.finditer(c.get("body", "")):
-            keys.add(m.group(1))
-    return keys
+        body = c.get("body", "")
+        for m in INLINE_MARKER_RE.finditer(body):
+            inline_keys.add(m.group(1))
+        for m in REPLY_MARKER_RE.finditer(body):
+            reply_keys.add(m.group(1))
+        if INLINE_MARKER_RE.search(body) and c.get("path") and c.get("line"):
+            threaded_lines.add((c["path"], c["line"]))
+    return inline_keys, reply_keys, threaded_lines
 
 
 def find_summary_comment(repo, pr):
@@ -136,6 +212,14 @@ def find_summary_comment(repo, pr):
         if SUMMARY_MARKER in c.get("body", ""):
             return c["id"]
     return None
+
+
+def resolve_thread(thread_id):
+    query = (
+        "mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId})"
+        "{thread{isResolved}}}"
+    )
+    gh(["api", "graphql", "-f", f"query={query}", "-f", f"threadId={thread_id}"])
 
 
 def render_finding_body(finding):
@@ -158,7 +242,6 @@ def render_summary(findings_json, general, demoted):
         "",
         f"**Verdict:** {VERDICT_LABELS.get(verdict, verdict)}",
     ]
-
     general_and_demoted = list(general) + list(demoted)
     if general_and_demoted:
         lines += ["", "### General findings", ""]
@@ -175,7 +258,6 @@ def render_summary(findings_json, general, demoted):
             if body:
                 for bl in body.splitlines():
                     lines.append(f"  {bl}")
-
     lines += [
         "",
         "<sub>Inline comments are attached to the relevant lines. "
@@ -184,62 +266,49 @@ def render_summary(findings_json, general, demoted):
     return "\n".join(lines)
 
 
-def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--repo", required=True, help="owner/repo")
-    ap.add_argument("--pr", required=True)
-    ap.add_argument("--input", required=True, help="path to findings JSON")
-    args = ap.parse_args()
+def cmd_fetch(args):
+    print(json.dumps(fetch_threads(args.repo, args.pr), indent=2))
 
+
+def cmd_post(args):
     with open(args.input) as fh:
         data = json.load(fh)
 
     findings = data.get("findings", []) or []
     general = data.get("general_findings", []) or []
+    thread_actions = data.get("thread_actions", []) or []
 
     commentable = diff_commentable_lines(args.repo, args.pr)
-    already = existing_inline_keys(args.repo, args.pr)
+    inline_keys, reply_keys, threaded_lines = existing_markers(args.repo, args.pr)
 
-    new_comments = []
-    demoted = []
-    skipped_dup = 0
+    # --- new inline comments ---
+    new_comments, demoted, skipped_dup = [], [], 0
     for f in findings:
-        sev = f.get("severity")
-        if sev not in VALID_SEVERITIES:
-            f["severity"] = sev = "should_fix"
-        path = f.get("path")
-        line = f.get("line")
-        body = f.get("body", "")
-        if not path or not isinstance(line, int) or line not in commentable.get(path, set()):
-            # Not anchorable to a diff line — surface it in the summary instead
-            # of dropping it or failing the whole review.
+        if f.get("severity") not in VALID_SEVERITIES:
+            f["severity"] = "should_fix"
+        path, line, body = f.get("path"), f.get("line"), f.get("body", "")
+        if (not path or not isinstance(line, int)
+                or line not in commentable.get(path, set())):
             f["_loc"] = f"{path}:{line}" if path and line else (path or "")
             demoted.append(f)
             continue
-        key = inline_key(path, line, body)
-        if key in already:
+        if (path, line) in threaded_lines:
+            # A thread already exists here; re-engagement must go through
+            # thread_actions (reply), not a duplicate top-level comment.
             skipped_dup += 1
             continue
-        marked_body = f"{render_finding_body(f)}\n\n<!-- claude-review:inline:{key} -->"
+        key = inline_key(path, line, body)
+        if key in inline_keys:
+            skipped_dup += 1
+            continue
+        marked = f"{render_finding_body(f)}\n\n<!-- claude-review:inline:{key} -->"
         new_comments.append(
-            {"path": path, "line": line, "side": "RIGHT", "body": marked_body}
-        )
+            {"path": path, "line": line, "side": "RIGHT", "body": marked})
 
-    # Post a review only if there are genuinely new inline comments. An empty
-    # review with no body is rejected by the API, and re-posting an empty one
-    # would be noise.
     if new_comments:
-        gh(
-            [
-                "api",
-                f"repos/{args.repo}/pulls/{args.pr}/reviews",
-                "--method",
-                "POST",
-                "--input",
-                "-",
-            ],
-            payload={"event": "COMMENT", "comments": new_comments},
-        )
+        gh(["api", f"repos/{args.repo}/pulls/{args.pr}/reviews",
+            "--method", "POST", "--input", "-"],
+           payload={"event": "COMMENT", "comments": new_comments})
         print(f"Posted {len(new_comments)} new inline comment(s).")
     else:
         print("No new inline comments to post.")
@@ -248,39 +317,79 @@ def main():
     if demoted:
         print(f"Demoted {len(demoted)} off-diff finding(s) into the summary.")
 
+    # --- thread replies and resolutions ---
+    replied = resolved = 0
+    for act in thread_actions:
+        action = act.get("action")
+        thread_id = act.get("thread_id")
+        root_id = act.get("root_comment_id")
+        if action == "reply" and root_id:
+            body = (act.get("reply_body") or "").strip()
+            if not body:
+                continue
+            key = reply_key(root_id, body)
+            if key in reply_keys:
+                continue  # already replied with this content
+            marked = f"{body}\n\n<!-- claude-review:reply:{key} -->"
+            gh(["api", f"repos/{args.repo}/pulls/{args.pr}/comments/{root_id}/replies",
+                "--method", "POST", "--input", "-"],
+               payload={"body": marked})
+            replied += 1
+        elif action == "resolve" and thread_id:
+            if act.get("reply_body"):
+                body = act["reply_body"].strip()
+                key = reply_key(root_id, body) if root_id else None
+                if root_id and key not in reply_keys:
+                    marked = f"{body}\n\n<!-- claude-review:reply:{key} -->"
+                    gh(["api",
+                        f"repos/{args.repo}/pulls/{args.pr}/comments/{root_id}/replies",
+                        "--method", "POST", "--input", "-"],
+                       payload={"body": marked})
+            resolve_thread(thread_id)
+            resolved += 1
+        # action == "keep" (or unknown): do nothing
+    if replied:
+        print(f"Replied to {replied} thread(s).")
+    if resolved:
+        print(f"Resolved {resolved} thread(s).")
+
+    # --- summary comment (always reflects latest state) ---
     summary_body = render_summary(data, general, demoted)
     summary_id = find_summary_comment(args.repo, args.pr)
     if summary_id is not None:
-        gh(
-            [
-                "api",
-                f"repos/{args.repo}/issues/comments/{summary_id}",
-                "--method",
-                "PATCH",
-                "--input",
-                "-",
-            ],
-            payload={"body": summary_body},
-        )
+        gh(["api", f"repos/{args.repo}/issues/comments/{summary_id}",
+            "--method", "PATCH", "--input", "-"],
+           payload={"body": summary_body})
         print(f"Updated summary comment {summary_id}.")
     else:
-        gh(
-            [
-                "api",
-                f"repos/{args.repo}/issues/{args.pr}/comments",
-                "--method",
-                "POST",
-                "--input",
-                "-",
-            ],
-            payload={"body": summary_body},
-        )
+        gh(["api", f"repos/{args.repo}/issues/{args.pr}/comments",
+            "--method", "POST", "--input", "-"],
+           payload={"body": summary_body})
         print("Created summary comment.")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    fp = sub.add_parser("fetch", help="dump our existing review threads as JSON")
+    fp.add_argument("--repo", required=True, help="owner/repo")
+    fp.add_argument("--pr", required=True)
+    fp.set_defaults(func=cmd_fetch)
+
+    pp = sub.add_parser("post", help="post findings JSON as review feedback")
+    pp.add_argument("--repo", required=True, help="owner/repo")
+    pp.add_argument("--pr", required=True)
+    pp.add_argument("--input", required=True, help="path to findings JSON")
+    pp.set_defaults(func=cmd_post)
+
+    args = ap.parse_args()
+    args.func(args)
 
 
 if __name__ == "__main__":
     try:
         main()
-    except Exception as exc:  # surface a clear CI failure
+    except Exception as exc:
         print(f"post_review.py: {exc}", file=sys.stderr)
         sys.exit(1)

--- a/.claude/skills/review-pr/post_review.py
+++ b/.claude/skills/review-pr/post_review.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Post a Claude PR review as inline comments plus one updating summary comment.
+
+This script is the deterministic half of the review skill: Claude produces a
+findings JSON (see SKILL.md for the schema), and this script turns it into a
+GitHub Pull Request *review* with line-anchored inline comments, plus a single
+summary comment that is updated in place on every re-run.
+
+Why a script instead of letting the model call the API directly:
+  - The Reviews API rejects the *entire* review if any inline comment points at
+    a line that is not part of the diff. The model cannot reliably know which
+    lines are commentable, so we validate every finding against the diff hunks
+    here and demote off-diff findings into the summary instead of failing.
+  - Re-running the review must not spam the PR. We embed a hidden marker in
+    every comment body and skip findings whose marker already exists, and we
+    PATCH the existing summary comment rather than creating a new one.
+
+It shells out to `gh api`, which must be authenticated (the workflow provides
+GH_TOKEN). Standard library only — no third-party dependencies.
+"""
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+
+SUMMARY_MARKER = "<!-- claude-review:summary -->"
+INLINE_MARKER_RE = re.compile(r"<!-- claude-review:inline:([0-9a-f]{12}) -->")
+
+VALID_SEVERITIES = ("must_fix", "should_fix", "nit")
+SEVERITY_LABELS = {
+    "must_fix": "❌ Must fix",
+    "should_fix": "⚠️ Should fix",
+    "nit": "💡 Nit",
+}
+VERDICT_LABELS = {
+    "approve": "✅ Approve",
+    "request_changes": "⚠️ Request changes",
+    "needs_discussion": "💬 Needs discussion",
+}
+
+
+def gh(args, payload=None):
+    """Run a `gh` command, optionally piping a JSON payload to stdin.
+
+    Returns parsed JSON when the command emits any, else None. Raises
+    CalledProcessError on failure so the caller can decide whether to abort.
+    """
+    proc = subprocess.run(
+        ["gh", *args],
+        input=json.dumps(payload) if payload is not None else None,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh {' '.join(args)} failed: {proc.stderr.strip()}")
+    out = proc.stdout.strip()
+    if not out:
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        return out
+
+
+def diff_commentable_lines(repo, pr):
+    """Return {path: set(new_file_line_numbers)} for lines commentable on RIGHT.
+
+    Parses the unified diff and tracks new-file line numbers for added (`+`) and
+    context (` `) lines. Removed lines (`-`) do not advance the new-file counter
+    and are not commentable on the RIGHT side.
+    """
+    proc = subprocess.run(
+        ["gh", "pr", "diff", str(pr), "--repo", repo],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh pr diff failed: {proc.stderr.strip()}")
+
+    commentable = {}
+    path = None
+    new_line = 0
+    hunk_re = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+    for raw in proc.stdout.splitlines():
+        if raw.startswith("+++ b/"):
+            path = raw[6:]
+            commentable.setdefault(path, set())
+            continue
+        if raw.startswith("+++ ") or raw.startswith("--- "):
+            continue
+        m = hunk_re.match(raw)
+        if m:
+            new_line = int(m.group(1))
+            continue
+        if path is None:
+            continue
+        if raw.startswith("+"):
+            commentable[path].add(new_line)
+            new_line += 1
+        elif raw.startswith("-"):
+            pass
+        elif raw.startswith("\\"):  # "\ No newline at end of file"
+            pass
+        else:  # context line
+            commentable[path].add(new_line)
+            new_line += 1
+    return commentable
+
+
+def inline_key(path, line, body):
+    """Stable per-finding key, robust to trivial whitespace edits in the body."""
+    normalized = " ".join(body.split())
+    digest = hashlib.sha1(f"{path}:{line}:{normalized}".encode()).hexdigest()
+    return digest[:12]
+
+
+def existing_inline_keys(repo, pr):
+    comments = gh(
+        ["api", f"repos/{repo}/pulls/{pr}/comments", "--paginate"]
+    ) or []
+    keys = set()
+    for c in comments:
+        for m in INLINE_MARKER_RE.finditer(c.get("body", "")):
+            keys.add(m.group(1))
+    return keys
+
+
+def find_summary_comment(repo, pr):
+    comments = gh(
+        ["api", f"repos/{repo}/issues/{pr}/comments", "--paginate"]
+    ) or []
+    for c in comments:
+        if SUMMARY_MARKER in c.get("body", ""):
+            return c["id"]
+    return None
+
+
+def render_finding_body(finding):
+    label = SEVERITY_LABELS.get(finding["severity"], finding["severity"])
+    title = finding.get("title", "").strip()
+    body = finding.get("body", "").strip()
+    header = f"**{label}**"
+    if title:
+        header += f" — {title}"
+    return f"{header}\n\n{body}"
+
+
+def render_summary(findings_json, general, demoted):
+    verdict = findings_json.get("verdict", "needs_discussion")
+    lines = [
+        SUMMARY_MARKER,
+        "## 🤖 Claude review",
+        "",
+        findings_json.get("summary", "").strip(),
+        "",
+        f"**Verdict:** {VERDICT_LABELS.get(verdict, verdict)}",
+    ]
+
+    general_and_demoted = list(general) + list(demoted)
+    if general_and_demoted:
+        lines += ["", "### General findings", ""]
+        for f in general_and_demoted:
+            label = SEVERITY_LABELS.get(f["severity"], f["severity"])
+            loc = f.get("_loc", "")
+            loc = f" (`{loc}`)" if loc else ""
+            title = f.get("title", "").strip()
+            head = f"- **{label}**{loc}"
+            if title:
+                head += f" — {title}"
+            lines.append(head)
+            body = f.get("body", "").strip()
+            if body:
+                for bl in body.splitlines():
+                    lines.append(f"  {bl}")
+
+    lines += [
+        "",
+        "<sub>Inline comments are attached to the relevant lines. "
+        "This summary updates in place on re-review.</sub>",
+    ]
+    return "\n".join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", required=True, help="owner/repo")
+    ap.add_argument("--pr", required=True)
+    ap.add_argument("--input", required=True, help="path to findings JSON")
+    args = ap.parse_args()
+
+    with open(args.input) as fh:
+        data = json.load(fh)
+
+    findings = data.get("findings", []) or []
+    general = data.get("general_findings", []) or []
+
+    commentable = diff_commentable_lines(args.repo, args.pr)
+    already = existing_inline_keys(args.repo, args.pr)
+
+    new_comments = []
+    demoted = []
+    skipped_dup = 0
+    for f in findings:
+        sev = f.get("severity")
+        if sev not in VALID_SEVERITIES:
+            f["severity"] = sev = "should_fix"
+        path = f.get("path")
+        line = f.get("line")
+        body = f.get("body", "")
+        if not path or not isinstance(line, int) or line not in commentable.get(path, set()):
+            # Not anchorable to a diff line — surface it in the summary instead
+            # of dropping it or failing the whole review.
+            f["_loc"] = f"{path}:{line}" if path and line else (path or "")
+            demoted.append(f)
+            continue
+        key = inline_key(path, line, body)
+        if key in already:
+            skipped_dup += 1
+            continue
+        marked_body = f"{render_finding_body(f)}\n\n<!-- claude-review:inline:{key} -->"
+        new_comments.append(
+            {"path": path, "line": line, "side": "RIGHT", "body": marked_body}
+        )
+
+    # Post a review only if there are genuinely new inline comments. An empty
+    # review with no body is rejected by the API, and re-posting an empty one
+    # would be noise.
+    if new_comments:
+        gh(
+            [
+                "api",
+                f"repos/{args.repo}/pulls/{args.pr}/reviews",
+                "--method",
+                "POST",
+                "--input",
+                "-",
+            ],
+            payload={"event": "COMMENT", "comments": new_comments},
+        )
+        print(f"Posted {len(new_comments)} new inline comment(s).")
+    else:
+        print("No new inline comments to post.")
+    if skipped_dup:
+        print(f"Skipped {skipped_dup} inline finding(s) already present.")
+    if demoted:
+        print(f"Demoted {len(demoted)} off-diff finding(s) into the summary.")
+
+    summary_body = render_summary(data, general, demoted)
+    summary_id = find_summary_comment(args.repo, args.pr)
+    if summary_id is not None:
+        gh(
+            [
+                "api",
+                f"repos/{args.repo}/issues/comments/{summary_id}",
+                "--method",
+                "PATCH",
+                "--input",
+                "-",
+            ],
+            payload={"body": summary_body},
+        )
+        print(f"Updated summary comment {summary_id}.")
+    else:
+        gh(
+            [
+                "api",
+                f"repos/{args.repo}/issues/{args.pr}/comments",
+                "--method",
+                "POST",
+                "--input",
+                "-",
+            ],
+            payload={"body": summary_body},
+        )
+        print("Created summary comment.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # surface a clear CI failure
+        print(f"post_review.py: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/.claude/skills/review-pr/review-core.md
+++ b/.claude/skills/review-pr/review-core.md
@@ -1,0 +1,73 @@
+# clickhouse-go Review Core
+
+Shared review criteria for **any** review of a clickhouse-go change — a numbered GitHub PR, a
+local diff, or a pre-PR self-review. This file defines *what to look for* and *how to weigh it*;
+the caller decides how the diff is obtained and how findings are reported. The GitHub PR workflow
+wrapper lives in `SKILL.md` next to this file.
+
+You are a senior `clickhouse-go` maintainer performing a **strict, high-signal review**. Your job
+is to catch **real problems** — correctness, resource leaks, concurrency, API misuse, protocol
+gaps, missing tests — and give concise, actionable, line-anchored feedback. Avoid noisy comments
+about style or trivial cleanups.
+
+## Review gates
+
+These are the questions you must answer before settling on a verdict. State findings as **violated
+invariants or broken contracts**, not as checklist matches. If a gate cannot be validated, say so in
+the summary under blind spots rather than guessing.
+
+1. **Contract** — Derive what the change promises from its title, description, tests, and code
+   shape. A `Bug Fix` promises the bug is fixed *and* covered by a regression test; a perf change
+   promises a measured benefit. Frame findings as "X promises Y, but Z breaks it."
+2. **Impacted surface** — Follow the changed behavior through unchanged callers/callees, both the
+   **native (`Open`)** and **`database/sql` (`OpenDB`)** surfaces, and both the **native TCP** and
+   **HTTP** protocol paths. A change to one path that should apply to the other is a finding.
+3. **Failure & lifecycle** — Check error paths, cancellation, and resource lifecycle: is every
+   `Rows`, `Batch`, and `Conn` closed/aborted on **every** path including errors? Is the `Batch`
+   lifecycle (`Append` → `Send`/`Abort`) preserved? Is `context.Context` the first parameter and
+   never stored in a struct?
+4. **Evidence** — Map each material claim to proof. Correctness fixes need a regression test in
+   `tests/issues/issue_<N>_test.go`; new type support needs a column impl + round-trip test +
+   example. Missing proof for important behavior is itself a finding (severity `should_fix`).
+
+When you find one serious invariant failure, fan out **once** through sibling paths sharing the same
+cause (other column types, the other protocol, the other API surface) before concluding.
+
+**Use concrete traces.** If callee logic looks suspicious, trace a minimal input through it with
+concrete values. Do not dismiss it with abstract reasoning ("probably safe because…"). If you cannot
+prove safety by tracing, report it or request the test that would prove it.
+
+## clickhouse-go supporting checks
+
+Use these to surface project-specific invariants; the finding should name the broken behavior, not
+just cite the rule.
+
+- **Errors** — never swallowed with `_`; wrapped with `%w` to preserve the chain; strings lowercase,
+  no trailing punctuation; no `panic` outside `init()`-style invariant checks; messages actionable
+  for the end user.
+- **Concurrency** — no unsynchronized shared state; a struct holding a mutex (e.g. `batch`) is never
+  copied by value; goroutines have a documented exit/stop path.
+- **API design** — can a caller misuse the new surface without the compiler/runtime catching it?
+  Does it silently break existing callers (prefer deprecation over removal)? Are new exported
+  symbols necessary, or expressible with existing primitives? Do new interfaces sit at the point of
+  consumption? Is the zero value of new structs safe / a sensible default?
+- **Go idioms** — acronyms keep case (`URL`, `HTTP`, `ID`); short receiver names, never `self`/`this`;
+  `mixedCaps` not `ALL_CAPS` for unexported constants; imports grouped stdlib → external → internal.
+- **Tests** — would the test have caught the bug? Are they table-driven with messages stating
+  input / expected / got? **No mocking** of `driver.Conn`/`driver.Rows` in `/tests/` — use a real
+  ClickHouse via testcontainers. Cover **both** TCP and HTTP, and **both** native and `std` APIs.
+- **Docs** — new exported symbols have full-sentence doc comments beginning with the symbol name;
+  SQL types/functions in prose wrapped in backticks; examples added/updated for new behavior. Do not
+  flag missing error handling in *example* code inside comments.
+
+## Severity model
+
+- `must_fix` — incorrectness, data loss, resource/goroutine leaks, data races/deadlocks, silent
+  breaking changes to a public API or protocol, security issues.
+- `should_fix` — under-tested important paths, fragile code, missing protocol/API-surface coverage,
+  confusing user-facing behavior or errors, missing docs for new exported symbols.
+- `nit` — minor clarity/naming/idiom issues. Prefix the finding with `nit:`. Keep these rare; do not
+  let them crowd out real findings.
+
+Omit speculative refactors, pure formatting, and bikeshedding. Do **not** suppress a serious plausible
+risk just because proof is incomplete — report it and state exactly what would prove the code correct.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,6 +31,18 @@ jobs:
         # that would run untrusted fork code with access to repository secrets.
         # that's why labeling check (usually by maintainer)
 
+      # Dump the bot's existing review threads (prior comments + author replies +
+      # resolved/outdated state) so the review step can decide, per open thread,
+      # whether to reply, resolve, or leave it alone. Empty on a first review.
+      - name: Fetch existing review threads
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 .claude/skills/review-pr/post_review.py fetch \
+            --repo "${{ github.repository }}" \
+            --pr "${{ github.event.inputs.pr_number || github.event.pull_request.number }}" \
+            > existing-threads.json || echo '{"threads":[]}' > existing-threads.json
+
       - name: Review PR with Claude (produce findings JSON)
         uses: anthropics/claude-code-action@v1
         with:
@@ -43,23 +55,24 @@ jobs:
 
             Steps:
             1. Read `.claude/skills/review-pr/SKILL.md` to load the review gates, supporting checks, and JSON output schema.
-            2. Fetch the PR description: `gh pr view ${{ github.event.inputs.pr_number || github.event.pull_request.number }} --json title,body,headRefName,baseRefName,author,url`.
-            3. Fetch the diff: `gh pr diff ${{ github.event.inputs.pr_number || github.event.pull_request.number }}`.
-            4. Work through the review gates and supporting checks. Anchor each finding to a specific changed line where possible.
-            5. Write the findings as JSON to `claude-review.json` in the repo root, exactly matching the schema in section 5 of SKILL.md.
-            6. Do NOT post any comments yourself — a separate workflow step posts the JSON.
+            2. Read `existing-threads.json` (your prior review threads on this PR, with author replies and resolve state). For each open thread, decide a `thread_actions` entry per section 1 of SKILL.md.
+            3. Fetch the PR description: `gh pr view ${{ github.event.inputs.pr_number || github.event.pull_request.number }} --json title,body,headRefName,baseRefName,author,url`.
+            4. Fetch the diff: `gh pr diff ${{ github.event.inputs.pr_number || github.event.pull_request.number }}`.
+            5. Work through the review gates and supporting checks. Anchor each finding to a specific changed line where possible.
+            6. Write the findings as JSON to `claude-review.json` in the repo root, exactly matching the schema in section 5 of SKILL.md (including `thread_actions` for open threads).
+            7. Do NOT post any comments yourself — a separate workflow step posts the JSON.
 
-      # Deterministic posting: turns the findings JSON into a PR review with
-      # inline line-anchored comments, and updates one summary comment in place
-      # (idempotent, so re-runs do not duplicate). Runs even if the review step
-      # produced no JSON (the script is skipped in that case).
+      # Deterministic posting: inline line-anchored comments, threaded replies,
+      # resolution of addressed/outdated threads, and one summary comment updated
+      # in place (idempotent, so re-runs do not duplicate). Runs even if the
+      # review step produced no JSON (the script is skipped in that case).
       - name: Post review comments
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           if [ -f claude-review.json ]; then
-            python3 .claude/skills/review-pr/post_review.py \
+            python3 .claude/skills/review-pr/post_review.py post \
               --repo "${{ github.repository }}" \
               --pr "${{ github.event.inputs.pr_number || github.event.pull_request.number }}" \
               --input claude-review.json

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,16 +51,13 @@ jobs:
           claude_args:
             --allowedTools "Read,Glob,Grep,Bash(grep:*),Bash(gh pr view:*),Bash(gh pr diff:*),Write"
           prompt: |
-            Review pull request #${{ github.event.inputs.pr_number || github.event.pull_request.number }} using `.claude/skills/review-pr/SKILL.md`.
+            Review pull request #${{ github.event.inputs.pr_number || github.event.pull_request.number }} by following `.claude/skills/review-pr/SKILL.md` exactly.
 
-            Steps:
-            1. Read `.claude/skills/review-pr/SKILL.md` to load the review gates, supporting checks, and JSON output schema.
-            2. Read `existing-threads.json` (your prior review threads on this PR, with author replies and resolve state). For each open thread, decide a `thread_actions` entry per section 1 of SKILL.md.
-            3. Fetch the PR description: `gh pr view ${{ github.event.inputs.pr_number || github.event.pull_request.number }} --json title,body,headRefName,baseRefName,author,url`.
-            4. Fetch the diff: `gh pr diff ${{ github.event.inputs.pr_number || github.event.pull_request.number }}`.
-            5. Work through the review gates and supporting checks. Anchor each finding to a specific changed line where possible.
-            6. Write the findings as JSON to `claude-review.json` in the repo root, exactly matching the schema in section 5 of SKILL.md (including `thread_actions` for open threads).
-            7. Do NOT post any comments yourself — a separate workflow step posts the JSON.
+            Read `.claude/skills/review-pr/SKILL.md` first — it points to `review-core.md` (same
+            directory) for the review criteria and defines the findings JSON schema.
+            `existing-threads.json` is already present in the working directory. Write your findings
+            to `claude-review.json` in the repo root, matching the schema in SKILL.md. Do NOT post
+            any comments yourself — a separate workflow step posts the JSON.
 
       # Deterministic posting: inline line-anchored comments, threaded replies,
       # resolution of addressed/outdated threads, and one summary comment updated

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,23 +31,41 @@ jobs:
         # that would run untrusted fork code with access to repository secrets.
         # that's why labeling check (usually by maintainer)
 
-      - name: Review PR with Claude
+      - name: Review PR with Claude (produce findings JSON)
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ github.token }}
           claude_args:
-            --allowedTools "Read,Glob,Bash(grep:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*)"
+            --allowedTools "Read,Glob,Grep,Bash(grep:*),Bash(gh pr view:*),Bash(gh pr diff:*),Write"
           prompt: |
-            Review pull request #${{ github.event.inputs.pr_number || github.event.pull_request.number }} using the checklist in `.claude/skills/review-pr/SKILL.md`.
+            Review pull request #${{ github.event.inputs.pr_number || github.event.pull_request.number }} using `.claude/skills/review-pr/SKILL.md`.
 
             Steps:
-            1. Read `.claude/skills/review-pr/SKILL.md` to load the review checklist and output format.
-            2. Fetch the PR description with `gh pr view ${{ github.event.inputs.pr_number || github.event.pull_request.number }}`.
-            3. Fetch the diff with `gh pr diff ${{ github.event.inputs.pr_number || github.event.pull_request.number }}`.
-            4. Work through every checklist category in SKILL.md: Correctness, API design, Go idioms, Tests, Performance & protocol, Documentation.
-            5. Post a single review comment on the PR using `gh pr comment ${{ github.event.inputs.pr_number || github.event.pull_request.number }} --body "..."` with the sections defined in SKILL.md: Summary, Must fix, Should fix, Nits, Verdict.
-            6. Omit any section that has no items.
+            1. Read `.claude/skills/review-pr/SKILL.md` to load the review gates, supporting checks, and JSON output schema.
+            2. Fetch the PR description: `gh pr view ${{ github.event.inputs.pr_number || github.event.pull_request.number }} --json title,body,headRefName,baseRefName,author,url`.
+            3. Fetch the diff: `gh pr diff ${{ github.event.inputs.pr_number || github.event.pull_request.number }}`.
+            4. Work through the review gates and supporting checks. Anchor each finding to a specific changed line where possible.
+            5. Write the findings as JSON to `claude-review.json` in the repo root, exactly matching the schema in section 5 of SKILL.md.
+            6. Do NOT post any comments yourself — a separate workflow step posts the JSON.
+
+      # Deterministic posting: turns the findings JSON into a PR review with
+      # inline line-anchored comments, and updates one summary comment in place
+      # (idempotent, so re-runs do not duplicate). Runs even if the review step
+      # produced no JSON (the script is skipped in that case).
+      - name: Post review comments
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -f claude-review.json ]; then
+            python3 .claude/skills/review-pr/post_review.py \
+              --repo "${{ github.repository }}" \
+              --pr "${{ github.event.inputs.pr_number || github.event.pull_request.number }}" \
+              --input claude-review.json
+          else
+            echo "No claude-review.json produced; nothing to post."
+          fi
 
       - name: Remove trigger label
         if: always() && github.event_name != 'workflow_dispatch'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,8 +53,8 @@ jobs:
           prompt: |
             Review pull request #${{ github.event.inputs.pr_number || github.event.pull_request.number }} by following `.claude/skills/review-pr/SKILL.md` exactly.
 
-            Read `.claude/skills/review-pr/SKILL.md` first — it points to `review-core.md` (same
-            directory) for the review criteria and defines the findings JSON schema.
+            First Read `.claude/skills/review-pr/review-core.md` (the review criteria) and
+            `.claude/skills/review-pr/SKILL.md` (the workflow steps and findings JSON schema).
             `existing-threads.json` is already present in the working directory. Write your findings
             to `claude-review.json` in the repo root, matching the schema in SKILL.md. Do NOT post
             any comments yourself — a separate workflow step posts the JSON.

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ pipeline.auto.tfvars
 
 .env
 go.work
+
+# Python bytecode from .claude tools
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Changes:
1. Add python script to deterministically post in-line review comments
   with correct line-number and close to the code
2. Update SKILL.md to make it similar to how core ClickHouse does it
   (gate based)

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
