### PR TITLE
fix: handle the named arg inside backtick

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"regexp"
 	"strings"
 	"time"
 
@@ -46,10 +45,6 @@ func DateNamed(name string, value time.Time, scale TimeUnit) driver.NamedDateVal
 		Scale: uint8(scale),
 	}
 }
-
-var (
-	bindNamedRe = regexp.MustCompile(`@[a-zA-Z0-9\_]+`)
-)
 
 func bind(tz *time.Location, query string, args ...any) (string, error) {
 	if len(args) == 0 {
@@ -98,19 +93,60 @@ func checkAllNamedArguments(args ...any) (bool, error) {
 	return haveNamed, nil
 }
 
+// bindQuoteState tracks whether the scanner is currently inside a region of the
+// query where bind placeholders ('?', '$N', '@name') must NOT be substituted: a
+// quoted identifier (backtick or double quote), a string literal (single quote),
+// or a comment.
+//
+// ClickHouse comment syntax: single-line comments start with "--", "#" or "#!"
+// and run to the end of the line; block comments are delimited by "/*" and "*/"
+// and may be nested.
 type bindQuoteState struct {
-	inBacktick bool
-	inSingle   bool
-	inDouble   bool
+	inBacktick    bool
+	inSingle      bool
+	inDouble      bool
+	inLineComment bool
+	blockComment  int // nesting depth of /* */ comments (ClickHouse nests them)
 }
 
-func (s *bindQuoteState) inQuotedContext() bool {
-	return s.inBacktick || s.inSingle || s.inDouble
+// inProtectedContext reports whether the current position is inside a quoted
+// identifier, string literal, or comment: any region where '?', '$N' and
+// '@name' markers are part of the query text rather than bind placeholders.
+func (s *bindQuoteState) inProtectedContext() bool {
+	return s.inBacktick || s.inSingle || s.inDouble || s.inLineComment || s.blockComment > 0
 }
 
+// inIdentifierOrComment reports whether the current position is inside a quoted
+// identifier (backtick or double quote) or a comment. In these contexts the
+// query text is passed through untouched, including any backslash that precedes
+// a '?'. This is deliberately distinct from a single-quoted string literal,
+// where a "\?" is unescaped to a literal "?" for backward compatibility (see
+// bindPositional).
+func (s *bindQuoteState) inIdentifierOrComment() bool {
+	return s.inBacktick || s.inDouble || s.inLineComment || s.blockComment > 0
+}
+
+// update consumes the byte at pos and advances the quote/comment state. It
+// returns the index of the last byte it consumed, which may be pos+1 when a
+// two-byte token (a doubled quote delimiter, "--", "/*" or "*/") is recognized
+// so the caller's loop skips the second byte. Doubled delimiters and backslash
+// escapes keep the scanner inside the current quoted context.
 func (s *bindQuoteState) update(query string, pos int) int {
-	// Quoted contexts allow doubled delimiters and backslash-escaped delimiters.
 	switch {
+	case s.inLineComment:
+		if query[pos] == '\n' {
+			s.inLineComment = false
+		}
+	case s.blockComment > 0:
+		// Block comments nest in ClickHouse, so track depth rather than a bool.
+		switch {
+		case query[pos] == '/' && pos+1 < len(query) && query[pos+1] == '*':
+			s.blockComment++
+			return pos + 1
+		case query[pos] == '*' && pos+1 < len(query) && query[pos+1] == '/':
+			s.blockComment--
+			return pos + 1
+		}
 	case s.inBacktick:
 		if query[pos] == '`' && !isEscaped(query, pos) {
 			if pos+1 < len(query) && query[pos+1] == '`' {
@@ -133,16 +169,26 @@ func (s *bindQuoteState) update(query string, pos int) int {
 			s.inDouble = false
 		}
 	default:
+		// Raw context: a backslash-escaped delimiter does not open anything.
 		if isEscaped(query, pos) {
 			return pos
 		}
-		switch query[pos] {
-		case '`':
+		switch {
+		case query[pos] == '`':
 			s.inBacktick = true
-		case '\'':
+		case query[pos] == '\'':
 			s.inSingle = true
-		case '"':
+		case query[pos] == '"':
 			s.inDouble = true
+		case query[pos] == '#':
+			// "#" and "#!" both start a single-line comment.
+			s.inLineComment = true
+		case query[pos] == '-' && pos+1 < len(query) && query[pos+1] == '-':
+			s.inLineComment = true
+			return pos + 1
+		case query[pos] == '/' && pos+1 < len(query) && query[pos+1] == '*':
+			s.blockComment++
+			return pos + 1
 		}
 	}
 	return pos
@@ -160,10 +206,19 @@ func isDigit(ch byte) bool {
 	return ch >= '0' && ch <= '9'
 }
 
+// isNameChar reports whether ch is valid in a named placeholder (@name); it
+// mirrors the previous bindNamedRe pattern `@[a-zA-Z0-9_]+`.
+func isNameChar(ch byte) bool {
+	return ch == '_' ||
+		(ch >= '0' && ch <= '9') ||
+		(ch >= 'a' && ch <= 'z') ||
+		(ch >= 'A' && ch <= 'Z')
+}
+
 func bindParamsFormats(query string) (haveNumeric, havePositional bool) {
 	var state bindQuoteState
 	for i := 0; i < len(query); i++ {
-		if !state.inQuotedContext() {
+		if !state.inProtectedContext() {
 			switch {
 			case query[i] == '?' && (i == 0 || query[i-1] != '\\'):
 				havePositional = true
@@ -192,17 +247,22 @@ func bindPositional(tz *time.Location, query string, args ...any) (_ string, err
 		// It's fine looping through the query string as bytes, because the (fixed) characters we're looking for
 		// are in the ASCII range to won't take up more than one byte.
 		if query[i] == '?' {
-			if state.inBacktick || state.inDouble {
+			// Inside identifier quotes or comments the text is passed through
+			// unchanged, including any backslash that precedes the '?'.
+			if state.inIdentifierOrComment() {
 				continue
 			}
 			if i > 0 && query[i-1] == '\\' {
-				// Copy all previous index to here characters
+				// Escaped "\?" becomes a literal "?" (the backslash is dropped).
+				// Applies in raw and single-quoted contexts; kept for backward
+				// compatibility.
 				buf = append(buf, query[lastMatchIndex+1:i-1]...)
 				buf = append(buf, '?')
 				lastMatchIndex = i
 				continue
 			}
-			if state.inQuotedContext() {
+			if state.inSingle {
+				// An unescaped '?' inside a string literal is verbatim.
 				continue
 			}
 
@@ -272,7 +332,7 @@ func bindNumeric(tz *time.Location, query string, args ...any) (_ string, err er
 	}
 
 	for i := 0; i < len(query); i++ {
-		if !state.inQuotedContext() && query[i] == '$' && i+1 < len(query) && isDigit(query[i+1]) {
+		if !state.inProtectedContext() && query[i] == '$' && i+1 < len(query) && isDigit(query[i+1]) {
 			j := i + 2
 			for j < len(query) && isDigit(query[j]) {
 				j++
@@ -302,8 +362,11 @@ func bindNumeric(tz *time.Location, query string, args ...any) (_ string, err er
 
 func bindNamed(tz *time.Location, query string, args ...any) (_ string, err error) {
 	var (
-		unbind = make(map[string]struct{})
-		params = make(map[string]string)
+		lastMatchIndex = -1
+		unbind         = make(map[string]struct{})
+		params         = make(map[string]string)
+		buf            = make([]byte, 0, len(query))
+		state          bindQuoteState
 	)
 	for _, v := range args {
 		switch v := v.(type) {
@@ -327,17 +390,38 @@ func bindNamed(tz *time.Location, query string, args ...any) (_ string, err erro
 			params["@"+v.Name] = val
 		}
 	}
-	query = bindNamedRe.ReplaceAllStringFunc(query, func(n string) string {
-		if _, found := params[n]; !found {
-			unbind[n] = struct{}{}
-			return ""
+
+	for i := 0; i < len(query); i++ {
+		// A named placeholder is "@" followed by at least one name character, and
+		// only counts outside of quoted identifiers, string literals and comments.
+		if !state.inProtectedContext() && query[i] == '@' && i+1 < len(query) && isNameChar(query[i+1]) {
+			j := i + 1
+			for j < len(query) && isNameChar(query[j]) {
+				j++
+			}
+			param := query[i:j]
+			buf = append(buf, query[lastMatchIndex+1:i]...)
+			if value, found := params[param]; found {
+				buf = append(buf, value...)
+			} else {
+				unbind[param] = struct{}{}
+			}
+			lastMatchIndex = j - 1
+			i = j - 1
+			continue
 		}
-		return params[n]
-	})
+		i = state.update(query, i)
+	}
+
+	// If there were no replacements, quick return without copying the string.
+	if lastMatchIndex < 0 {
+		return query, nil
+	}
+	buf = append(buf, query[lastMatchIndex+1:]...)
 	for param := range unbind {
 		return "", fmt.Errorf("have no arg for %q param", param)
 	}
-	return query, nil
+	return string(buf), nil
 }
 
 func formatTime(tz *time.Location, scale TimeUnit, value time.Time) (string, error) {

--- a/bind_test.go
+++ b/bind_test.go
@@ -326,6 +326,160 @@ func TestBindMixedParamsFormatsQuotedContexts(t *testing.T) {
 	}
 }
 
+func TestBindPositionalComments(t *testing.T) {
+	assets := []struct {
+		query    string
+		params   []any
+		expected string
+	}{
+		{
+			query:    "SELECT ? FROM t -- comment ?\nWHERE x = ?",
+			params:   []any{1, 2},
+			expected: "SELECT 1 FROM t -- comment ?\nWHERE x = 2",
+		},
+		{
+			query:    "SELECT ? # comment ?\nWHERE x = ?",
+			params:   []any{1, 2},
+			expected: "SELECT 1 # comment ?\nWHERE x = 2",
+		},
+		{
+			query:    "SELECT ? /* ? ignored */, ?",
+			params:   []any{1, 2},
+			expected: "SELECT 1 /* ? ignored */, 2",
+		},
+		{
+			// Block comments nest in ClickHouse: every ? until the outermost
+			// "*/" is part of the comment.
+			query:    "SELECT ? /* a /* ? */ ? */, ?",
+			params:   []any{1, 2},
+			expected: "SELECT 1 /* a /* ? */ ? */, 2",
+		},
+		{
+			// A backslash inside a comment is left verbatim, not unescaped.
+			query:    "SELECT ? -- \\?\n",
+			params:   []any{1},
+			expected: "SELECT 1 -- \\?\n",
+		},
+	}
+
+	for _, asset := range assets {
+		actual, err := bind(time.Local, asset.query, asset.params...)
+		require.NoError(t, err)
+		assert.Equal(t, asset.expected, actual)
+	}
+}
+
+func TestBindPositionalEscapedQuestionInIdentifier(t *testing.T) {
+	// "\?" must stay verbatim inside identifier quotes and comments; only inside
+	// single-quoted string literals (and raw text) is the backslash dropped.
+	assets := []struct {
+		query    string
+		params   []any
+		expected string
+	}{
+		{
+			query:    "SELECT `a\\?b`, ?",
+			params:   []any{42},
+			expected: "SELECT `a\\?b`, 42",
+		},
+		{
+			query:    `SELECT "a\?b", ?`,
+			params:   []any{42},
+			expected: `SELECT "a\?b", 42`,
+		},
+		{
+			query:    "SELECT 'a\\?b', ?",
+			params:   []any{42},
+			expected: "SELECT 'a?b', 42",
+		},
+	}
+
+	for _, asset := range assets {
+		actual, err := bind(time.Local, asset.query, asset.params...)
+		require.NoError(t, err)
+		assert.Equal(t, asset.expected, actual)
+	}
+}
+
+func TestBindNumericComments(t *testing.T) {
+	assets := []struct {
+		query    string
+		params   []any
+		expected string
+	}{
+		{
+			// $2 only appears in a comment, so a single arg is sufficient and
+			// must not raise "have no arg for $2".
+			query:    "SELECT $1 -- $2\n, $1",
+			params:   []any{42},
+			expected: "SELECT 42 -- $2\n, 42",
+		},
+		{
+			query:    "SELECT $1 /* $2 */",
+			params:   []any{42},
+			expected: "SELECT 42 /* $2 */",
+		},
+	}
+
+	for _, asset := range assets {
+		actual, err := bind(time.Local, asset.query, asset.params...)
+		require.NoError(t, err)
+		assert.Equal(t, asset.expected, actual)
+	}
+}
+
+func TestBindNamedQuotedContexts(t *testing.T) {
+	assets := []struct {
+		query    string
+		params   []any
+		expected string
+	}{
+		{
+			query:    "SELECT `col@x`, @id",
+			params:   []any{Named("id", 42)},
+			expected: "SELECT `col@x`, 42",
+		},
+		{
+			query:    "SELECT 'literal @name', @id",
+			params:   []any{Named("id", 7)},
+			expected: "SELECT 'literal @name', 7",
+		},
+		{
+			query:    `SELECT "col@x", @id`,
+			params:   []any{Named("id", 7)},
+			expected: `SELECT "col@x", 7`,
+		},
+		{
+			query:    "SELECT @id -- @ignored\n",
+			params:   []any{Named("id", 7)},
+			expected: "SELECT 7 -- @ignored\n",
+		},
+		{
+			query:    "SELECT @id # @ignored\n",
+			params:   []any{Named("id", 7)},
+			expected: "SELECT 7 # @ignored\n",
+		},
+		{
+			query:    "SELECT @id /* @ignored */",
+			params:   []any{Named("id", 7)},
+			expected: "SELECT 7 /* @ignored */",
+		},
+	}
+
+	for _, asset := range assets {
+		actual, err := bind(time.Local, asset.query, asset.params...)
+		require.NoError(t, err)
+		assert.Equal(t, asset.expected, actual)
+	}
+}
+
+func TestBindNamedUnbound(t *testing.T) {
+	// A genuinely missing named parameter (outside any quoted context) must
+	// still error through the scanner-based binder.
+	_, err := bind(time.Local, "SELECT @a, @b", Named("a", 1))
+	require.Error(t, err)
+}
+
 func TestFormatTime(t *testing.T) {
 	var (
 		t1, _   = time.Parse("2006-01-02 15:04:05", "2022-01-12 15:00:00")


### PR DESCRIPTION

## Summary
<!-- A short description of the changes with a link to an open issue. -->
This is follow up to https://github.com/ClickHouse/clickhouse-go/pull/1879 but handling named binding (inside backticks in the query including comments)

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
