### PR TITLE
chore: fix the `formatValue` helper for complex types

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -481,9 +481,10 @@ const (
 	formatSQL formatMode = iota
 	// formatParamText produces the text format the server expects for
 	// {name:Type} query parameters: bools as true/false, maps as {'k':v},
-	// floats as plain numbers, times as quoted '2006-01-02 15:04:05'
-	// strings. The server parses these values with the declared type's text
-	// reader, which does not understand SQL function syntax.
+	// floats as plain numbers, times as quoted epoch seconds like
+	// '1577934245' (see formatTimeParam). The server parses these values
+	// with the declared type's text reader, which does not understand SQL
+	// function syntax.
 	formatParamText
 )
 

--- a/bind.go
+++ b/bind.go
@@ -468,27 +468,43 @@ func formatTime(tz *time.Location, scale TimeUnit, value time.Time) (string, err
 
 var stringQuoteReplacer = strings.NewReplacer(`\`, `\\`, `'`, `\'`)
 
+// formatMode selects the output syntax formatValue emits. SQL literals and
+// the server's query-parameter text format diverge for several types, so the
+// caller must say which of the two it is producing.
+type formatMode uint8
+
+const (
+	// formatSQL renders v as a SQL literal for client-side binding, where
+	// placeholders like `?`, `$1`, and `@name` are replaced directly in the
+	// query text: bools as `1`/`0`, maps as `map('k', v)`, floats as
+	// `cast(..., 'Float64')`, times as `toDateTime(...)`.
+	formatSQL formatMode = iota
+	// formatParamText renders v in the text format the server's
+	// query-parameter parser (`{name:Type}`) expects. The server deserializes
+	// parameter values with the declared type's text reader, which accepts
+	// SQL-function syntax for none of the composite types: bools must be
+	// `true`/`false`, maps `{'k':v}`, floats plain literals (`1.5`, `nan`,
+	// `inf`), times quoted `'2006-01-02 15:04:05'` strings.
+	formatParamText
+)
+
 // format turns v into a SQL literal for client-side binding, where
 // placeholders like `?`, `$1`, and `@name` are replaced directly in the query
-// text. Bools become `1`/`0` here, which is valid SQL. Server-side query
-// parameters need `true`/`false` instead — see formatValue.
+// text. Server-side query parameters need the text format instead — see
+// formatValue.
 func format(tz *time.Location, scale TimeUnit, v any) (string, error) {
-	return formatValue(tz, scale, v, false)
+	return formatValue(tz, scale, v, formatSQL)
 }
 
-// formatValue turns v into a string. The boolAsText flag picks how bools are
-// written:
+// formatValue turns v into a string using the syntax picked by mode (see
+// formatMode). The mode is passed down into nested values, so a bool or map
+// inside an array, map, or tuple is formatted the same way at any depth.
 //
-//   - false: for client-side binding, where the value is spliced into the
-//     query text. Bools become `1`/`0`.
-//   - true: for server-side query parameters (`{name:Type}`). The server
-//     parses these values as text, and its text parser only accepts
-//     `true`/`false` for bools inside types like `Array(Bool)` — `1`/`0` is
-//     rejected.
-//
-// The flag is passed down into nested values, so a bool inside an array, map,
-// or tuple is formatted the same way at any depth.
-func formatValue(tz *time.Location, scale TimeUnit, v any, boolAsText bool) (string, error) {
+// In formatParamText mode values are rendered with the quoting rules the
+// server applies to elements nested inside a composite type (strings and
+// times quoted). A top-level String or DateTime parameter must be sent raw
+// instead; bindQueryOrAppendParameters handles that case before calling here.
+func formatValue(tz *time.Location, scale TimeUnit, v any, mode formatMode) (string, error) {
 	quote := func(v string) string {
 		return "'" + stringQuoteReplacer.Replace(v) + "'"
 	}
@@ -498,14 +514,20 @@ func formatValue(tz *time.Location, scale TimeUnit, v any, boolAsText bool) (str
 	case string:
 		return quote(v), nil
 	case time.Time:
+		if mode == formatParamText {
+			return quote(formatTimeWithScale(v, scale)), nil
+		}
 		return formatTime(tz, scale, v)
 	case *time.Time:
 		if v == nil {
 			return "NULL", nil
 		}
+		if mode == formatParamText {
+			return quote(formatTimeWithScale(*v, scale)), nil
+		}
 		return formatTime(tz, scale, *v)
 	case bool:
-		if boolAsText {
+		if mode == formatParamText {
 			if v {
 				return "true", nil
 			}
@@ -516,23 +538,23 @@ func formatValue(tz *time.Location, scale TimeUnit, v any, boolAsText bool) (str
 		}
 		return "0", nil
 	case float32:
-		return formatFloat(float64(v), 32), nil
+		return formatFloat(float64(v), 32, mode), nil
 	case float64:
-		return formatFloat(v, 64), nil
+		return formatFloat(v, 64, mode), nil
 	case GroupSet:
-		val, err := join(tz, scale, v.Value, boolAsText)
+		val, err := join(tz, scale, v.Value, mode)
 		if err != nil {
 			return "", err
 		}
 		return fmt.Sprintf("(%s)", val), nil
 	case []GroupSet:
-		val, err := join(tz, scale, v, boolAsText)
+		val, err := join(tz, scale, v, mode)
 		if err != nil {
 			return "", err
 		}
 		return val, err
 	case ArraySet:
-		val, err := join(tz, scale, v, boolAsText)
+		val, err := join(tz, scale, v, mode)
 		if err != nil {
 			return "", err
 		}
@@ -545,38 +567,36 @@ func formatValue(tz *time.Location, scale TimeUnit, v any, boolAsText bool) (str
 		}
 		return quote(v.String()), nil
 	case column.OrderedMap:
-		values := make([]string, 0)
+		entries := make([]mapEntry, 0)
 		for key := range v.Keys() {
-			name, err := formatValue(tz, scale, key, boolAsText)
+			name, err := formatValue(tz, scale, key, mode)
 			if err != nil {
 				return "", err
 			}
 			value, _ := v.Get(key)
-			val, err := formatValue(tz, scale, value, boolAsText)
+			val, err := formatValue(tz, scale, value, mode)
 			if err != nil {
 				return "", err
 			}
-			values = append(values, fmt.Sprintf("%s, %s", name, val))
+			entries = append(entries, mapEntry{name, val})
 		}
-
-		return "map(" + strings.Join(values, ", ") + ")", nil
+		return formatMap(entries, mode), nil
 	case column.IterableOrderedMap:
-		values := make([]string, 0)
+		entries := make([]mapEntry, 0)
 		iter := v.Iterator()
 		for iter.Next() {
 			key, value := iter.Key(), iter.Value()
-			name, err := formatValue(tz, scale, key, boolAsText)
+			name, err := formatValue(tz, scale, key, mode)
 			if err != nil {
 				return "", err
 			}
-			val, err := formatValue(tz, scale, value, boolAsText)
+			val, err := formatValue(tz, scale, value, mode)
 			if err != nil {
 				return "", err
 			}
-			values = append(values, fmt.Sprintf("%s, %s", name, val))
+			entries = append(entries, mapEntry{name, val})
 		}
-
-		return "map(" + strings.Join(values, ", ") + ")", nil
+		return formatMap(entries, mode), nil
 	}
 	switch v := reflect.ValueOf(v); v.Kind() {
 	case reflect.String:
@@ -584,7 +604,7 @@ func formatValue(tz *time.Location, scale TimeUnit, v any, boolAsText bool) (str
 	case reflect.Slice, reflect.Array:
 		values := make([]string, 0, v.Len())
 		for i := 0; i < v.Len(); i++ {
-			val, err := formatValue(tz, scale, v.Index(i).Interface(), boolAsText)
+			val, err := formatValue(tz, scale, v.Index(i).Interface(), mode)
 			if err != nil {
 				return "", err
 			}
@@ -592,38 +612,78 @@ func formatValue(tz *time.Location, scale TimeUnit, v any, boolAsText bool) (str
 		}
 		return fmt.Sprintf("[%s]", strings.Join(values, ", ")), nil
 	case reflect.Map: // map
-		values := make([]string, 0, len(v.MapKeys()))
+		entries := make([]mapEntry, 0, v.Len())
 		for _, key := range v.MapKeys() {
-			name, err := format(tz, scale, key.Interface())
+			name, err := formatValue(tz, scale, key.Interface(), mode)
 			if err != nil {
 				return "", err
 			}
-			val, err := formatValue(tz, scale, v.MapIndex(key).Interface(), boolAsText)
+			val, err := formatValue(tz, scale, v.MapIndex(key).Interface(), mode)
 			if err != nil {
 				return "", err
 			}
-			values = append(values, fmt.Sprintf("%s, %s", name, val))
+			entries = append(entries, mapEntry{name, val})
 		}
-		return "map(" + strings.Join(values, ", ") + ")", nil
+		return formatMap(entries, mode), nil
 	case reflect.Float32:
-		return formatFloat(v.Float(), 32), nil
+		return formatFloat(v.Float(), 32, mode), nil
 	case reflect.Float64:
-		return formatFloat(v.Float(), 64), nil
+		return formatFloat(v.Float(), 64, mode), nil
 	case reflect.Ptr:
 		if v.IsNil() {
 			return "NULL", nil
 		}
-		return formatValue(tz, scale, v.Elem().Interface(), boolAsText)
+		return formatValue(tz, scale, v.Elem().Interface(), mode)
 	}
 	return fmt.Sprint(v), nil
 }
 
-// formatFloat renders a float as a CAST to the matching ClickHouse Float type.
+// mapEntry is one formatted key/value pair of a map value.
+type mapEntry struct {
+	key, value string
+}
+
+// formatMap assembles formatted key/value pairs into the map syntax for the
+// given mode: the `map('k', v, ...)` SQL function for client-side binding, or
+// the `{'k':v,...}` text format the server's query-parameter parser expects.
+func formatMap(entries []mapEntry, mode formatMode) string {
+	pairs := make([]string, len(entries))
+	if mode == formatParamText {
+		for i, e := range entries {
+			pairs[i] = e.key + ":" + e.value
+		}
+		return "{" + strings.Join(pairs, ",") + "}"
+	}
+	for i, e := range entries {
+		pairs[i] = e.key + ", " + e.value
+	}
+	return "map(" + strings.Join(pairs, ", ") + ")"
+}
+
+// formatFloat renders a float.
+//
+// In formatSQL mode it emits a CAST to the matching ClickHouse Float type.
 // Without the cast, integer-valued floats like 1.0 render as the bare literal
 // "1", which ClickHouse infers as an integer and later narrows (breaking typed
 // float scans). NaN and infinities are quoted in the lowercase form ClickHouse
 // accepts, since Go's default formatting ("NaN", "+Inf") is not valid SQL.
-func formatFloat(f float64, bitSize int) string {
+//
+// In formatParamText mode it emits the plain literal instead: the server's
+// query-parameter parser reads the value with the declared type's text reader,
+// which rejects the cast(...) function syntax but accepts bare `nan`, `inf`,
+// and `-inf`. The declared parameter type makes the CAST unnecessary.
+func formatFloat(f float64, bitSize int, mode formatMode) string {
+	if mode == formatParamText {
+		switch {
+		case math.IsNaN(f):
+			return "nan"
+		case math.IsInf(f, 1):
+			return "inf"
+		case math.IsInf(f, -1):
+			return "-inf"
+		}
+		return strconv.FormatFloat(f, 'g', -1, bitSize)
+	}
 	chType := "Float64"
 	if bitSize == 32 {
 		chType = "Float32"
@@ -639,10 +699,10 @@ func formatFloat(f float64, bitSize int) string {
 	return fmt.Sprintf("cast(%s, '%s')", strconv.FormatFloat(f, 'g', -1, bitSize), chType)
 }
 
-func join[E any](tz *time.Location, scale TimeUnit, values []E, boolAsText bool) (string, error) {
+func join[E any](tz *time.Location, scale TimeUnit, values []E, mode formatMode) (string, error) {
 	items := make([]string, len(values))
 	for i := range values {
-		val, err := formatValue(tz, scale, values[i], boolAsText)
+		val, err := formatValue(tz, scale, values[i], mode)
 		if err != nil {
 			return "", err
 		}

--- a/bind.go
+++ b/bind.go
@@ -468,42 +468,39 @@ func formatTime(tz *time.Location, scale TimeUnit, value time.Time) (string, err
 
 var stringQuoteReplacer = strings.NewReplacer(`\`, `\\`, `'`, `\'`)
 
-// formatMode selects the output syntax formatValue emits. SQL literals and
-// the server's query-parameter text format diverge for several types, so the
-// caller must say which of the two it is producing.
+// formatMode says which syntax formatValue should produce. A value spliced
+// into the query text needs SQL syntax; a server-side query parameter needs
+// the text format the server parses instead. The two disagree for bools,
+// maps, floats, and times, so the caller has to pick one.
 type formatMode uint8
 
 const (
-	// formatSQL renders v as a SQL literal for client-side binding, where
-	// placeholders like `?`, `$1`, and `@name` are replaced directly in the
-	// query text: bools as `1`/`0`, maps as `map('k', v)`, floats as
-	// `cast(..., 'Float64')`, times as `toDateTime(...)`.
+	// formatSQL produces SQL literals for client-side binding (the ?, $1,
+	// and @name placeholders): bools as 1/0, maps as map('k', v), floats as
+	// cast(..., 'Float64'), times as toDateTime(...).
 	formatSQL formatMode = iota
-	// formatParamText renders v in the text format the server's
-	// query-parameter parser (`{name:Type}`) expects. The server deserializes
-	// parameter values with the declared type's text reader, which accepts
-	// SQL-function syntax for none of the composite types: bools must be
-	// `true`/`false`, maps `{'k':v}`, floats plain literals (`1.5`, `nan`,
-	// `inf`), times quoted `'2006-01-02 15:04:05'` strings.
+	// formatParamText produces the text format the server expects for
+	// {name:Type} query parameters: bools as true/false, maps as {'k':v},
+	// floats as plain numbers, times as quoted '2006-01-02 15:04:05'
+	// strings. The server parses these values with the declared type's text
+	// reader, which does not understand SQL function syntax.
 	formatParamText
 )
 
 // format turns v into a SQL literal for client-side binding, where
 // placeholders like `?`, `$1`, and `@name` are replaced directly in the query
-// text. Server-side query parameters need the text format instead — see
-// formatValue.
+// text. Server-side query parameters need formatParamText instead.
 func format(tz *time.Location, scale TimeUnit, v any) (string, error) {
 	return formatValue(tz, scale, v, formatSQL)
 }
 
-// formatValue turns v into a string using the syntax picked by mode (see
-// formatMode). The mode is passed down into nested values, so a bool or map
-// inside an array, map, or tuple is formatted the same way at any depth.
+// formatValue turns v into a string in the given mode. The mode carries down
+// into nested values, so a bool or map keeps its formatting at any depth.
 //
-// In formatParamText mode values are rendered with the quoting rules the
-// server applies to elements nested inside a composite type (strings and
-// times quoted). A top-level String or DateTime parameter must be sent raw
-// instead; bindQueryOrAppendParameters handles that case before calling here.
+// In formatParamText mode, values come out quoted the way the server expects
+// them *inside* a composite type. Top-level String and DateTime parameters
+// must be sent raw instead — bindQueryOrAppendParameters takes care of those
+// before calling here.
 func formatValue(tz *time.Location, scale TimeUnit, v any, mode formatMode) (string, error) {
 	quote := func(v string) string {
 		return "'" + stringQuoteReplacer.Replace(v) + "'"
@@ -638,14 +635,13 @@ func formatValue(tz *time.Location, scale TimeUnit, v any, mode formatMode) (str
 	return fmt.Sprint(v), nil
 }
 
-// mapEntry is one formatted key/value pair of a map value.
+// mapEntry is one already-formatted key/value pair of a map.
 type mapEntry struct {
 	key, value string
 }
 
-// formatMap assembles formatted key/value pairs into the map syntax for the
-// given mode: the `map('k', v, ...)` SQL function for client-side binding, or
-// the `{'k':v,...}` text format the server's query-parameter parser expects.
+// formatMap joins formatted key/value pairs into a whole map: map('k', v)
+// in SQL mode, {'k':v} in query-parameter text mode.
 func formatMap(entries []mapEntry, mode formatMode) string {
 	pairs := make([]string, len(entries))
 	if mode == formatParamText {
@@ -662,16 +658,15 @@ func formatMap(entries []mapEntry, mode formatMode) string {
 
 // formatFloat renders a float.
 //
-// In formatSQL mode it emits a CAST to the matching ClickHouse Float type.
-// Without the cast, integer-valued floats like 1.0 render as the bare literal
-// "1", which ClickHouse infers as an integer and later narrows (breaking typed
-// float scans). NaN and infinities are quoted in the lowercase form ClickHouse
-// accepts, since Go's default formatting ("NaN", "+Inf") is not valid SQL.
+// In SQL mode it wraps the number in a CAST to the matching Float type.
+// Without it, a value like 1.0 renders as the bare literal "1", which
+// ClickHouse treats as an integer and later narrows, breaking typed float
+// scans. NaN and infinities are quoted in the lowercase form ClickHouse
+// accepts, since Go's "NaN" and "+Inf" are not valid SQL.
 //
-// In formatParamText mode it emits the plain literal instead: the server's
-// query-parameter parser reads the value with the declared type's text reader,
-// which rejects the cast(...) function syntax but accepts bare `nan`, `inf`,
-// and `-inf`. The declared parameter type makes the CAST unnecessary.
+// In query-parameter text mode none of that applies: the parameter already
+// has a declared type, and the server's text reader rejects cast(...) but
+// happily takes plain numbers and bare nan/inf/-inf.
 func formatFloat(f float64, bitSize int, mode formatMode) string {
 	if mode == formatParamText {
 		switch {

--- a/bind.go
+++ b/bind.go
@@ -512,7 +512,7 @@ func formatValue(tz *time.Location, scale TimeUnit, v any, mode formatMode) (str
 		return quote(v), nil
 	case time.Time:
 		if mode == formatParamText {
-			return quote(formatTimeWithScale(v, scale)), nil
+			return quote(formatTimeParam(v)), nil
 		}
 		return formatTime(tz, scale, v)
 	case *time.Time:
@@ -520,7 +520,7 @@ func formatValue(tz *time.Location, scale TimeUnit, v any, mode formatMode) (str
 			return "NULL", nil
 		}
 		if mode == formatParamText {
-			return quote(formatTimeWithScale(*v, scale)), nil
+			return quote(formatTimeParam(*v)), nil
 		}
 		return formatTime(tz, scale, *v)
 	case bool:

--- a/bind_test.go
+++ b/bind_test.go
@@ -665,9 +665,9 @@ func TestTimezoneSQLEscaping(t *testing.T) {
 		assert.Contains(t, val, "toDateTime(")
 	})
 
-	// Query-parameter formatting writes times with fixed numeric layouts and
-	// never includes the timezone name, so a malicious name has nothing to
-	// leak into. These lock that in for both the nested and top-level paths.
+	// Query-parameter formatting writes times as epoch digits and never
+	// includes the timezone name, so a malicious name has nothing to leak
+	// into. These lock that in for both the nested and top-level paths.
 	t.Run("timezone name never reaches query-parameter text", func(t *testing.T) {
 		maliciousLoc := time.FixedZone("UTC') UNION ALL SELECT 1,2,3 --", 0)
 		maliciousTime := time.Date(2020, 1, 2, 3, 4, 5, 0, maliciousLoc)
@@ -675,14 +675,14 @@ func TestTimezoneSQLEscaping(t *testing.T) {
 		// Nested inside a composite value.
 		val, err := formatValue(time.UTC, Seconds, []time.Time{maliciousTime}, formatParamText)
 		require.NoError(t, err)
-		assert.Equal(t, "['2020-01-02 03:04:05']", val)
+		assert.Equal(t, "['1577934245']", val)
 
 		// Top-level Named value.
 		opts := &QueryOptions{}
 		_, err = bindQueryOrAppendParameters(true, opts, "SELECT {d:DateTime}", time.UTC,
 			driver.NamedValue{Name: "d", Value: maliciousTime})
 		require.NoError(t, err)
-		assert.Equal(t, "2020-01-02 03:04:05", opts.parameters["d"])
+		assert.Equal(t, "1577934245", opts.parameters["d"])
 	})
 
 	t.Run("malicious string stays escaped in query-parameter text", func(t *testing.T) {
@@ -785,14 +785,14 @@ func TestFormatValueModes(t *testing.T) {
 		{"Float64 +Inf", math.Inf(1), "inf", "cast('inf', 'Float64')"},
 		{"Float64 -Inf", math.Inf(-1), "-inf", "cast('-inf', 'Float64')"},
 		{"Map(String, Float64)", map[string]float64{"a": 1.5}, "{'a':1.5}", "map('a', cast(1.5, 'Float64'))"},
-		// nested times: quoted text vs toDateTime() SQL function
+		// nested times: quoted epoch (zone-free) vs toDateTime() SQL function
 		{"Array(DateTime)", []time.Time{ts},
-			"['2020-01-02 03:04:05']", "[toDateTime('2020-01-02 03:04:05')]"},
+			"['1577934245']", "[toDateTime('2020-01-02 03:04:05')]"},
 		{"Map(String, DateTime)", map[string]time.Time{"a": ts},
-			"{'a':'2020-01-02 03:04:05'}", "map('a', toDateTime('2020-01-02 03:04:05'))"},
+			"{'a':'1577934245'}", "map('a', toDateTime('2020-01-02 03:04:05'))"},
 		// a sub-second time keeps its fraction in param mode (for DateTime64)
 		{"Map(String, DateTime64)", map[string]time.Time{"a": ts.Add(123 * time.Millisecond)},
-			"{'a':'2020-01-02 03:04:05.123'}", "map('a', toDateTime('2020-01-02 03:04:05'))"},
+			"{'a':'1577934245.123'}", "map('a', toDateTime('2020-01-02 03:04:05'))"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -808,20 +808,28 @@ func TestFormatValueModes(t *testing.T) {
 }
 
 // TestFormatTimeParam checks how a time.Time is rendered as a query
-// parameter: whole seconds stay plain, sub-second values keep their fraction
-// trimmed to milli/micro/nanoseconds so a DateTime64 parameter doesn't lose
-// precision.
+// parameter: epoch seconds, so the instant survives no matter which timezone
+// the value carries or the parameter declares. Sub-second values keep their
+// fraction trimmed to milli/micro/nanoseconds so a DateTime64 parameter
+// doesn't lose precision.
 func TestFormatTimeParam(t *testing.T) {
-	base := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+	base := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC) // epoch 1577934245
+	tokyo := time.FixedZone("Asia/Tokyo", 9*3600)
 	cases := []struct {
 		name string
 		in   time.Time
 		want string
 	}{
-		{"whole seconds", base, "2020-01-02 03:04:05"},
-		{"milliseconds", base.Add(123 * time.Millisecond), "2020-01-02 03:04:05.123"},
-		{"microseconds", base.Add(123456 * time.Microsecond), "2020-01-02 03:04:05.123456"},
-		{"nanoseconds", base.Add(123456789 * time.Nanosecond), "2020-01-02 03:04:05.123456789"},
+		{"whole seconds", base, "1577934245"},
+		{"milliseconds", base.Add(123 * time.Millisecond), "1577934245.123"},
+		{"microseconds", base.Add(123456 * time.Microsecond), "1577934245.123456"},
+		{"nanoseconds", base.Add(123456789 * time.Nanosecond), "1577934245.123456789"},
+		// the same instant expressed in another zone renders identically
+		{"non-UTC zone, same instant", base.In(tokyo), "1577934245"},
+		// pre-1970 instants: the sign must cover the fraction too
+		// (-86400.5 seconds, not -86401 + 0.5)
+		{"pre-1970 sub-second", time.Date(1969, 12, 30, 23, 59, 59, 500000000, time.UTC), "-86400.500"},
+		{"pre-1970 whole second", time.Date(1969, 12, 31, 0, 0, 0, 0, time.UTC), "-86400"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/bind_test.go
+++ b/bind_test.go
@@ -713,13 +713,12 @@ func TestFormatMapOrdered(t *testing.T) {
 	assert.Equal(t, "map('b', 2, 'a', 1)", val)
 }
 
-// TestFormatValueModes covers the fixes for #1891 and #1898. Server-side
-// query parameters ({name:Type}) are parsed by the server as text, which
-// diverges from SQL-literal syntax: bools must be `true`/`false` (not
-// `1`/`0`), maps `{'k':v}` (not `map('k', v)`), floats plain literals (not
-// `cast(...)`), and times quoted date-time strings (not `toDateTime(...)`).
-// Client-side binding (the ?/$1/@name placeholders) must keep the SQL-literal
-// forms. Both apply at any nesting depth.
+// TestFormatValueModes covers the fixes for #1891 and #1898. The server
+// parses {name:Type} query parameters as text, not SQL: bools must be
+// true/false instead of 1/0, maps {'k':v} instead of map('k', v), floats
+// plain numbers instead of cast(...), times quoted strings instead of
+// toDateTime(...). Client-side binding (the ?/$1/@name placeholders) must
+// keep the SQL forms. Both hold at any nesting depth.
 func TestFormatValueModes(t *testing.T) {
 	tru, fls := true, false
 	ts := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
@@ -776,9 +775,8 @@ func TestFormatValueModes(t *testing.T) {
 	}
 }
 
-// TestFormatValueModesOrderedMap is the ordered-map variant of
-// TestFormatValueModes: column.OrderedMap and column.IterableOrderedMap
-// values must follow the same map syntax switch as plain Go maps.
+// TestFormatValueModesOrderedMap checks that ordered maps switch syntax
+// between the two modes just like plain Go maps do.
 func TestFormatValueModesOrderedMap(t *testing.T) {
 	om := NewOrderedMap()
 	om.Put("b", true)

--- a/bind_test.go
+++ b/bind_test.go
@@ -830,6 +830,34 @@ func TestFormatTimeParam(t *testing.T) {
 	}
 }
 
+// TestNilQueryParameter checks that a nil sent as a query parameter becomes
+// `\N` — the whole-text NULL marker. The `NULL` keyword only works nested
+// inside composites; at the top level the server would read it as the string
+// "NULL" or fail to parse it.
+func TestNilQueryParameter(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{"untyped nil", nil, `\N`},
+		{"nil *string", (*string)(nil), `\N`},
+		{"nil *time.Time", (*time.Time)(nil), `\N`},
+		{"nil *int", (*int)(nil), `\N`},
+		// nils nested inside a composite keep the NULL keyword
+		{"nil inside array", []*string{nil}, "[NULL]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &QueryOptions{}
+			_, err := bindQueryOrAppendParameters(true, opts, "SELECT {p:Nullable(String)}", time.UTC,
+				driver.NamedValue{Name: "p", Value: tc.value})
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, opts.parameters["p"])
+		})
+	}
+}
+
 // TestFormatValueModesOrderedMap checks that ordered maps switch syntax
 // between the two modes just like plain Go maps do.
 func TestFormatValueModesOrderedMap(t *testing.T) {

--- a/bind_test.go
+++ b/bind_test.go
@@ -745,7 +745,7 @@ func TestFormatMapOrdered(t *testing.T) {
 // TestFormatValueModes covers the fixes for #1891 and #1898. The server
 // parses {name:Type} query parameters as text, not SQL: bools must be
 // true/false instead of 1/0, maps {'k':v} instead of map('k', v), floats
-// plain numbers instead of cast(...), times quoted strings instead of
+// plain numbers instead of cast(...), times quoted epoch strings instead of
 // toDateTime(...). Client-side binding (the ?/$1/@name placeholders) must
 // keep the SQL forms. Both hold at any nesting depth.
 func TestFormatValueModes(t *testing.T) {

--- a/bind_test.go
+++ b/bind_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 )
 
 func TestBindNumeric(t *testing.T) {
@@ -662,6 +664,33 @@ func TestTimezoneSQLEscaping(t *testing.T) {
 		assert.NotContains(t, val, `\'`, "Normal timezone names should not have escaped quotes")
 		assert.Contains(t, val, "toDateTime(")
 	})
+
+	// Query-parameter formatting writes times with fixed numeric layouts and
+	// never includes the timezone name, so a malicious name has nothing to
+	// leak into. These lock that in for both the nested and top-level paths.
+	t.Run("timezone name never reaches query-parameter text", func(t *testing.T) {
+		maliciousLoc := time.FixedZone("UTC') UNION ALL SELECT 1,2,3 --", 0)
+		maliciousTime := time.Date(2020, 1, 2, 3, 4, 5, 0, maliciousLoc)
+
+		// Nested inside a composite value.
+		val, err := formatValue(time.UTC, Seconds, []time.Time{maliciousTime}, formatParamText)
+		require.NoError(t, err)
+		assert.Equal(t, "['2020-01-02 03:04:05']", val)
+
+		// Top-level Named value.
+		opts := &QueryOptions{}
+		_, err = bindQueryOrAppendParameters(true, opts, "SELECT {d:DateTime}", time.UTC,
+			driver.NamedValue{Name: "d", Value: maliciousTime})
+		require.NoError(t, err)
+		assert.Equal(t, "2020-01-02 03:04:05", opts.parameters["d"])
+	})
+
+	t.Run("malicious string stays escaped in query-parameter text", func(t *testing.T) {
+		payload := `'} UNION ALL SELECT 1 --`
+		val, err := formatValue(time.UTC, Seconds, map[string]string{"k": payload}, formatParamText)
+		require.NoError(t, err)
+		assert.Equal(t, `{'k':'\'} UNION ALL SELECT 1 --'}`, val)
+	})
 }
 
 // a simple (non thread safe) ordered map, implementing the column.OrderedMap interface
@@ -761,6 +790,9 @@ func TestFormatValueModes(t *testing.T) {
 			"['2020-01-02 03:04:05']", "[toDateTime('2020-01-02 03:04:05')]"},
 		{"Map(String, DateTime)", map[string]time.Time{"a": ts},
 			"{'a':'2020-01-02 03:04:05'}", "map('a', toDateTime('2020-01-02 03:04:05'))"},
+		// a sub-second time keeps its fraction in param mode (for DateTime64)
+		{"Map(String, DateTime64)", map[string]time.Time{"a": ts.Add(123 * time.Millisecond)},
+			"{'a':'2020-01-02 03:04:05.123'}", "map('a', toDateTime('2020-01-02 03:04:05'))"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -771,6 +803,29 @@ func TestFormatValueModes(t *testing.T) {
 			got, err = formatValue(time.UTC, Seconds, tc.value, formatSQL)
 			require.NoError(t, err)
 			assert.Equal(t, tc.bindSQL, got, "client-side bind formatting must be unchanged")
+		})
+	}
+}
+
+// TestFormatTimeParam checks how a time.Time is rendered as a query
+// parameter: whole seconds stay plain, sub-second values keep their fraction
+// trimmed to milli/micro/nanoseconds so a DateTime64 parameter doesn't lose
+// precision.
+func TestFormatTimeParam(t *testing.T) {
+	base := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+	cases := []struct {
+		name string
+		in   time.Time
+		want string
+	}{
+		{"whole seconds", base, "2020-01-02 03:04:05"},
+		{"milliseconds", base.Add(123 * time.Millisecond), "2020-01-02 03:04:05.123"},
+		{"microseconds", base.Add(123456 * time.Microsecond), "2020-01-02 03:04:05.123456"},
+		{"nanoseconds", base.Add(123456789 * time.Nanosecond), "2020-01-02 03:04:05.123456789"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, formatTimeParam(tc.in))
 		})
 	}
 }

--- a/bind_test.go
+++ b/bind_test.go
@@ -713,18 +713,21 @@ func TestFormatMapOrdered(t *testing.T) {
 	assert.Equal(t, "map('b', 2, 'a', 1)", val)
 }
 
-// TestFormatValueBoolAsText covers the fix for #1891. When formatting a
-// server-side query parameter (boolAsText=true), bools must come out as
-// `true`/`false`, no matter how deeply nested. When formatting for client-side
-// binding (boolAsText=false, the ?/$1/@name placeholders), they must stay
-// `1`/`0` as before.
-func TestFormatValueBoolAsText(t *testing.T) {
+// TestFormatValueModes covers the fixes for #1891 and #1898. Server-side
+// query parameters ({name:Type}) are parsed by the server as text, which
+// diverges from SQL-literal syntax: bools must be `true`/`false` (not
+// `1`/`0`), maps `{'k':v}` (not `map('k', v)`), floats plain literals (not
+// `cast(...)`), and times quoted date-time strings (not `toDateTime(...)`).
+// Client-side binding (the ?/$1/@name placeholders) must keep the SQL-literal
+// forms. Both apply at any nesting depth.
+func TestFormatValueModes(t *testing.T) {
 	tru, fls := true, false
+	ts := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
 	cases := []struct {
 		name       string
 		value      any
-		queryParam string // boolAsText=true  (server-side {name:Type} parameter)
-		bindSQL    string // boolAsText=false (client-side bind substitution)
+		queryParam string // formatParamText (server-side {name:Type} parameter)
+		bindSQL    string // formatSQL (client-side bind substitution)
 	}{
 		{"scalar true", true, "true", "1"},
 		{"scalar false", false, "false", "0"},
@@ -732,18 +735,62 @@ func TestFormatValueBoolAsText(t *testing.T) {
 		{"Array(Array(Bool))", [][]bool{{true}, {false}}, "[[true], [false]]", "[[1], [0]]"},
 		// nullable bools: real values change format, nil stays NULL
 		{"Array(Nullable(Bool))", []*bool{&tru, nil, &fls}, "[true, NULL, false]", "[1, NULL, 0]"},
+		// maps: text format vs map() SQL function (#1898)
+		{"Map(String, Bool)", map[string]bool{"a": true}, "{'a':true}", "map('a', 1)"},
+		{"Map(String, String)", map[string]string{"a": "b"}, "{'a':'b'}", "map('a', 'b')"},
+		{"empty map", map[string]string{}, "{}", "map()"},
+		{"Map string key escaping", map[string]uint8{`a'b\c`: 1}, `{'a\'b\\c':1}`, `map('a\'b\\c', 1)`},
+		{"Map(String, Map(String, Bool))",
+			map[string]map[string]bool{"a": {"x": true}},
+			"{'a':{'x':true}}", "map('a', map('x', 1))"},
+		{"Array(Map(String, Bool))",
+			[]map[string]bool{{"a": true}, {"b": false}},
+			"[{'a':true}, {'b':false}]", "[map('a', 1), map('b', 0)]"},
+		{"Map(String, Array(Bool))",
+			map[string][]bool{"a": {true, false}},
+			"{'a':[true, false]}", "map('a', [1, 0])"},
+		{"Map(Bool, String) key formatting", map[bool]string{true: "x"}, "{true:'x'}", "map(1, 'x')"},
+		// floats: plain text vs cast() SQL function
+		{"Float64", 1.5, "1.5", "cast(1.5, 'Float64')"},
+		{"Float32", float32(1.5), "1.5", "cast(1.5, 'Float32')"},
+		{"Float64 NaN", math.NaN(), "nan", "cast('nan', 'Float64')"},
+		{"Float64 +Inf", math.Inf(1), "inf", "cast('inf', 'Float64')"},
+		{"Float64 -Inf", math.Inf(-1), "-inf", "cast('-inf', 'Float64')"},
+		{"Map(String, Float64)", map[string]float64{"a": 1.5}, "{'a':1.5}", "map('a', cast(1.5, 'Float64'))"},
+		// nested times: quoted text vs toDateTime() SQL function
+		{"Array(DateTime)", []time.Time{ts},
+			"['2020-01-02 03:04:05']", "[toDateTime('2020-01-02 03:04:05')]"},
+		{"Map(String, DateTime)", map[string]time.Time{"a": ts},
+			"{'a':'2020-01-02 03:04:05'}", "map('a', toDateTime('2020-01-02 03:04:05'))"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := formatValue(time.UTC, Seconds, tc.value, true)
+			got, err := formatValue(time.UTC, Seconds, tc.value, formatParamText)
 			require.NoError(t, err)
 			assert.Equal(t, tc.queryParam, got, "server-side query-parameter formatting")
 
-			got, err = formatValue(time.UTC, Seconds, tc.value, false)
+			got, err = formatValue(time.UTC, Seconds, tc.value, formatSQL)
 			require.NoError(t, err)
 			assert.Equal(t, tc.bindSQL, got, "client-side bind formatting must be unchanged")
 		})
 	}
+}
+
+// TestFormatValueModesOrderedMap is the ordered-map variant of
+// TestFormatValueModes: column.OrderedMap and column.IterableOrderedMap
+// values must follow the same map syntax switch as plain Go maps.
+func TestFormatValueModesOrderedMap(t *testing.T) {
+	om := NewOrderedMap()
+	om.Put("b", true)
+	om.Put("a", false)
+
+	got, err := formatValue(time.UTC, Seconds, om, formatParamText)
+	require.NoError(t, err)
+	assert.Equal(t, "{'b':true,'a':false}", got)
+
+	got, err = formatValue(time.UTC, Seconds, om, formatSQL)
+	require.NoError(t, err)
+	assert.Equal(t, "map('b', 1, 'a', 0)", got)
 }
 
 func TestBindNamedWithTernaryOperator(t *testing.T) {

--- a/lib/proto/query.go
+++ b/lib/proto/query.go
@@ -219,13 +219,20 @@ func (s *Parameter) encode(buffer *chproto.Buffer, revision uint64) error {
 	return nil
 }
 
+// fieldDumpEscaper escapes a string for a quoted Field dump. The server
+// decodes the dump with its quoted-string reader, which treats a bare
+// backslash as the start of an escape sequence — so backslashes must be
+// escaped along with single quotes, or values containing them are corrupted
+// or rejected.
+var fieldDumpEscaper = strings.NewReplacer(`\`, `\\`, `'`, `\'`)
+
 // encodes a field dump with an appropriate type format
 // implements the same logic as in ClickHouse Field::restoreFromDump (https://github.com/ClickHouse/ClickHouse/blob/master/src/Core/Field.cpp#L312)
 // currently, only string type is supported
 func encodeFieldDump(value any) (string, error) {
 	switch v := value.(type) {
 	case string:
-		return fmt.Sprintf("'%v'", strings.ReplaceAll(v, "'", "\\'")), nil
+		return "'" + fieldDumpEscaper.Replace(v) + "'", nil
 	}
 
 	return "", fmt.Errorf("unsupported field type %T", value)

--- a/lib/proto/query.go
+++ b/lib/proto/query.go
@@ -219,11 +219,10 @@ func (s *Parameter) encode(buffer *chproto.Buffer, revision uint64) error {
 	return nil
 }
 
-// fieldDumpEscaper escapes a string for a quoted Field dump. The server
-// decodes the dump with its quoted-string reader, which treats a bare
-// backslash as the start of an escape sequence — so backslashes must be
-// escaped along with single quotes, or values containing them are corrupted
-// or rejected.
+// fieldDumpEscaper escapes a string for a quoted Field dump. Both single
+// quotes and backslashes need escaping: the server reads the dump back with
+// its quoted-string reader, where a bare backslash starts an escape sequence,
+// so an unescaped one corrupts the value or makes it unparseable.
 var fieldDumpEscaper = strings.NewReplacer(`\`, `\\`, `'`, `\'`)
 
 // encodes a field dump with an appropriate type format

--- a/lib/proto/query_test.go
+++ b/lib/proto/query_test.go
@@ -1,0 +1,38 @@
+package proto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEncodeFieldDump checks the quoted Field dump sent for query parameters
+// over the native protocol. The server decodes it with its quoted-string
+// reader, so both single quotes and backslashes must be escaped; an unescaped
+// backslash starts an escape sequence and corrupts the value (#1898).
+func TestEncodeFieldDump(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{"plain", "abc", `'abc'`},
+		{"single quote", "a'b", `'a\'b'`},
+		{"backslash", `a\b`, `'a\\b'`},
+		{"backslash before quote", `a\'b`, `'a\\\'b'`},
+		{"map text format", `{'a\'b\\c':1}`, `'{\'a\\\'b\\\\c\':1}'`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := encodeFieldDump(tc.value)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("unsupported type", func(t *testing.T) {
+		_, err := encodeFieldDump(42)
+		require.Error(t, err)
+	})
+}

--- a/lib/proto/query_test.go
+++ b/lib/proto/query_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestEncodeFieldDump checks the quoted Field dump sent for query parameters
-// over the native protocol. The server decodes it with its quoted-string
-// reader, so both single quotes and backslashes must be escaped; an unescaped
-// backslash starts an escape sequence and corrupts the value (#1898).
+// TestEncodeFieldDump checks the quoted Field dump used to send query
+// parameters over the native protocol. Both single quotes and backslashes
+// must be escaped — the server unescapes the dump when reading it back, so
+// an unescaped backslash corrupts the value (#1898).
 func TestEncodeFieldDump(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/query_parameters.go
+++ b/query_parameters.go
@@ -30,14 +30,20 @@ func bindQueryOrAppendParameters(paramsProtocolSupport bool, options *QueryOptio
 		for _, a := range args {
 			switch p := a.(type) {
 			case driver.NamedValue:
-				if str, ok := p.Value.(string); ok {
-					options.parameters[p.Name] = str
+				// The server parses a parameter value with the declared
+				// type's text reader. At the top level, String and DateTime
+				// values are read raw — unquoted — so they bypass
+				// formatValue, which applies the quoting rules for values
+				// nested inside composite types.
+				switch v := p.Value.(type) {
+				case string:
+					options.parameters[p.Name] = v
+					continue
+				case time.Time:
+					options.parameters[p.Name] = formatTimeWithScale(v, Seconds)
 					continue
 				}
-				// The server parses query parameter values as text, and its
-				// text parser wants bools as `true`/`false` — for example,
-				// `Array(Bool)` rejects `1`/`0`.
-				strVal, err := formatValue(timezone, Seconds, p.Value, true)
+				strVal, err := formatValue(timezone, Seconds, p.Value, formatParamText)
 				if err != nil {
 					return "", err
 				}

--- a/query_parameters.go
+++ b/query_parameters.go
@@ -46,11 +46,11 @@ func bindQueryOrAppendParameters(paramsProtocolSupport bool, options *QueryOptio
 						continue
 					}
 				case time.Time:
-					options.parameters[p.Name] = formatTimeWithScale(v, Seconds)
+					options.parameters[p.Name] = formatTimeParam(v)
 					continue
 				case *time.Time:
 					if v != nil {
-						options.parameters[p.Name] = formatTimeWithScale(*v, Seconds)
+						options.parameters[p.Name] = formatTimeParam(*v)
 						continue
 					}
 				}
@@ -77,6 +77,26 @@ func bindQueryOrAppendParameters(paramsProtocolSupport bool, options *QueryOptio
 	}
 
 	return bind(timezone, query, args...)
+}
+
+// formatTimeParam renders a time.Time sent as a query parameter through
+// Named (which, unlike NamedDateValue, carries no scale). Whole-second times
+// use the plain DateTime form. Sub-second times keep their fraction, trimmed
+// to milli/micro/nanoseconds: a DateTime64 parameter preserves the precision
+// (the server drops digits beyond its declared scale), while a plain
+// DateTime parameter rejects the value with an error — better than silently
+// truncating it. Use DateNamed to pin an exact scale.
+func formatTimeParam(t time.Time) string {
+	switch ns := t.Nanosecond(); {
+	case ns == 0:
+		return t.Format("2006-01-02 15:04:05")
+	case ns%1e6 == 0:
+		return t.Format("2006-01-02 15:04:05.000")
+	case ns%1e3 == 0:
+		return t.Format("2006-01-02 15:04:05.000000")
+	default:
+		return t.Format("2006-01-02 15:04:05.000000000")
+	}
 }
 
 func formatTimeWithScale(t time.Time, scale TimeUnit) string {

--- a/query_parameters.go
+++ b/query_parameters.go
@@ -30,11 +30,11 @@ func bindQueryOrAppendParameters(paramsProtocolSupport bool, options *QueryOptio
 		for _, a := range args {
 			switch p := a.(type) {
 			case driver.NamedValue:
-				// The server parses a parameter value with the declared
-				// type's text reader. At the top level, String and DateTime
-				// values are read raw — unquoted — so they bypass
-				// formatValue, which applies the quoting rules for values
-				// nested inside composite types.
+				// Strings and times at the top level are sent raw, without
+				// quotes: the server reads a whole parameter value as-is,
+				// and only quotes values nested inside arrays, maps, and
+				// tuples. formatValue below applies the nested (quoted)
+				// rules, so these two skip it.
 				switch v := p.Value.(type) {
 				case string:
 					options.parameters[p.Name] = v

--- a/query_parameters.go
+++ b/query_parameters.go
@@ -34,14 +34,25 @@ func bindQueryOrAppendParameters(paramsProtocolSupport bool, options *QueryOptio
 				// quotes: the server reads a whole parameter value as-is,
 				// and only quotes values nested inside arrays, maps, and
 				// tuples. formatValue below applies the nested (quoted)
-				// rules, so these two skip it.
+				// rules, so these skip it. Nil pointers fall through and
+				// format as NULL.
 				switch v := p.Value.(type) {
 				case string:
 					options.parameters[p.Name] = v
 					continue
+				case *string:
+					if v != nil {
+						options.parameters[p.Name] = *v
+						continue
+					}
 				case time.Time:
 					options.parameters[p.Name] = formatTimeWithScale(v, Seconds)
 					continue
+				case *time.Time:
+					if v != nil {
+						options.parameters[p.Name] = formatTimeWithScale(*v, Seconds)
+						continue
+					}
 				}
 				strVal, err := formatValue(timezone, Seconds, p.Value, formatParamText)
 				if err != nil {

--- a/query_parameters.go
+++ b/query_parameters.go
@@ -2,6 +2,7 @@ package clickhouse
 
 import (
 	"errors"
+	"reflect"
 	"regexp"
 	"time"
 
@@ -30,29 +31,33 @@ func bindQueryOrAppendParameters(paramsProtocolSupport bool, options *QueryOptio
 		for _, a := range args {
 			switch p := a.(type) {
 			case driver.NamedValue:
+				// A nil at the top level means SQL NULL, whose whole-text
+				// marker is `\N`. The `NULL` keyword formatValue emits only
+				// works nested inside arrays, maps, and tuples — at the top
+				// level the server would read it as the string "NULL" (or
+				// fail to parse it at all).
+				if isNilParamValue(p.Value) {
+					options.parameters[p.Name] = `\N`
+					continue
+				}
 				// Strings and times at the top level are sent raw, without
 				// quotes: the server reads a whole parameter value as-is,
 				// and only quotes values nested inside arrays, maps, and
 				// tuples. formatValue below applies the nested (quoted)
-				// rules, so these skip it. Nil pointers fall through and
-				// format as NULL.
+				// rules, so these skip it.
 				switch v := p.Value.(type) {
 				case string:
 					options.parameters[p.Name] = v
 					continue
 				case *string:
-					if v != nil {
-						options.parameters[p.Name] = *v
-						continue
-					}
+					options.parameters[p.Name] = *v
+					continue
 				case time.Time:
 					options.parameters[p.Name] = formatTimeParam(v)
 					continue
 				case *time.Time:
-					if v != nil {
-						options.parameters[p.Name] = formatTimeParam(*v)
-						continue
-					}
+					options.parameters[p.Name] = formatTimeParam(*v)
+					continue
 				}
 				strVal, err := formatValue(timezone, Seconds, p.Value, formatParamText)
 				if err != nil {
@@ -77,6 +82,18 @@ func bindQueryOrAppendParameters(paramsProtocolSupport bool, options *QueryOptio
 	}
 
 	return bind(timezone, query, args...)
+}
+
+// isNilParamValue reports whether v is nil itself or a typed nil pointer —
+// the same values formatValue would render as NULL.
+func isNilParamValue(v any) bool {
+	if v == nil {
+		return true
+	}
+	if rv := reflect.ValueOf(v); rv.Kind() == reflect.Ptr {
+		return rv.IsNil()
+	}
+	return false
 }
 
 // formatTimeParam renders a time.Time sent as a query parameter through

--- a/query_parameters.go
+++ b/query_parameters.go
@@ -2,8 +2,10 @@ package clickhouse
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -97,23 +99,41 @@ func isNilParamValue(v any) bool {
 }
 
 // formatTimeParam renders a time.Time sent as a query parameter through
-// Named (which, unlike NamedDateValue, carries no scale). Whole-second times
-// use the plain DateTime form. Sub-second times keep their fraction, trimmed
-// to milli/micro/nanoseconds: a DateTime64 parameter preserves the precision
-// (the server drops digits beyond its declared scale), while a plain
-// DateTime parameter rejects the value with an error — better than silently
-// truncating it. Use DateNamed to pin an exact scale.
+// Named (which, unlike NamedDateValue, carries no scale). It emits epoch
+// seconds rather than wall-clock text: parameter text has no syntax for a
+// timezone, so a wall-clock string would be re-interpreted in the
+// parameter's declared zone and shift the instant whenever that zone differs
+// from the value's — epoch is zone-free, so the instant always survives.
+//
+// Whole-second times emit just the integer. Sub-second times keep their
+// fraction, trimmed to milli/micro/nanoseconds: a DateTime64 parameter
+// preserves the precision (the server drops digits beyond its declared
+// scale), while a plain DateTime parameter rejects the value with an error —
+// better than silently truncating it. Use DateNamed to pin an exact scale
+// and wall-clock semantics.
 func formatTimeParam(t time.Time) string {
-	switch ns := t.Nanosecond(); {
-	case ns == 0:
-		return t.Format("2006-01-02 15:04:05")
-	case ns%1e6 == 0:
-		return t.Format("2006-01-02 15:04:05.000")
-	case ns%1e3 == 0:
-		return t.Format("2006-01-02 15:04:05.000000")
-	default:
-		return t.Format("2006-01-02 15:04:05.000000000")
+	sec, ns := t.Unix(), int64(t.Nanosecond())
+	if ns == 0 {
+		return strconv.FormatInt(sec, 10)
 	}
+	// Unix() floors and Nanosecond() is the positive offset within that
+	// second, so a pre-1970 instant like -86400.5 arrives as sec -86401,
+	// ns 5e8. Printing those digits naively would yield "-86401.500" =
+	// -86401.5 — carry the sign into both parts instead.
+	sign := ""
+	if sec < 0 {
+		sign = "-"
+		sec = -sec - 1
+		ns = 1e9 - ns
+	}
+	frac := fmt.Sprintf("%09d", ns)
+	switch {
+	case ns%1e6 == 0:
+		frac = frac[:3]
+	case ns%1e3 == 0:
+		frac = frac[:6]
+	}
+	return sign + strconv.FormatInt(sec, 10) + "." + frac
 }
 
 func formatTimeWithScale(t time.Time, scale TimeUnit) string {

--- a/tests/issues/1898_test.go
+++ b/tests/issues/1898_test.go
@@ -211,6 +211,37 @@ func TestIssue1898_MapQueryParameter(t *testing.T) {
 			require.Equal(t, map[string]time.Time{"a": in}, gotMap)
 		})
 
+		// A nil parameter must arrive as SQL NULL. Before the fix it was
+		// sent as the text `NULL`, which a Nullable(String) parameter
+		// silently read as the string "NULL" and other types rejected.
+		t.Run("nil round-trips as NULL", func(t *testing.T) {
+			var gotStr *string
+			var isNull uint8
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {s:Nullable(String)}, isNull({s:Nullable(String)})",
+				clickhouse.Named("s", (*string)(nil)),
+			).Scan(&gotStr, &isNull))
+			require.Nil(t, gotStr)
+			require.Equal(t, uint8(1), isNull)
+
+			var gotInt *int32
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {i:Nullable(Int32)}",
+				clickhouse.Named("i", nil),
+			).Scan(&gotInt))
+			require.Nil(t, gotInt)
+
+			// nils nested inside a composite must keep working too
+			s := "x"
+			in := []*string{&s, nil}
+			var gotArr []*string
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {a:Array(Nullable(String))}",
+				clickhouse.Named("a", in),
+			).Scan(&gotArr))
+			require.Equal(t, in, gotArr)
+		})
+
 		// A sub-second time.Time sent to a plain DateTime parameter fails
 		// loudly instead of silently dropping the fraction. DateNamed is
 		// the way to pick the scale explicitly.

--- a/tests/issues/1898_test.go
+++ b/tests/issues/1898_test.go
@@ -1,0 +1,174 @@
+package issues
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+)
+
+// TestIssue1898_MapQueryParameter covers the fix for #1898: `Map`-typed
+// server-side query parameters must be sent in the `{'k':v}` text format the
+// server's parameter parser expects, not the `map('k', v)` SQL-function
+// syntax used for client-side binding. The same formatting split applies to
+// floats (plain literal, not `cast(...)`) and nested `DateTime` values
+// (quoted text, not `toDateTime(...)`).
+//
+// Native and HTTP share the same query-parameter code path, so every case
+// runs on both protocols.
+func TestIssue1898_MapQueryParameter(t *testing.T) {
+	clickhouse_tests.TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
+		ctx := context.Background()
+		conn, err := clickhouse_tests.GetConnection("issues", t, protocol, nil, nil, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		if !clickhouse_tests.CheckMinServerServerVersion(conn, 22, 8, 0) {
+			t.Skip("server-side query parameters require ClickHouse 22.8+")
+		}
+
+		// The repro from the bug report.
+		t.Run("Map(String, Bool) round-trip", func(t *testing.T) {
+			in := map[string]bool{"a": true, "b": false}
+			var got map[string]bool
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {m:Map(String, Bool)}",
+				clickhouse.Named("m", in),
+			).Scan(&got))
+			require.Equal(t, in, got)
+		})
+
+		// The bug affected every Map value type, not just Bool.
+		t.Run("Map(String, String) round-trip", func(t *testing.T) {
+			in := map[string]string{"a": "x", "b": "y"}
+			var got map[string]string
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {m:Map(String, String)}",
+				clickhouse.Named("m", in),
+			).Scan(&got))
+			require.Equal(t, in, got)
+		})
+
+		// Quotes and backslashes in string keys must survive the text format.
+		t.Run("Map key escaping", func(t *testing.T) {
+			in := map[string]uint8{`a'b\c`: 1}
+			var got map[string]uint8
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {m:Map(String, UInt8)}",
+				clickhouse.Named("m", in),
+			).Scan(&got))
+			require.Equal(t, in, got)
+		})
+
+		// Top-level strings are passed through raw (they double as the
+		// escape hatch for pre-formatted parameter text), so the server
+		// applies its escaped-text semantics: `\'` decodes to `'`. Both
+		// protocols must agree — before the native Field-dump escaping fix,
+		// native rejected any value with a backslash before a quote.
+		t.Run("String passes through raw on both protocols", func(t *testing.T) {
+			var got string
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {s:String}",
+				clickhouse.Named("s", `a'b\'c`),
+			).Scan(&got))
+			require.Equal(t, `a'b'c`, got)
+		})
+
+		t.Run("empty map", func(t *testing.T) {
+			var got map[string]string
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {m:Map(String, String)}",
+				clickhouse.Named("m", map[string]string{}),
+			).Scan(&got))
+			require.Empty(t, got)
+		})
+
+		// Nested composites: the container syntax must be right at any depth.
+		t.Run("Map(String, Map(String, Bool)) round-trip", func(t *testing.T) {
+			in := map[string]map[string]bool{"a": {"x": true, "y": false}}
+			var got map[string]map[string]bool
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {m:Map(String, Map(String, Bool))}",
+				clickhouse.Named("m", in),
+			).Scan(&got))
+			require.Equal(t, in, got)
+		})
+
+		t.Run("Array(Map(String, String)) round-trip", func(t *testing.T) {
+			in := []map[string]string{{"a": "x"}, {"b": "y"}}
+			var got []map[string]string
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {m:Array(Map(String, String))}",
+				clickhouse.Named("m", in),
+			).Scan(&got))
+			require.Equal(t, in, got)
+		})
+
+		t.Run("Map(String, Array(Bool)) round-trip", func(t *testing.T) {
+			in := map[string][]bool{"a": {true, false}}
+			var got map[string][]bool
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {m:Map(String, Array(Bool))}",
+				clickhouse.Named("m", in),
+			).Scan(&got))
+			require.Equal(t, in, got)
+		})
+
+		// Floats hit the same issue class: the SQL-literal form
+		// cast(1.5, 'Float64') is rejected by the parameter text parser.
+		t.Run("Float64 round-trip", func(t *testing.T) {
+			for _, in := range []float64{1.5, -3.25, 0, math.Inf(1), math.Inf(-1)} {
+				var got float64
+				require.NoError(t, conn.QueryRow(ctx,
+					"SELECT {f:Float64}",
+					clickhouse.Named("f", in),
+				).Scan(&got))
+				require.Equal(t, in, got)
+			}
+
+			var got float64
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {f:Float64}",
+				clickhouse.Named("f", math.NaN()),
+			).Scan(&got))
+			require.True(t, math.IsNaN(got))
+		})
+
+		t.Run("Map(String, Float64) round-trip", func(t *testing.T) {
+			in := map[string]float64{"a": 1.5}
+			var got map[string]float64
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {m:Map(String, Float64)}",
+				clickhouse.Named("m", in),
+			).Scan(&got))
+			require.Equal(t, in, got)
+		})
+
+		// time.Time as a plain Named parameter: raw text at the top level,
+		// quoted text when nested inside a composite type.
+		t.Run("DateTime round-trip", func(t *testing.T) {
+			in := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+			var got time.Time
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {d:DateTime('UTC')}",
+				clickhouse.Named("d", in),
+			).Scan(&got))
+			require.Equal(t, in, got)
+		})
+
+		t.Run("Map(String, DateTime) round-trip", func(t *testing.T) {
+			in := map[string]time.Time{"a": time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)}
+			var got map[string]time.Time
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {m:Map(String, DateTime('UTC'))}",
+				clickhouse.Named("m", in),
+			).Scan(&got))
+			require.Equal(t, in, got)
+		})
+	})
+}

--- a/tests/issues/1898_test.go
+++ b/tests/issues/1898_test.go
@@ -12,12 +12,11 @@ import (
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 )
 
-// TestIssue1898_MapQueryParameter covers the fix for #1898: `Map`-typed
-// server-side query parameters must be sent in the `{'k':v}` text format the
-// server's parameter parser expects, not the `map('k', v)` SQL-function
-// syntax used for client-side binding. The same formatting split applies to
-// floats (plain literal, not `cast(...)`) and nested `DateTime` values
-// (quoted text, not `toDateTime(...)`).
+// TestIssue1898_MapQueryParameter covers the fix for #1898: a Go map sent as
+// a `Map` query parameter must arrive as `{'k':v}` — the text format the
+// server parses — not the `map('k', v)` SQL syntax used for client-side
+// binding. Floats and nested `DateTime` values had the same problem, so they
+// are covered here too.
 //
 // Native and HTTP share the same query-parameter code path, so every case
 // runs on both protocols.
@@ -54,7 +53,7 @@ func TestIssue1898_MapQueryParameter(t *testing.T) {
 			require.Equal(t, in, got)
 		})
 
-		// Quotes and backslashes in string keys must survive the text format.
+		// Quotes and backslashes in string keys must survive the round trip.
 		t.Run("Map key escaping", func(t *testing.T) {
 			in := map[string]uint8{`a'b\c`: 1}
 			var got map[string]uint8
@@ -65,11 +64,12 @@ func TestIssue1898_MapQueryParameter(t *testing.T) {
 			require.Equal(t, in, got)
 		})
 
-		// Top-level strings are passed through raw (they double as the
-		// escape hatch for pre-formatted parameter text), so the server
-		// applies its escaped-text semantics: `\'` decodes to `'`. Both
-		// protocols must agree — before the native Field-dump escaping fix,
-		// native rejected any value with a backslash before a quote.
+		// A top-level string is passed to the server as-is (that is also the
+		// escape hatch for sending pre-formatted parameter text), and the
+		// server then decodes escapes in it: `\'` becomes `'`. Both
+		// protocols must agree on the result — before the Field-dump
+		// escaping fix, native rejected any value with a backslash before a
+		// quote.
 		t.Run("String passes through raw on both protocols", func(t *testing.T) {
 			var got string
 			require.NoError(t, conn.QueryRow(ctx,
@@ -88,7 +88,7 @@ func TestIssue1898_MapQueryParameter(t *testing.T) {
 			require.Empty(t, got)
 		})
 
-		// Nested composites: the container syntax must be right at any depth.
+		// The container syntax must be right at any nesting depth.
 		t.Run("Map(String, Map(String, Bool)) round-trip", func(t *testing.T) {
 			in := map[string]map[string]bool{"a": {"x": true, "y": false}}
 			var got map[string]map[string]bool
@@ -119,8 +119,8 @@ func TestIssue1898_MapQueryParameter(t *testing.T) {
 			require.Equal(t, in, got)
 		})
 
-		// Floats hit the same issue class: the SQL-literal form
-		// cast(1.5, 'Float64') is rejected by the parameter text parser.
+		// Floats had the same bug: the server rejects the SQL form
+		// cast(1.5, 'Float64') and wants the plain number.
 		t.Run("Float64 round-trip", func(t *testing.T) {
 			for _, in := range []float64{1.5, -3.25, 0, math.Inf(1), math.Inf(-1)} {
 				var got float64
@@ -149,8 +149,8 @@ func TestIssue1898_MapQueryParameter(t *testing.T) {
 			require.Equal(t, in, got)
 		})
 
-		// time.Time as a plain Named parameter: raw text at the top level,
-		// quoted text when nested inside a composite type.
+		// time.Time as a plain Named parameter: sent raw at the top level,
+		// quoted when nested inside a map or array.
 		t.Run("DateTime round-trip", func(t *testing.T) {
 			in := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
 			var got time.Time

--- a/tests/issues/1898_test.go
+++ b/tests/issues/1898_test.go
@@ -161,6 +161,26 @@ func TestIssue1898_MapQueryParameter(t *testing.T) {
 			require.Equal(t, in, got)
 		})
 
+		// Pointers to strings and times must get the same top-level raw
+		// treatment as their plain counterparts.
+		t.Run("pointer round-trips", func(t *testing.T) {
+			s := "hello"
+			var gotStr string
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {s:String}",
+				clickhouse.Named("s", &s),
+			).Scan(&gotStr))
+			require.Equal(t, s, gotStr)
+
+			d := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+			var gotTime time.Time
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {d:DateTime('UTC')}",
+				clickhouse.Named("d", &d),
+			).Scan(&gotTime))
+			require.Equal(t, d, gotTime)
+		})
+
 		t.Run("Map(String, DateTime) round-trip", func(t *testing.T) {
 			in := map[string]time.Time{"a": time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)}
 			var got map[string]time.Time

--- a/tests/issues/1898_test.go
+++ b/tests/issues/1898_test.go
@@ -211,6 +211,30 @@ func TestIssue1898_MapQueryParameter(t *testing.T) {
 			require.Equal(t, map[string]time.Time{"a": in}, gotMap)
 		})
 
+		// A time.Time carrying a non-UTC zone must keep its instant. Times
+		// are sent as epoch (parameter text has no timezone syntax), so the
+		// parameter's declared zone changes only the rendering, never the
+		// instant. Before the fix the wall-clock text was re-interpreted in
+		// the parameter's zone, shifting the instant by the zone offset.
+		t.Run("non-UTC time keeps its instant", func(t *testing.T) {
+			tokyo := time.FixedZone("Asia/Tokyo", 9*3600)
+			in := time.Date(2020, 1, 2, 12, 0, 0, 0, tokyo) // == 03:00:00 UTC
+
+			var got time.Time
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {d:DateTime('UTC')}",
+				clickhouse.Named("d", in),
+			).Scan(&got))
+			require.True(t, got.Equal(in), "want instant %s, got %s", in.UTC(), got.UTC())
+
+			var gotMap map[string]time.Time
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {m:Map(String, DateTime('UTC'))}",
+				clickhouse.Named("m", map[string]time.Time{"a": in}),
+			).Scan(&gotMap))
+			require.True(t, gotMap["a"].Equal(in), "want instant %s, got %s", in.UTC(), gotMap["a"].UTC())
+		})
+
 		// A nil parameter must arrive as SQL NULL. Before the fix it was
 		// sent as the text `NULL`, which a Nullable(String) parameter
 		// silently read as the string "NULL" and other types rejected.

--- a/tests/issues/1898_test.go
+++ b/tests/issues/1898_test.go
@@ -190,5 +190,37 @@ func TestIssue1898_MapQueryParameter(t *testing.T) {
 			).Scan(&got))
 			require.Equal(t, in, got)
 		})
+
+		// A sub-second time.Time keeps its fraction, so DateTime64
+		// parameters don't silently lose precision — top-level and nested.
+		t.Run("DateTime64 keeps sub-second precision", func(t *testing.T) {
+			in := time.Date(2020, 1, 2, 3, 4, 5, 123456789, time.UTC)
+
+			var got time.Time
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {d:DateTime64(9, 'UTC')}",
+				clickhouse.Named("d", in),
+			).Scan(&got))
+			require.Equal(t, in, got)
+
+			var gotMap map[string]time.Time
+			require.NoError(t, conn.QueryRow(ctx,
+				"SELECT {m:Map(String, DateTime64(9, 'UTC'))}",
+				clickhouse.Named("m", map[string]time.Time{"a": in}),
+			).Scan(&gotMap))
+			require.Equal(t, map[string]time.Time{"a": in}, gotMap)
+		})
+
+		// A sub-second time.Time sent to a plain DateTime parameter fails
+		// loudly instead of silently dropping the fraction. DateNamed is
+		// the way to pick the scale explicitly.
+		t.Run("sub-second time into DateTime errors", func(t *testing.T) {
+			in := time.Date(2020, 1, 2, 3, 4, 5, 123000000, time.UTC)
+			var got time.Time
+			require.Error(t, conn.QueryRow(ctx,
+				"SELECT {d:DateTime('UTC')}",
+				clickhouse.Named("d", in),
+			).Scan(&got))
+		})
 	})
 }

--- a/tests/std/1898_test.go
+++ b/tests/std/1898_test.go
@@ -1,0 +1,46 @@
+package std
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+)
+
+// TestIssue1898MapQueryParameter checks the fix for #1898 through the
+// database/sql interface: a Go map sent as a `Map(K, V)` server-side query
+// parameter must be formatted in the `{'k':v}` text format, because the
+// server rejects the `map('k', v)` SQL-function syntax with
+// CANNOT_PARSE_INPUT_ASSERTION_FAILED. The std driver ends up in the same
+// formatting code as the native client, but this makes sure the second API
+// surface is covered too.
+func TestIssue1898MapQueryParameter(t *testing.T) {
+	env, err := GetStdTestEnvironment()
+	require.NoError(t, err)
+	useSSL, err := strconv.ParseBool(clickhouse_tests.GetEnv("CLICKHOUSE_USE_SSL", "false"))
+	require.NoError(t, err)
+	dsn := fmt.Sprintf("http://%s:%d?username=%s&password=%s&dial_timeout=200ms&max_execution_time=60", env.Host, env.HttpPort, env.Username, env.Password)
+	if useSSL {
+		dsn = fmt.Sprintf("https://%s:%d?username=%s&password=%s&dial_timeout=200ms&max_execution_time=60&secure=true", env.Host, env.HttpsPort, env.Username, env.Password)
+	}
+	conn, err := GetConnectionFromDSN(dsn)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	if !CheckMinServerVersion(conn, 22, 8, 0) {
+		t.Skip("server-side query parameters require ClickHouse 22.8+")
+	}
+
+	var ok bool
+	row := conn.QueryRow(
+		"SELECT {m:Map(String, Bool)} = map('a', true)",
+		clickhouse.Named("m", map[string]bool{"a": true}),
+	)
+	require.NoError(t, row.Err())
+	require.NoError(t, row.Scan(&ok))
+	require.True(t, ok)
+}

--- a/tests/std/1898_test.go
+++ b/tests/std/1898_test.go
@@ -12,12 +12,10 @@ import (
 )
 
 // TestIssue1898MapQueryParameter checks the fix for #1898 through the
-// database/sql interface: a Go map sent as a `Map(K, V)` server-side query
-// parameter must be formatted in the `{'k':v}` text format, because the
-// server rejects the `map('k', v)` SQL-function syntax with
-// CANNOT_PARSE_INPUT_ASSERTION_FAILED. The std driver ends up in the same
-// formatting code as the native client, but this makes sure the second API
-// surface is covered too.
+// database/sql interface: a Go map sent as a `Map(K, V)` query parameter
+// must arrive as `{'k':v}`, since the server rejects the `map('k', v)` SQL
+// syntax. The std driver goes through the same formatting code as the native
+// client, but this makes sure the second API surface is covered too.
 func TestIssue1898MapQueryParameter(t *testing.T) {
 	env, err := GetStdTestEnvironment()
 	require.NoError(t, err)


### PR DESCRIPTION


## Summary
<!-- A short description of the changes with a link to an open issue. -->
Fixes: #1898

### changes

1. Map-typed server-side query parameters `({name:Map(K, V)})` fail because the client renders Go maps with the `map(...)` SQL-function syntax, But the server parses query-parameter values with the declared type's text deserializer, which expects the `{'key':value}` Map text format.

This PR makes the `formatValue` that is in-consistent with how server expects complex types like Map when sent as query params

2. Make formatTimeParams timezone aware

While making this change, I realized the server side params of `DateTime` type is not timezone aware. Fixed it in `formatTimeParams` (which got introduced in this PR). 

Still the old NamedDateTime still has this bug (not related to this PR). which I will fix in the follow up.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
