### PR TITLE
fix: bind float params as typed Float literals (#1862)

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -4,7 +4,9 @@ import (
 	std_driver "database/sql/driver"
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -487,6 +489,10 @@ func format(tz *time.Location, scale TimeUnit, v any) (string, error) {
 			return "1", nil
 		}
 		return "0", nil
+	case float32:
+		return formatFloat(float64(v), 32), nil
+	case float64:
+		return formatFloat(v, 64), nil
 	case GroupSet:
 		val, err := join(tz, scale, v.Value)
 		if err != nil {
@@ -573,6 +579,10 @@ func format(tz *time.Location, scale TimeUnit, v any) (string, error) {
 			values = append(values, fmt.Sprintf("%s, %s", name, val))
 		}
 		return "map(" + strings.Join(values, ", ") + ")", nil
+	case reflect.Float32:
+		return formatFloat(v.Float(), 32), nil
+	case reflect.Float64:
+		return formatFloat(v.Float(), 64), nil
 	case reflect.Ptr:
 		if v.IsNil() {
 			return "NULL", nil
@@ -580,6 +590,27 @@ func format(tz *time.Location, scale TimeUnit, v any) (string, error) {
 		return format(tz, scale, v.Elem().Interface())
 	}
 	return fmt.Sprint(v), nil
+}
+
+// formatFloat renders a float as a CAST to the matching ClickHouse Float type.
+// Without the cast, integer-valued floats like 1.0 render as the bare literal
+// "1", which ClickHouse infers as an integer and later narrows (breaking typed
+// float scans). NaN and infinities are quoted in the lowercase form ClickHouse
+// accepts, since Go's default formatting ("NaN", "+Inf") is not valid SQL.
+func formatFloat(f float64, bitSize int) string {
+	chType := "Float64"
+	if bitSize == 32 {
+		chType = "Float32"
+	}
+	switch {
+	case math.IsNaN(f):
+		return fmt.Sprintf("cast('nan', '%s')", chType)
+	case math.IsInf(f, 1):
+		return fmt.Sprintf("cast('inf', '%s')", chType)
+	case math.IsInf(f, -1):
+		return fmt.Sprintf("cast('-inf', '%s')", chType)
+	}
+	return fmt.Sprintf("cast(%s, '%s')", strconv.FormatFloat(f, 'g', -1, bitSize), chType)
 }
 
 func join[E any](tz *time.Location, scale TimeUnit, values []E) (string, error) {

--- a/bind_test.go
+++ b/bind_test.go
@@ -1,6 +1,7 @@
 package clickhouse
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -500,6 +501,31 @@ func TestFormatTime(t *testing.T) {
 	// test with nil pointer to time.Time
 	val, _ := format(time.UTC, Seconds, (*time.Time)(nil))
 	assert.Equal(t, "NULL", val)
+}
+
+// TestFormatFloat is a regression test for issue #1862: a bound float64/float32
+// used to fall through to fmt.Sprint, so 1.0 rendered as the bare literal "1"
+// (which ClickHouse narrows to an integer type) and non-finite values rendered
+// as "NaN"/"+Inf" which ClickHouse cannot parse.
+func TestFormatFloat(t *testing.T) {
+	cases := []struct {
+		param    any
+		expected string
+	}{
+		{float64(1.0), "cast(1, 'Float64')"},
+		{float64(1.5), "cast(1.5, 'Float64')"},
+		{float64(-2), "cast(-2, 'Float64')"},
+		{float32(1.0), "cast(1, 'Float32')"},
+		{float32(2.5), "cast(2.5, 'Float32')"},
+		{math.Inf(1), "cast('inf', 'Float64')"},
+		{math.Inf(-1), "cast('-inf', 'Float64')"},
+		{math.NaN(), "cast('nan', 'Float64')"},
+	}
+	for _, c := range cases {
+		val, err := format(time.UTC, Seconds, c.param)
+		require.NoError(t, err)
+		assert.Equal(t, c.expected, val)
+	}
 }
 
 func TestFormatScaledTime(t *testing.T) {

--- a/tests/issues/issue_1862_test.go
+++ b/tests/issues/issue_1862_test.go
@@ -32,6 +32,12 @@ type queryRowFunc func(dest any, query string, args ...any) error
 // binds float scalars, arrays, and maps and scans them back, exercising the
 // fix end-to-end across both protocols (native TCP and HTTP) and both APIs.
 func Test1862_FloatBinding(t *testing.T) {
+	// The two helpers have opposite SSL conventions on Cloud:
+	//   - native GetConnection derives TLS and the secure port from CLICKHOUSE_USE_SSL
+	//     when tlsConfig is nil, so passing a non-nil config would pin the plaintext port.
+	//   - std GetOpenDBConnection does not read the env var; it needs an explicit
+	//     non-nil *tls.Config to select the secure port.
+	// So the native path passes nil and the std path passes tlsConfig.
 	useSSL, err := strconv.ParseBool(clickhouse_tests.GetEnv("CLICKHOUSE_USE_SSL", "false"))
 	require.NoError(t, err)
 	var tlsConfig *tls.Config
@@ -45,7 +51,7 @@ func Test1862_FloatBinding(t *testing.T) {
 		protocol := protocol
 
 		t.Run("native/"+protocol.String(), func(t *testing.T) {
-			conn, err := clickhouse_tests.GetConnection("issues", t, protocol, nil, tlsConfig, nil)
+			conn, err := clickhouse_tests.GetConnection("issues", t, protocol, nil, nil, nil)
 			require.NoError(t, err)
 			runFloatBindingAssertions(t, func(dest any, query string, args ...any) error {
 				return conn.QueryRow(ctx, query, args...).Scan(dest)

--- a/tests/issues/issue_1862_test.go
+++ b/tests/issues/issue_1862_test.go
@@ -1,0 +1,127 @@
+package issues
+
+import (
+	"context"
+	"crypto/tls"
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+)
+
+// queryRowFunc abstracts single-row parameter binding + scan so the same
+// assertions can run against both the native (Open) and std (OpenDB) APIs.
+type queryRowFunc func(dest any, query string, args ...any) error
+
+// Test1862_FloatBinding is a regression test for issue #1862: binding a
+// float64/float32 parameter used to fall through to fmt.Sprint, so an
+// integer-valued float like 1.0 rendered as the bare literal "1".
+//
+// ClickHouse then inferred an integer type and a later typed scan into a *float64 failed
+// with "converting UInt8 to *float64 is unsupported". Non-finite values were
+// broken too, since Go prints "NaN"/"+Inf" while ClickHouse only parses the
+// lowercase nan/inf spellings.
+//
+// The float now renders as cast(<value>, 'Float32'|'Float64'), so this test
+// binds float scalars, arrays, and maps and scans them back, exercising the
+// fix end-to-end across both protocols (native TCP and HTTP) and both APIs.
+func Test1862_FloatBinding(t *testing.T) {
+	useSSL, err := strconv.ParseBool(clickhouse_tests.GetEnv("CLICKHOUSE_USE_SSL", "false"))
+	require.NoError(t, err)
+	var tlsConfig *tls.Config
+	if useSSL {
+		tlsConfig = &tls.Config{}
+	}
+
+	ctx := context.Background()
+
+	for _, protocol := range []clickhouse.Protocol{clickhouse.Native, clickhouse.HTTP} {
+		protocol := protocol
+
+		t.Run("native/"+protocol.String(), func(t *testing.T) {
+			conn, err := clickhouse_tests.GetConnection("issues", t, protocol, nil, tlsConfig, nil)
+			require.NoError(t, err)
+			runFloatBindingAssertions(t, func(dest any, query string, args ...any) error {
+				return conn.QueryRow(ctx, query, args...).Scan(dest)
+			})
+		})
+
+		t.Run("std/"+protocol.String(), func(t *testing.T) {
+			conn, err := clickhouse_std_tests.GetOpenDBConnection("issues", protocol, nil, tlsConfig, nil)
+			require.NoError(t, err)
+			defer conn.Close()
+			runFloatBindingAssertions(t, func(dest any, query string, args ...any) error {
+				return conn.QueryRowContext(ctx, query, args...).Scan(dest)
+			})
+		})
+	}
+}
+
+func runFloatBindingAssertions(t *testing.T, queryRow queryRowFunc) {
+	t.Run("float64", func(t *testing.T) {
+		cases := []struct {
+			name  string
+			param float64
+		}{
+			{"integer-valued", 1.0},
+			{"fractional", 1.5},
+			{"negative", -2.0},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				var got float64
+				require.NoError(t, queryRow(&got, "SELECT ?", c.param))
+				assert.Equal(t, c.param, got, "bound %v", c.param)
+			})
+		}
+	})
+
+	t.Run("float32", func(t *testing.T) {
+		cases := []struct {
+			name  string
+			param float32
+		}{
+			{"integer-valued", 1.0},
+			{"fractional", 2.5},
+			{"negative", -2.0},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				var got float32
+				require.NoError(t, queryRow(&got, "SELECT ?", c.param))
+				assert.Equal(t, c.param, got, "bound %v", c.param)
+			})
+		}
+	})
+
+	t.Run("non-finite", func(t *testing.T) {
+		var got float64
+
+		require.NoError(t, queryRow(&got, "SELECT ?", math.Inf(1)))
+		assert.True(t, math.IsInf(got, 1), "expected +Inf, got %v", got)
+
+		require.NoError(t, queryRow(&got, "SELECT ?", math.Inf(-1)))
+		assert.True(t, math.IsInf(got, -1), "expected -Inf, got %v", got)
+
+		require.NoError(t, queryRow(&got, "SELECT ?", math.NaN()))
+		assert.True(t, math.IsNaN(got), "expected NaN, got %v", got)
+	})
+
+	t.Run("array of float64", func(t *testing.T) {
+		var got []float64
+		require.NoError(t, queryRow(&got, "SELECT ?", []float64{1.0, 2.5, -3.0}))
+		assert.Equal(t, []float64{1.0, 2.5, -3.0}, got)
+	})
+
+	t.Run("map of float64", func(t *testing.T) {
+		var got map[string]float64
+		require.NoError(t, queryRow(&got, "SELECT ?", map[string]float64{"a": 1.0, "b": 2.5}))
+		assert.Equal(t, map[string]float64{"a": 1.0, "b": 2.5}, got)
+	})
+}


### PR DESCRIPTION
Binding a float parameter renders it wrong today. A float64/float32 falls through the switch in `format()` to `fmt.Sprint`, so `1.0` comes out as the bare literal `1`. ClickHouse then reads that as an integer, and a later typed scan into a `*float64` fails with "converting UInt8 to *float64 is unsupported". Non-finite values are broken too, since Go prints `NaN` and `+Inf` but ClickHouse only parses the lowercase `nan`/`inf` spellings, so binding one produces a SQL syntax error.

This adds float32/float64 cases (plus the matching reflect kinds) that render the value as `cast(<value>, 'Float32'|'Float64')`, which pins the type and uses the spellings ClickHouse accepts for non-finite values. Closes #1862.

I added a `TestFormatFloat` regression test in `bind_test.go` covering integer-valued, fractional, and non-finite floats for both widths. Thanks for taking a look.
