### PR TITLE
chore: correct permission to resolve review comment

### DIFF
--- a/.claude/skills/review-pr/post_review.py
+++ b/.claude/skills/review-pr/post_review.py
@@ -345,8 +345,16 @@ def cmd_post(args):
                         f"repos/{args.repo}/pulls/{args.pr}/comments/{root_id}/replies",
                         "--method", "POST", "--input", "-"],
                        payload={"body": marked})
-            resolve_thread(thread_id)
-            resolved += 1
+            # If resolving fails (e.g. missing permission), just warn —
+            # not worth failing the whole post step over.
+            try:
+                resolve_thread(thread_id)
+                resolved += 1
+            except RuntimeError as exc:
+                print(
+                    f"warning: could not resolve thread {thread_id}: {exc}",
+                    file=sys.stderr,
+                )
         # action == "keep" (or unknown): do nothing
     if replied:
         print(f"Replied to {replied} thread(s).")

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,10 @@ jobs:
       github.event.label.name == 'review:claude-agent'
     runs-on: ubuntu-latest
     permissions:
-      contents: read        # read repo files (SKILL.md, etc.)
+      # resolving review threads needs contents:write, oddly enough:
+      # https://github.com/orgs/community/discussions/44650
+      # Safe here: we only check out the base branch, and only on a maintainer label.
+      contents: write
       pull-requests: write  # post review comments
       issues: write         # update labels / post issue comments
       id-token: write       # OIDC token for claude-code-action auth


### PR DESCRIPTION


## Summary
<!-- A short description of the changes with a link to an open issue. -->
Changes

1. Github Action which runs the code review workflow also check if it makes sense to resolve already addressed feedback. Resolving the comment needs write permission.

2. Also failing to resolve shouldn't fail the whole workflow

Exposed in [this PR run](https://github.com/ClickHouse/clickhouse-go/actions/runs/29094782328/job/86368565278)
## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
