### PR TITLE
fix: gurantee datetime string format in JSON

### DIFF
--- a/.github/workflows/run-tests-head.yml
+++ b/.github/workflows/run-tests-head.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && github.event.label_name == 'tests:run-head')
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'tests:run-head'))
     runs-on: [self-hosted, style-checker-aarch64]
     strategy:
       matrix:

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -317,6 +317,7 @@ func TestJSONString(t *testing.T) {
 
 		require.NoError(t, conn.Exec(ctx, "SET output_format_native_write_json_as_string=1"))
 		require.NoError(t, conn.Exec(ctx, "SET output_format_json_quote_64bit_integers=0"))
+		require.NoError(t, conn.Exec(ctx, "SET date_time_output_format='iso'"))
 
 		const ddl = `
 			CREATE TABLE IF NOT EXISTS test_json_string (

--- a/tests/std/json_test.go
+++ b/tests/std/json_test.go
@@ -262,6 +262,8 @@ func TestJSONString(t *testing.T) {
 	require.NoError(t, err)
 	_, err = conn.ExecContext(ctx, "SET output_format_json_quote_64bit_integers = 0")
 	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, "SET date_time_output_format='iso'")
+	require.NoError(t, err)
 
 	const ddl = `
 			CREATE TABLE IF NOT EXISTS std_test_json_string (


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

To [fix the failing test cases](https://github.com/ClickHouse/clickhouse-go/actions/runs/29060545816/job/86261238922) on latest CH (26.5+)

Since CH 26.5. The datetime parsing is default to `best_effort` meaning, even the date time string in JSON is parsed as DateTime object.

### Before (<=26.4)
```
$ clickhouse-26-4 local -q "
  VERSION();
  CREATE TABLE test (c JSON);
  INSERT INTO test VALUES ('{\"x\": \"2024-12-13T02:09:30.123Z\"}');
  SELECT * FROM test
  "
26.4.5.118
{"x":"2024-12-13T02:09:30.123Z"}
```

### After (26.5+)
```
clickhouse-26-5 local -q "
  VERSION();
  CREATE TABLE test (c JSON);
  INSERT INTO test VALUES ('{\"x\": \"2024-12-13T02:09:30.123Z\"}');
  SELECT * FROM test
  "
26.5.6.31
{"x":"2024-12-13 03:09:30.123000000"}
```
So previously was just string (during SELECT) can be formatted from timezone aware DateTime object which can differ in format.

In Go, by default when you parse date time string -> Time object it default to ISO.

To make it sane default, make the tests uses ISO. To make the tests passes for CH > 26.5

Either we should make this date format default everywhere in the client is up for discussion and I will do that in separate PR

Tested this PR with different version
### Before
```bash
 CLICKHOUSE_VERSION=26.5 go test ./tests/... -run TestJSONString -v -count=1
=== RUN   TestJSONString
    json_test.go:332:
        	Error Trace:	/home/kavi/src/clickhouse-go/main/tests/std/json_test.go:332
        	Error:      	Received unexpected error:
        	            	parsing time "2024-12-13 02:09:30.123000000" as "2006-01-02T15:04:05Z07:00": cannot parse " 02:09:30.123000000" as "T"
        	Test:       	TestJSONString

```

### After
```bash
 CLICKHOUSE_VERSION=26.5 go test ./tests/... -run TestJSONString -v -count=1
```
NO error.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
