### PR TITLE
fix: escaping for string keys in Map parameter binding

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -568,9 +568,9 @@ func format(tz *time.Location, scale TimeUnit, v any) (string, error) {
 	case reflect.Map: // map
 		values := make([]string, 0, len(v.MapKeys()))
 		for _, key := range v.MapKeys() {
-			name := fmt.Sprint(key.Interface())
-			if key.Kind() == reflect.String {
-				name = fmt.Sprintf("'%s'", name)
+			name, err := format(tz, scale, key.Interface())
+			if err != nil {
+				return "", err
 			}
 			val, err := format(tz, scale, v.MapIndex(key).Interface())
 			if err != nil {

--- a/bind_test.go
+++ b/bind_test.go
@@ -610,6 +610,12 @@ func TestFormatMap(t *testing.T) {
 	assert.Equal(t, "map('a', 1)", val)
 }
 
+func TestFormatMapEscapesStringKeys(t *testing.T) {
+	val, err := format(time.UTC, Seconds, map[string]uint8{`a'b\c`: 1})
+	require.NoError(t, err)
+	assert.Equal(t, `map('a\'b\\c', 1)`, val)
+}
+
 func TestTimezoneSQLEscaping(t *testing.T) {
 	t.Run("prevent SQL injection via timezone name", func(t *testing.T) {
 		maliciousLoc := time.FixedZone("UTC') UNION ALL SELECT 1,2,3 --", 0)


### PR DESCRIPTION
Changes:

- Updated reflect.Map parameter formatting so map keys reuse the shared format() escaping path.
- Prevent invalid SQL generation when map[string]... keys contain single quotes or backslashes.
- Added a regression test for map string keys containing ' and \.
