### PR TITLE
fix: make format time helpers fully timezone aware

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -18,15 +18,16 @@ var (
 	ErrInvalidTimezone = errors.New("invalid timezone value")
 )
 
-// Named binds a value to a query argument by name. With server-side query
-// parameters (the `{name:Type}` placeholder syntax) the value travels
-// out-of-band in the server's text format; a time.Time is sent as epoch
-// seconds, so the instant is preserved no matter which timezone the value
-// carries or the parameter declares, and its sub-second fraction is included
-// only when present (a fraction suits `DateTime64` but makes a plain
-// `DateTime` parameter fail — use DateNamed to pin an exact scale). With
-// client-side binding (the `@name` placeholder syntax) the value is inlined
-// into the query text as a SQL literal instead.
+// Named gives a query argument a name. It works with both placeholder
+// styles: with server-side query parameters (`{name:Type}`) the value is
+// sent to the server separately from the query, with client-side binding
+// (`@name`) it is written into the query text as a SQL literal.
+//
+// A time.Time is sent as epoch seconds, so the moment it points to is
+// preserved whatever timezone it or the parameter carries. Sub-second
+// precision is kept when the value has any — fine for `DateTime64`, but a
+// plain `DateTime` parameter rejects fractions. Use DateNamed to choose the
+// precision yourself.
 func Named(name string, value any) driver.NamedValue {
 	return driver.NamedValue{
 		Name:  name,
@@ -49,13 +50,12 @@ type GroupSet struct {
 
 type ArraySet []any
 
-// DateNamed binds a time.Time to a query argument by name at an explicit
-// precision. As a server-side query parameter the value is sent as epoch
-// seconds with exactly the fractional digits the scale selects (Seconds →
-// none, MilliSeconds → 3, MicroSeconds → 6, NanoSeconds → 9), truncating
-// anything finer — so the instant is preserved regardless of timezone, and
-// the precision matches the parameter's declared type (e.g. Seconds for
-// `DateTime`, MilliSeconds for `DateTime64(3)`).
+// DateNamed is Named for a time.Time with the precision chosen by you
+// instead of inferred from the value: the scale decides how many fractional
+// digits are sent (Seconds none, MilliSeconds 3, and so on), and anything
+// finer is dropped. Pick the scale that matches the parameter's type —
+// Seconds for `DateTime`, MilliSeconds for `DateTime64(3)`. Like Named, the
+// value is sent as epoch seconds, so timezones can't shift it.
 func DateNamed(name string, value time.Time, scale TimeUnit) driver.NamedDateValue {
 	return driver.NamedDateValue{
 		Name:  name,

--- a/bind.go
+++ b/bind.go
@@ -18,6 +18,15 @@ var (
 	ErrInvalidTimezone = errors.New("invalid timezone value")
 )
 
+// Named binds a value to a query argument by name. With server-side query
+// parameters (the `{name:Type}` placeholder syntax) the value travels
+// out-of-band in the server's text format; a time.Time is sent as epoch
+// seconds, so the instant is preserved no matter which timezone the value
+// carries or the parameter declares, and its sub-second fraction is included
+// only when present (a fraction suits `DateTime64` but makes a plain
+// `DateTime` parameter fail — use DateNamed to pin an exact scale). With
+// client-side binding (the `@name` placeholder syntax) the value is inlined
+// into the query text as a SQL literal instead.
 func Named(name string, value any) driver.NamedValue {
 	return driver.NamedValue{
 		Name:  name,
@@ -40,6 +49,13 @@ type GroupSet struct {
 
 type ArraySet []any
 
+// DateNamed binds a time.Time to a query argument by name at an explicit
+// precision. As a server-side query parameter the value is sent as epoch
+// seconds with exactly the fractional digits the scale selects (Seconds →
+// none, MilliSeconds → 3, MicroSeconds → 6, NanoSeconds → 9), truncating
+// anything finer — so the instant is preserved regardless of timezone, and
+// the precision matches the parameter's declared type (e.g. Seconds for
+// `DateTime`, MilliSeconds for `DateTime64(3)`).
 func DateNamed(name string, value time.Time, scale TimeUnit) driver.NamedDateValue {
 	return driver.NamedDateValue{
 		Name:  name,

--- a/bind.go
+++ b/bind.go
@@ -23,11 +23,12 @@ var (
 // sent to the server separately from the query, with client-side binding
 // (`@name`) it is written into the query text as a SQL literal.
 //
-// A time.Time is sent as epoch seconds, so the moment it points to is
-// preserved whatever timezone it or the parameter carries. Sub-second
-// precision is kept when the value has any — fine for `DateTime64`, but a
-// plain `DateTime` parameter rejects fractions. Use DateNamed to choose the
-// precision yourself.
+// Either way, a time.Time keeps the moment it points to, whatever timezone
+// it or the target carries: query parameters send it as epoch seconds, and
+// client-side binding emits a SQL form that carries the zone when it needs
+// to. On the query-parameter path, sub-second precision is kept when the
+// value has any — fine for `DateTime64`, but a plain `DateTime` parameter
+// rejects fractions. Use DateNamed to choose the precision yourself.
 func Named(name string, value any) driver.NamedValue {
 	return driver.NamedValue{
 		Name:  name,
@@ -55,7 +56,7 @@ type ArraySet []any
 // digits are sent (Seconds none, MilliSeconds 3, and so on), and anything
 // finer is dropped. Pick the scale that matches the parameter's type —
 // Seconds for `DateTime`, MilliSeconds for `DateTime64(3)`. Like Named, the
-// value is sent as epoch seconds, so timezones can't shift it.
+// moment the value points to is preserved regardless of timezones.
 func DateNamed(name string, value time.Time, scale TimeUnit) driver.NamedDateValue {
 	return driver.NamedDateValue{
 		Name:  name,

--- a/bind_test.go
+++ b/bind_test.go
@@ -838,6 +838,38 @@ func TestFormatTimeParam(t *testing.T) {
 	}
 }
 
+// TestFormatTimeWithScale checks how a DateNamed value is rendered as a
+// query parameter: epoch seconds (instant-preserving, like formatTimeParam)
+// with exactly the fractional digits the explicit scale selects, truncating
+// anything finer.
+func TestFormatTimeWithScale(t *testing.T) {
+	base := time.Date(2020, 1, 2, 3, 4, 5, 123456789, time.UTC) // epoch 1577934245.123456789
+	tokyo := time.FixedZone("Asia/Tokyo", 9*3600)
+	cases := []struct {
+		name  string
+		in    time.Time
+		scale TimeUnit
+		want  string
+	}{
+		{"Seconds truncates fraction", base, Seconds, "1577934245"},
+		{"MilliSeconds", base, MilliSeconds, "1577934245.123"},
+		{"MicroSeconds", base, MicroSeconds, "1577934245.123456"},
+		{"NanoSeconds", base, NanoSeconds, "1577934245.123456789"},
+		// fixed width even when the value is coarser than the scale
+		{"whole second at MilliSeconds", base.Truncate(time.Second), MilliSeconds, "1577934245.000"},
+		// the same instant expressed in another zone renders identically
+		{"non-UTC zone, same instant", base.In(tokyo), MilliSeconds, "1577934245.123"},
+		// pre-1970: the sign must cover the fraction too
+		{"pre-1970 sub-second", time.Date(1969, 12, 30, 23, 59, 59, 500000000, time.UTC), MilliSeconds, "-86400.500"},
+		{"pre-1970 whole second at MilliSeconds", time.Date(1969, 12, 31, 0, 0, 0, 0, time.UTC), MilliSeconds, "-86400.000"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, formatTimeWithScale(tc.in, tc.scale))
+		})
+	}
+}
+
 // TestNilQueryParameter checks that a nil sent as a query parameter becomes
 // `\N` — the whole-text NULL marker. The `NULL` keyword only works nested
 // inside composites; at the top level the server would read it as the string

--- a/bind_test.go
+++ b/bind_test.go
@@ -839,9 +839,9 @@ func TestFormatTimeParam(t *testing.T) {
 }
 
 // TestFormatTimeWithScale checks how a DateNamed value is rendered as a
-// query parameter: epoch seconds (instant-preserving, like formatTimeParam)
-// with exactly the fractional digits the explicit scale selects, truncating
-// anything finer.
+// query parameter: epoch seconds like formatTimeParam, but with the
+// fraction width fixed by the scale rather than inferred from the value,
+// dropping anything finer.
 func TestFormatTimeWithScale(t *testing.T) {
 	base := time.Date(2020, 1, 2, 3, 4, 5, 123456789, time.UTC) // epoch 1577934245.123456789
 	tokyo := time.FixedZone("Asia/Tokyo", 9*3600)

--- a/lib/driver/driver.go
+++ b/lib/driver/driver.go
@@ -12,11 +12,16 @@ import (
 type ServerVersion = proto.ServerHandshake
 
 type (
+	// NamedValue binds Value to the query argument Name; construct it with
+	// clickhouse.Named.
 	NamedValue struct {
 		Name  string
 		Value any
 	}
 
+	// NamedDateValue binds a time value to the query argument Name at an
+	// explicit precision; construct it with clickhouse.DateNamed. Scale is
+	// the clickhouse.TimeUnit (0 seconds, 1 milli, 2 micro, 3 nano).
 	NamedDateValue struct {
 		Name  string
 		Value time.Time

--- a/lib/driver/driver.go
+++ b/lib/driver/driver.go
@@ -12,16 +12,16 @@ import (
 type ServerVersion = proto.ServerHandshake
 
 type (
-	// NamedValue binds Value to the query argument Name; construct it with
+	// NamedValue is a query argument with a name. Create it with
 	// clickhouse.Named.
 	NamedValue struct {
 		Name  string
 		Value any
 	}
 
-	// NamedDateValue binds a time value to the query argument Name at an
-	// explicit precision; construct it with clickhouse.DateNamed. Scale is
-	// the clickhouse.TimeUnit (0 seconds, 1 milli, 2 micro, 3 nano).
+	// NamedDateValue is a time query argument with a name and an explicit
+	// precision. Create it with clickhouse.DateNamed. Scale holds a
+	// clickhouse.TimeUnit: 0 seconds, 1 milli, 2 micro, 3 nano.
 	NamedDateValue struct {
 		Name  string
 		Value time.Time

--- a/query_parameters.go
+++ b/query_parameters.go
@@ -98,12 +98,14 @@ func isNilParamValue(v any) bool {
 	return false
 }
 
-// formatEpoch renders t as epoch seconds with exactly digits fractional
-// digits (0, 3, 6 or 9), truncating anything finer. Query parameters are
-// sent as epoch rather than wall-clock text: parameter text has no syntax
-// for a timezone, so a wall-clock string would be re-interpreted in the
-// parameter's declared zone and shift the instant whenever that zone differs
-// from the value's — epoch is zone-free, so the instant always survives.
+// formatEpoch renders t as epoch seconds with exactly `digits` fractional
+// digits (0, 3, 6 or 9), dropping anything finer.
+//
+// Times go out as epoch rather than wall-clock text because parameter text
+// has no way to say which timezone the digits are in: the server would read
+// a wall-clock string in the parameter's own zone, and whenever that differs
+// from the value's zone the stored moment shifts by the offset. An epoch
+// number means the same moment everywhere.
 func formatEpoch(t time.Time, digits int) string {
 	sec, ns := t.Unix(), int64(t.Nanosecond())
 	if digits == 0 {
@@ -114,10 +116,9 @@ func formatEpoch(t time.Time, digits int) string {
 		pow *= 10
 	}
 	frac := ns / (1_000_000_000 / pow)
-	// Unix() floors and Nanosecond() is the positive offset within that
-	// second, so a pre-1970 instant like -86400.5 arrives as sec -86401,
-	// ns 5e8. Printing those digits naively would yield "-86401.500" =
-	// -86401.5 — carry the sign into both parts instead.
+	// Before 1970 the parts need care: Go gives -86400.5 as second -86401
+	// plus 0.5 forward, and printing those two numbers as-is would read as
+	// -86401.5. Put the sign in front of the combined value instead.
 	sign := ""
 	if sec < 0 {
 		sign = "-"
@@ -131,14 +132,12 @@ func formatEpoch(t time.Time, digits int) string {
 	return fmt.Sprintf("%s%d.%0*d", sign, sec, digits, frac)
 }
 
-// formatTimeParam renders a time.Time sent as a query parameter through
-// Named (which, unlike NamedDateValue, carries no scale), so the fraction
-// width is inferred from the value: whole-second times emit just the
-// integer, sub-second times keep their fraction. A DateTime64 parameter
-// preserves the precision (the server drops digits beyond its declared
-// scale), while a plain DateTime parameter rejects a fraction with an
-// error — better than silently truncating it. Use DateNamed to pin an
-// exact scale.
+// formatTimeParam renders a time.Time sent through Named. Named carries no
+// scale, so the fraction width comes from the value itself: whole seconds
+// stay a bare integer, sub-second values keep their fraction. That way a
+// DateTime64 parameter keeps the precision, and a plain DateTime parameter
+// fails loudly on a fraction instead of silently losing it. DateNamed is
+// the way to pick the width explicitly.
 func formatTimeParam(t time.Time) string {
 	switch ns := t.Nanosecond(); {
 	case ns == 0:
@@ -152,10 +151,9 @@ func formatTimeParam(t time.Time) string {
 	}
 }
 
-// formatTimeWithScale renders a time.Time sent as a query parameter through
-// DateNamed: the fraction width is pinned by the explicit scale (Seconds →
-// none, MilliSeconds → 3 digits, …), truncating any finer precision the
-// value carries.
+// formatTimeWithScale renders a time.Time sent through DateNamed: the
+// caller's scale decides the fraction width (Seconds none, MilliSeconds 3
+// digits, and so on), and anything finer is dropped.
 func formatTimeWithScale(t time.Time, scale TimeUnit) string {
 	switch scale {
 	case MilliSeconds:

--- a/query_parameters.go
+++ b/query_parameters.go
@@ -98,24 +98,22 @@ func isNilParamValue(v any) bool {
 	return false
 }
 
-// formatTimeParam renders a time.Time sent as a query parameter through
-// Named (which, unlike NamedDateValue, carries no scale). It emits epoch
-// seconds rather than wall-clock text: parameter text has no syntax for a
-// timezone, so a wall-clock string would be re-interpreted in the
+// formatEpoch renders t as epoch seconds with exactly digits fractional
+// digits (0, 3, 6 or 9), truncating anything finer. Query parameters are
+// sent as epoch rather than wall-clock text: parameter text has no syntax
+// for a timezone, so a wall-clock string would be re-interpreted in the
 // parameter's declared zone and shift the instant whenever that zone differs
 // from the value's — epoch is zone-free, so the instant always survives.
-//
-// Whole-second times emit just the integer. Sub-second times keep their
-// fraction, trimmed to milli/micro/nanoseconds: a DateTime64 parameter
-// preserves the precision (the server drops digits beyond its declared
-// scale), while a plain DateTime parameter rejects the value with an error —
-// better than silently truncating it. Use DateNamed to pin an exact scale
-// and wall-clock semantics.
-func formatTimeParam(t time.Time) string {
+func formatEpoch(t time.Time, digits int) string {
 	sec, ns := t.Unix(), int64(t.Nanosecond())
-	if ns == 0 {
+	if digits == 0 {
 		return strconv.FormatInt(sec, 10)
 	}
+	pow := int64(1)
+	for i := 0; i < digits; i++ {
+		pow *= 10
+	}
+	frac := ns / (1_000_000_000 / pow)
 	// Unix() floors and Nanosecond() is the positive offset within that
 	// second, so a pre-1970 instant like -86400.5 arrives as sec -86401,
 	// ns 5e8. Printing those digits naively would yield "-86401.500" =
@@ -123,28 +121,50 @@ func formatTimeParam(t time.Time) string {
 	sign := ""
 	if sec < 0 {
 		sign = "-"
-		sec = -sec - 1
-		ns = 1e9 - ns
+		if frac > 0 {
+			sec = -sec - 1
+			frac = pow - frac
+		} else {
+			sec = -sec
+		}
 	}
-	frac := fmt.Sprintf("%09d", ns)
-	switch {
-	case ns%1e6 == 0:
-		frac = frac[:3]
-	case ns%1e3 == 0:
-		frac = frac[:6]
-	}
-	return sign + strconv.FormatInt(sec, 10) + "." + frac
+	return fmt.Sprintf("%s%d.%0*d", sign, sec, digits, frac)
 }
 
+// formatTimeParam renders a time.Time sent as a query parameter through
+// Named (which, unlike NamedDateValue, carries no scale), so the fraction
+// width is inferred from the value: whole-second times emit just the
+// integer, sub-second times keep their fraction. A DateTime64 parameter
+// preserves the precision (the server drops digits beyond its declared
+// scale), while a plain DateTime parameter rejects a fraction with an
+// error — better than silently truncating it. Use DateNamed to pin an
+// exact scale.
+func formatTimeParam(t time.Time) string {
+	switch ns := t.Nanosecond(); {
+	case ns == 0:
+		return formatEpoch(t, 0)
+	case ns%1e6 == 0:
+		return formatEpoch(t, 3)
+	case ns%1e3 == 0:
+		return formatEpoch(t, 6)
+	default:
+		return formatEpoch(t, 9)
+	}
+}
+
+// formatTimeWithScale renders a time.Time sent as a query parameter through
+// DateNamed: the fraction width is pinned by the explicit scale (Seconds →
+// none, MilliSeconds → 3 digits, …), truncating any finer precision the
+// value carries.
 func formatTimeWithScale(t time.Time, scale TimeUnit) string {
 	switch scale {
-	case MicroSeconds:
-		return t.Format("2006-01-02 15:04:05.000000")
 	case MilliSeconds:
-		return t.Format("2006-01-02 15:04:05.000")
+		return formatEpoch(t, 3)
+	case MicroSeconds:
+		return formatEpoch(t, 6)
 	case NanoSeconds:
-		return t.Format("2006-01-02 15:04:05.000000000")
+		return formatEpoch(t, 9)
 	default:
-		return t.Format("2006-01-02 15:04:05")
+		return formatEpoch(t, 0)
 	}
 }

--- a/tests/query_parameters_test.go
+++ b/tests/query_parameters_test.go
@@ -121,10 +121,10 @@ func TestQueryParameters(t *testing.T) {
 		require.NoError(t, row.Err())
 	})
 
-	// DateNamed values are sent as epoch, so the instant survives no matter
-	// which timezone the value carries or the parameter declares. Before,
-	// wall-clock text was re-interpreted in the parameter's zone, shifting
-	// the instant by the zone offset (9h here).
+	// DateNamed values go out as epoch, so the moment they point to survives
+	// whatever timezone the value or the parameter carries. The old
+	// wall-clock text was re-read in the parameter's zone, which shifted the
+	// stored moment by the zone offset — 9 hours in this case.
 	t.Run("DateNamed keeps the instant for non-UTC times", func(t *testing.T) {
 		tokyo := time.FixedZone("Asia/Tokyo", 9*3600)
 		in := time.Date(2020, 1, 2, 12, 0, 0, 0, tokyo) // == 03:00:00 UTC
@@ -139,8 +139,8 @@ func TestQueryParameters(t *testing.T) {
 		assert.True(t, got.Equal(in), "want instant %s, got %s", in.UTC(), got.UTC())
 	})
 
-	// The scale pins the fraction width: it must round-trip sub-second
-	// precision into a matching DateTime64, and truncate it at Seconds.
+	// The scale decides the precision: milliseconds round-trip into a
+	// matching DateTime64, and the Seconds scale drops them.
 	t.Run("DateNamed scale controls sub-second precision", func(t *testing.T) {
 		in := time.Date(2020, 1, 2, 3, 4, 5, 123000000, time.UTC)
 

--- a/tests/query_parameters_test.go
+++ b/tests/query_parameters_test.go
@@ -121,6 +121,47 @@ func TestQueryParameters(t *testing.T) {
 		require.NoError(t, row.Err())
 	})
 
+	// DateNamed values are sent as epoch, so the instant survives no matter
+	// which timezone the value carries or the parameter declares. Before,
+	// wall-clock text was re-interpreted in the parameter's zone, shifting
+	// the instant by the zone offset (9h here).
+	t.Run("DateNamed keeps the instant for non-UTC times", func(t *testing.T) {
+		tokyo := time.FixedZone("Asia/Tokyo", 9*3600)
+		in := time.Date(2020, 1, 2, 12, 0, 0, 0, tokyo) // == 03:00:00 UTC
+
+		var got time.Time
+		row := client.QueryRow(ctx,
+			"SELECT {d:DateTime('UTC')}",
+			clickhouse.DateNamed("d", in, clickhouse.Seconds),
+		)
+		require.NoError(t, row.Err())
+		require.NoError(t, row.Scan(&got))
+		assert.True(t, got.Equal(in), "want instant %s, got %s", in.UTC(), got.UTC())
+	})
+
+	// The scale pins the fraction width: it must round-trip sub-second
+	// precision into a matching DateTime64, and truncate it at Seconds.
+	t.Run("DateNamed scale controls sub-second precision", func(t *testing.T) {
+		in := time.Date(2020, 1, 2, 3, 4, 5, 123000000, time.UTC)
+
+		var got time.Time
+		row := client.QueryRow(ctx,
+			"SELECT {d:DateTime64(3, 'UTC')}",
+			clickhouse.DateNamed("d", in, clickhouse.MilliSeconds),
+		)
+		require.NoError(t, row.Err())
+		require.NoError(t, row.Scan(&got))
+		assert.True(t, got.Equal(in), "want instant %s, got %s", in.UTC(), got.UTC())
+
+		row = client.QueryRow(ctx,
+			"SELECT {d:DateTime('UTC')}",
+			clickhouse.DateNamed("d", in, clickhouse.Seconds),
+		)
+		require.NoError(t, row.Err())
+		require.NoError(t, row.Scan(&got))
+		assert.True(t, got.Equal(in.Truncate(time.Second)), "want truncated instant %s, got %s", in.Truncate(time.Second).UTC(), got.UTC())
+	})
+
 	t.Run("with bind backwards compatibility", func(t *testing.T) {
 		var actualNum uint8
 		var actualStr string

--- a/tests/std/query_parameters_test.go
+++ b/tests/std/query_parameters_test.go
@@ -100,6 +100,50 @@ func TestQueryParameters(t *testing.T) {
 				require.NoError(t, row.Err())
 			})
 
+			// DateNamed values go out as epoch, so the moment they point to
+			// survives whatever timezone the value or the parameter carries.
+			// The old wall-clock text was re-read in the parameter's zone,
+			// which shifted the stored moment by the zone offset — 9 hours
+			// here. Same assertions as the native suite: parameters travel
+			// differently per protocol (URL-encoded on HTTP, Field dump on
+			// native), so each transport proves its own path.
+			t.Run("DateNamed keeps the instant for non-UTC times", func(t *testing.T) {
+				tokyo := time.FixedZone("Asia/Tokyo", 9*3600)
+				in := time.Date(2020, 1, 2, 12, 0, 0, 0, tokyo) // == 03:00:00 UTC
+
+				var got time.Time
+				row := conn.QueryRow(
+					"SELECT {d:DateTime('UTC')}",
+					clickhouse.DateNamed("d", in, clickhouse.Seconds),
+				)
+				require.NoError(t, row.Err())
+				require.NoError(t, row.Scan(&got))
+				assert.True(t, got.Equal(in), "want instant %s, got %s", in.UTC(), got.UTC())
+			})
+
+			// The scale decides the precision: milliseconds round-trip into
+			// a matching DateTime64, and the Seconds scale drops them.
+			t.Run("DateNamed scale controls sub-second precision", func(t *testing.T) {
+				in := time.Date(2020, 1, 2, 3, 4, 5, 123000000, time.UTC)
+
+				var got time.Time
+				row := conn.QueryRow(
+					"SELECT {d:DateTime64(3, 'UTC')}",
+					clickhouse.DateNamed("d", in, clickhouse.MilliSeconds),
+				)
+				require.NoError(t, row.Err())
+				require.NoError(t, row.Scan(&got))
+				assert.True(t, got.Equal(in), "want instant %s, got %s", in.UTC(), got.UTC())
+
+				row = conn.QueryRow(
+					"SELECT {d:DateTime('UTC')}",
+					clickhouse.DateNamed("d", in, clickhouse.Seconds),
+				)
+				require.NoError(t, row.Err())
+				require.NoError(t, row.Scan(&got))
+				assert.True(t, got.Equal(in.Truncate(time.Second)), "want truncated instant %s, got %s", in.Truncate(time.Second).UTC(), got.UTC())
+			})
+
 			t.Run("with bind backwards compatibility", func(t *testing.T) {
 				var actualNum uint8
 				var actualStr string


### PR DESCRIPTION

## Summary
<!-- A short description of the changes with a link to an open issue. -->

follow up to #1899

We have some in-consistency with `Named` and `DateNamed` server params how they treat timezone

Say we have the following code



```go
	// 2020/12/30 12:00, Tokyo (UTC - 9h)
	in := time.Date(2020, 12, 30, 12, 0, 0, 0, tokyo)

	var res time.Time
	row := conn.QueryRow(ctx, "SELECT {x:DateTime('UTC')}", clickhouse.Named("x", in))
	if err := row.Scan(&res); err != nil {
		fmt.Println("Named error: ", err)
	} else {
		fmt.Println("Named: ", res)
	}

	fmt.Println() // separator

	row = conn.QueryRow(ctx, "SELECT {x:DateTime('UTC')}", clickhouse.DateNamed("x", in, clickhouse.Seconds))
	if err := row.Scan(&res); err != nil {
		fmt.Println("DateNamed error: ", err)
	} else {
		fmt.Println("DateNamed: ", res)
	}


```


### Before (at `v2.47.0`)
`Named` fails loudly. `DateNamed` silently ignores the timezone.

Returns
```
Named error:  code: 41, message: Cannot parse datetime: value toDateTime('2020-12-30 12:00:00', 'Asia/Tokyo') cannot be parsed as DateTime('UTC') for query parameter 'x'

DateNamed:  2020-12-30 12:00:00 +0000 UTC

```
### Before (at `main`) - Where we fixed `Named`

Returns
`Named` handles timezone correctly, but `DateNamed` doesn't.

```
Named:  2020-12-30 03:00:00 +0000 UTC // correct

DateNamed:  2020-12-30 12:00:00 +0000 UTC // in-correct.


```
### After
Both `Named` and `DateNamed` handles timezone correctly

```bash
Named:  2020-12-30 03:00:00 +0000 UTC

DateNamed:  2020-12-30 03:00:00 +0000 UTC

```

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
