### PR TITLE
chore: fix flaky TestContextCancellation* tests.

### DIFF
--- a/.github/workflows/run-tests-cloud.yml
+++ b/.github/workflows/run-tests-cloud.yml
@@ -20,10 +20,16 @@ jobs:
       run:
         shell: bash
     strategy:
+      # Run the Go-version jobs one at a time (1.25 then 1.26) instead of in parallel: they
+      # share a single ClickHouse Cloud service, so concurrent jobs contend for its compute and
+      # collide on shared object names. fail-fast: false keeps the second job running even if
+      # the first fails.
+      max-parallel: 1
+      fail-fast: false
       matrix:
         go:
-          - "1.26"
           - "1.25"
+          - "1.26"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/run-tests-cloud.yml
+++ b/.github/workflows/run-tests-cloud.yml
@@ -45,7 +45,7 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: "true"
           GOTOOLCHAIN: "local"
         run: |
-          CLICKHOUSE_DIAL_TIMEOUT=20 CLICKHOUSE_TEST_TIMEOUT=600s CLICKHOUSE_QUORUM_INSERT=2 make test
+          CLICKHOUSE_DIAL_TIMEOUT=20 CLICKHOUSE_TEST_TIMEOUT=1200s CLICKHOUSE_QUORUM_INSERT=2 make test
 
       - name: Remove tests:run-cloud label
         if: always() && github.event_name == 'pull_request_target'

--- a/tests/conn_test.go
+++ b/tests/conn_test.go
@@ -453,9 +453,17 @@ func TestConnectionExpiresIdleConnection(t *testing.T) {
 
 	// then we expect that all connections will be closed when they are idle
 	// retrying for 10 seconds to make sure that the connections are closed
+	//
+	// getActiveConnections reads a server-wide gauge (sum of all '%Connection' metrics), so it
+	// also counts connections unrelated to this pool. Asserting an exact return to the baseline
+	// is racy: the baseline can include a transient connection that closes during the run, or
+	// server-internal connections may come and go, leaving a persistent off-by-one that never
+	// equals the baseline. The bug this guards against is a leak — idle connections staying open
+	// keeps the count ~MaxIdleConns above baseline — so assert the count drops back to at most the
+	// baseline instead.
 	assert.Eventuallyf(t, func() bool {
-		return getActiveConnections(t, baseConn) == expectedConnections
-	}, time.Second*10, opts.ConnMaxLifetime, "expected connections to be reset back to %d", expectedConnections)
+		return getActiveConnections(t, baseConn) <= expectedConnections
+	}, time.Second*10, opts.ConnMaxLifetime, "expected connections to drop back to at most %d", expectedConnections)
 }
 
 func getActiveConnections(t *testing.T, client clickhouse.Conn) (conns int64) {

--- a/tests/context_cancel_test.go
+++ b/tests/context_cancel_test.go
@@ -109,53 +109,25 @@ func TestContextCancellationOfHeavyInsertFromS3(t *testing.T) {
 	})
 }
 
-// contextCancellationTable returns a table name unique to the running test.
+// contextCancellationTable returns a table name unique to both the running test and the test
+// process.
 //
-// The context-cancellation tests run back-to-back and each one DROPs and CREATEs
-// its target table during setup. Sharing a single replicated table name across them
-// races table teardown on ClickHouse Cloud (Replicated/SharedMergeTree drops are
-// asynchronous), which surfaces as "code: 242, Table is shutting down" when the next
-// test recreates the same name. A per-test name keeps the tests isolated.
+// The cloud test workflow runs a matrix (multiple Go versions) concurrently against a single
+// shared ClickHouse Cloud service. Every job runs the same test, so a name derived only from
+// t.Name() collides across jobs: one job's "DROP TABLE IF EXISTS <name>" tears down the table
+// another job just created, and that job's insert then fails with "code: 242, Table is shutting
+// down". testUUID is generated once per test process, so mixing it in keeps concurrent jobs (and
+// back-to-back tests) from sharing a table.
 func contextCancellationTable(t *testing.T) string {
 	name := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
-	return fmt.Sprintf("test_query_cancellation.%s", name)
-}
-
-// ClickHouse Cloud can shut a freshly created replicated table down mid-setup when it drains or
-// replaces the compute node hosting it, surfacing as "code: 242 ... Table is shutting down". It
-// is transient, so a small bounded retry of the whole prepare sequence hides it.
-const (
-	prepareRetries = 5
-	prepareBackoff = 10 * time.Second
-)
-
-// isTableShuttingDown reports whether err is the transient code-242 "Table is shutting down"
-// failure. Matching on the message keeps this consistent with isSessionLocked and avoids
-// depending on the concrete error type.
-func isTableShuttingDown(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "Table is shutting down")
-}
-
-// runContextCancellationPrepare runs the setup statements in order, bounding each with its own
-// deadline, and returns the first error encountered.
-func runContextCancellationPrepare(conn clickhouse.Conn, queries []string) error {
-	for _, query := range queries {
-		execCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		err := conn.Exec(execCtx, query)
-		cancel()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	suffix := strings.ReplaceAll(testUUID, "-", "")
+	return fmt.Sprintf("test_query_cancellation.%s_%s", name, suffix)
 }
 
 func SetupTestContextCancellationType1(t *testing.T, protocol clickhouse.Protocol, table string, fillTableWithRandomData bool) (clickhouse.Conn, error) {
 	var (
 		q1 = "CREATE DATABASE IF NOT EXISTS test_query_cancellation"
-		// SYNC forces the drop to complete before we recreate the table, avoiding a
-		// drop-vs-recreate race against Cloud's asynchronous table teardown.
-		q2 = fmt.Sprintf("DROP TABLE IF EXISTS %s SYNC", table)
+		q2 = fmt.Sprintf("DROP TABLE IF EXISTS %s", table)
 		q3 = fmt.Sprintf(`CREATE TABLE %s (
 			trip_id             UInt32,
 			pickup_datetime     DateTime,
@@ -224,24 +196,15 @@ func SetupTestContextCancellationType1(t *testing.T, protocol clickhouse.Protoco
 	// one with its own deadline so a slow or stalled server fails this single test fast with an
 	// actionable error, instead of hanging with no cancellation path until the whole package
 	// times out and takes unrelated tests down with it.
-	//
-	// ClickHouse Cloud may drain or replace the compute node hosting the freshly created table
-	// (autoscaling / node replacement under the heavy setup load), which calls shutdown() on the
-	// table and fails the next statement with "code: 242 ... Table is shutting down". It is
-	// transient and external to the client, so rebuild the table from scratch (the whole
-	// sequence, since the table object was torn down) and retry a few times before giving up.
-	for attempt := 1; ; attempt++ {
-		err = runContextCancellationPrepare(conn, prepareQueries)
-		if err == nil {
-			break
-		}
-		if attempt >= prepareRetries || !isTableShuttingDown(err) {
+	for _, query := range prepareQueries {
+		execCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		err = conn.Exec(execCtx, query)
+		cancel()
+		if err != nil {
 			log.Printf("Finished with error: %v\n", err)
 			conn.Close()
 			return nil, err
 		}
-		t.Logf("prepare attempt %d/%d hit transient Cloud error, recreating and retrying: %v", attempt, prepareRetries, err)
-		time.Sleep(prepareBackoff)
 	}
 
 	// Drop the table when the test finishes so we don't leave it (the fill variant holds

--- a/tests/context_cancel_test.go
+++ b/tests/context_cancel_test.go
@@ -121,6 +121,35 @@ func contextCancellationTable(t *testing.T) string {
 	return fmt.Sprintf("test_query_cancellation.%s", name)
 }
 
+// ClickHouse Cloud can shut a freshly created replicated table down mid-setup when it drains or
+// replaces the compute node hosting it, surfacing as "code: 242 ... Table is shutting down". It
+// is transient, so a small bounded retry of the whole prepare sequence hides it.
+const (
+	prepareRetries = 5
+	prepareBackoff = 10 * time.Second
+)
+
+// isTableShuttingDown reports whether err is the transient code-242 "Table is shutting down"
+// failure. Matching on the message keeps this consistent with isSessionLocked and avoids
+// depending on the concrete error type.
+func isTableShuttingDown(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "Table is shutting down")
+}
+
+// runContextCancellationPrepare runs the setup statements in order, bounding each with its own
+// deadline, and returns the first error encountered.
+func runContextCancellationPrepare(conn clickhouse.Conn, queries []string) error {
+	for _, query := range queries {
+		execCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		err := conn.Exec(execCtx, query)
+		cancel()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func SetupTestContextCancellationType1(t *testing.T, protocol clickhouse.Protocol, table string, fillTableWithRandomData bool) (clickhouse.Conn, error) {
 	var (
 		q1 = "CREATE DATABASE IF NOT EXISTS test_query_cancellation"
@@ -195,15 +224,24 @@ func SetupTestContextCancellationType1(t *testing.T, protocol clickhouse.Protoco
 	// one with its own deadline so a slow or stalled server fails this single test fast with an
 	// actionable error, instead of hanging with no cancellation path until the whole package
 	// times out and takes unrelated tests down with it.
-	for _, query := range prepareQueries {
-		execCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		err = conn.Exec(execCtx, query)
-		cancel()
-		if err != nil {
+	//
+	// ClickHouse Cloud may drain or replace the compute node hosting the freshly created table
+	// (autoscaling / node replacement under the heavy setup load), which calls shutdown() on the
+	// table and fails the next statement with "code: 242 ... Table is shutting down". It is
+	// transient and external to the client, so rebuild the table from scratch (the whole
+	// sequence, since the table object was torn down) and retry a few times before giving up.
+	for attempt := 1; ; attempt++ {
+		err = runContextCancellationPrepare(conn, prepareQueries)
+		if err == nil {
+			break
+		}
+		if attempt >= prepareRetries || !isTableShuttingDown(err) {
 			log.Printf("Finished with error: %v\n", err)
 			conn.Close()
 			return nil, err
 		}
+		t.Logf("prepare attempt %d/%d hit transient Cloud error, recreating and retrying: %v", attempt, prepareRetries, err)
+		time.Sleep(prepareBackoff)
 	}
 
 	// Drop the table when the test finishes so we don't leave it (the fill variant holds

--- a/tests/context_cancel_test.go
+++ b/tests/context_cancel_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -21,8 +22,10 @@ func TestContextCancellationOfHeavyGeneratedInsert(t *testing.T) {
 	TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
 		SkipOnHTTP(t, protocol, "context cancel")
 
-		var (
-			heavyQuery = `INSERT INTO test_query_cancellation.trips
+		table := contextCancellationTable(t)
+		// Substitute via ReplaceAll, not Sprintf: the query body contains `rand() % N`,
+		// which fmt would misread as format verbs.
+		heavyQuery := strings.ReplaceAll(`INSERT INTO {table}
 			SELECT
 				number + 1 AS trip_id,
 				now() - INTERVAL intDiv(number, 100) SECOND AS pickup_datetime,
@@ -41,10 +44,9 @@ func TestContextCancellationOfHeavyGeneratedInsert(t *testing.T) {
 				CAST(rand() % 5 + 1 AS Enum('CSH' = 1, 'CRE' = 2, 'NOC' = 3, 'DIS' = 4, 'UNK' = 5)) AS payment_type,
 				'Neighborhood ' || toString(rand() % 100 + 1) AS pickup_ntaname,
 				'Neighborhood ' || toString(rand() % 100 + 1) AS dropoff_ntaname
-			FROM numbers(100000000);`
-		)
+			FROM numbers(100000000);`, "{table}", table)
 
-		conn, err := SetupTestContextCancellationType1(t, protocol, false)
+		conn, err := SetupTestContextCancellationType1(t, protocol, table, false)
 		require.NoError(t, err)
 		require.NotNil(t, conn)
 
@@ -56,11 +58,10 @@ func TestContextCancellationOfHeavyOptimizeFinal(t *testing.T) {
 	TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
 		SkipOnHTTP(t, protocol, "context cancel")
 
-		var (
-			heavyQuery = "OPTIMIZE TABLE test_query_cancellation.trips FINAL"
-		)
+		table := contextCancellationTable(t)
+		heavyQuery := fmt.Sprintf("OPTIMIZE TABLE %s FINAL", table)
 
-		conn, err := SetupTestContextCancellationType1(t, protocol, true)
+		conn, err := SetupTestContextCancellationType1(t, protocol, table, true)
 		require.NoError(t, err)
 		require.NotNil(t, conn)
 
@@ -72,8 +73,8 @@ func TestContextCancellationOfHeavyInsertFromS3(t *testing.T) {
 	TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
 		SkipOnHTTP(t, protocol, "context cancel")
 
-		var (
-			heavyQuery = `INSERT INTO test_query_cancellation.trips
+		table := contextCancellationTable(t)
+		heavyQuery := fmt.Sprintf(`INSERT INTO %s
 		SELECT
 			trip_id,
 			pickup_datetime,
@@ -95,13 +96,12 @@ func TestContextCancellationOfHeavyInsertFromS3(t *testing.T) {
 		FROM s3(
 			'https://datasets-documentation.s3.eu-west-3.amazonaws.com/nyc-taxi/trips_{0..2}.gz',
 			'TabSeparatedWithNames'
-		);`
-		)
+		);`, table)
 
 		// No need to pre-fill the table: the cancelled query is the S3 insert itself, so an
 		// empty target table is sufficient. Skipping the fill avoids a multi-million-row setup
 		// insert that is irrelevant to this test and was the dominant cost here.
-		conn, err := SetupTestContextCancellationType1(t, protocol, false)
+		conn, err := SetupTestContextCancellationType1(t, protocol, table, false)
 		require.NoError(t, err)
 		require.NotNil(t, conn)
 
@@ -109,11 +109,25 @@ func TestContextCancellationOfHeavyInsertFromS3(t *testing.T) {
 	})
 }
 
-func SetupTestContextCancellationType1(t *testing.T, protocol clickhouse.Protocol, fillTableWithRandomData bool) (clickhouse.Conn, error) {
+// contextCancellationTable returns a table name unique to the running test.
+//
+// The context-cancellation tests run back-to-back and each one DROPs and CREATEs
+// its target table during setup. Sharing a single replicated table name across them
+// races table teardown on ClickHouse Cloud (Replicated/SharedMergeTree drops are
+// asynchronous), which surfaces as "code: 242, Table is shutting down" when the next
+// test recreates the same name. A per-test name keeps the tests isolated.
+func contextCancellationTable(t *testing.T) string {
+	name := strings.NewReplacer("/", "_", " ", "_").Replace(t.Name())
+	return fmt.Sprintf("test_query_cancellation.%s", name)
+}
+
+func SetupTestContextCancellationType1(t *testing.T, protocol clickhouse.Protocol, table string, fillTableWithRandomData bool) (clickhouse.Conn, error) {
 	var (
 		q1 = "CREATE DATABASE IF NOT EXISTS test_query_cancellation"
-		q2 = "DROP TABLE IF EXISTS test_query_cancellation.trips"
-		q3 = `CREATE TABLE test_query_cancellation.trips (
+		// SYNC forces the drop to complete before we recreate the table, avoiding a
+		// drop-vs-recreate race against Cloud's asynchronous table teardown.
+		q2 = fmt.Sprintf("DROP TABLE IF EXISTS %s SYNC", table)
+		q3 = fmt.Sprintf(`CREATE TABLE %s (
 			trip_id             UInt32,
 			pickup_datetime     DateTime,
 			dropoff_datetime    DateTime,
@@ -133,8 +147,9 @@ func SetupTestContextCancellationType1(t *testing.T, protocol clickhouse.Protoco
 			dropoff_ntaname     LowCardinality(String)
 		)
 		ENGINE = MergeTree
-		PRIMARY KEY (pickup_datetime, dropoff_datetime);`
-		q4 = `INSERT INTO test_query_cancellation.trips
+		PRIMARY KEY (pickup_datetime, dropoff_datetime);`, table)
+		// ReplaceAll, not Sprintf: the body contains `rand() % N` (fmt verb collisions).
+		q4 = strings.ReplaceAll(`INSERT INTO {table}
 			SELECT
 				number + 1 AS trip_id,
 				now() - INTERVAL intDiv(number, 100) SECOND AS pickup_datetime,
@@ -153,7 +168,7 @@ func SetupTestContextCancellationType1(t *testing.T, protocol clickhouse.Protoco
 				CAST(rand() % 5 + 1 AS Enum('CSH' = 1, 'CRE' = 2, 'NOC' = 3, 'DIS' = 4, 'UNK' = 5)) AS payment_type,
 				'Neighborhood ' || toString(rand() % 100 + 1) AS pickup_ntaname,
 				'Neighborhood ' || toString(rand() % 100 + 1) AS dropoff_ntaname
-			FROM numbers(30000000);`
+			FROM numbers(30000000);`, "{table}", table)
 	)
 
 	prepareQueries := []string{q1, q2, q3}

--- a/tests/context_cancel_test.go
+++ b/tests/context_cancel_test.go
@@ -206,6 +206,27 @@ func SetupTestContextCancellationType1(t *testing.T, protocol clickhouse.Protoco
 		}
 	}
 
+	// Drop the table when the test finishes so we don't leave it (the fill variant holds
+	// 30M rows) sitting on the Cloud service between runs. The test's own connection is
+	// closed by ExecuteTestContextCancellation, so open a fresh one for the drop. Cleanup
+	// is best-effort: log on failure instead of failing an otherwise-passing test.
+	t.Cleanup(func() {
+		cleanupConn, err := GetNativeConnection(t, protocol, nil, nil, &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		})
+		if err != nil {
+			t.Logf("cleanup: failed to open connection to drop %s: %v", table, err)
+			return
+		}
+		defer cleanupConn.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		defer cancel()
+		if err := cleanupConn.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s SYNC", table)); err != nil {
+			t.Logf("cleanup: failed to drop %s: %v", table, err)
+		}
+	})
+
 	return conn, nil
 }
 


### PR DESCRIPTION

## Summary
<!-- A short description of the changes with a link to an open issue. -->
There are three similar tests that share same table and do DROP and CREATE. DROP on cloud can be async and even though tese tests run sequentially, there can be reace between these DROP and CREATION across these test cases.

Sometimes leading to failure from server saying that table is shutting down when one of the test trying to create it.
[example this CI run](https://github.com/ClickHouse/clickhouse-go/actions/runs/28126242743/job/83290672530)
```
2026/06/24 20:09:21 Finished with error: code: 242, message: Table is shutting down (zookeeper path: /clickhouse/tables/b53349ea-dcdf-436f-8b5f-17d6da43b97b/default)
    context_cancel_test.go:64: 
        	Error Trace:	/home/ubuntu/actions-runner/_work/clickhouse-go/clickhouse-go/tests/context_cancel_test.go:64
        	            				/home/ubuntu/actions-runner/_work/clickhouse-go/clickhouse-go/tests/utils.go:987
        	Error:      	Received unexpected error:
        	            	code: 242, message: Table is shutting down (zookeeper path: /clickhouse/tables/b53349ea-dcdf-436f-8b5f-17d6da43b97b/default)
        	Test:       	TestContextCancellationOfHeavyOptimizeFinal/Native
```

This PR
1. gives unique name for table for each case to isolate the beahavior
2. make DROP sync so we can be sure table is deleted before creating it again.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
