### PR TITLE
ci: add StressHouse PR-vs-main benchmark workflow

### DIFF
--- a/.github/workflows/stresshouse-benchmark-compare.yml
+++ b/.github/workflows/stresshouse-benchmark-compare.yml
@@ -1,0 +1,44 @@
+# Benchmark this PR's build vs `main` on StressHouse and comment the comparison
+# on the PR.
+#
+# Thin caller: the logic lives in the shared reusable workflow
+# ClickHouse/integrations-shared-workflows/.github/workflows/clickhouse-benchmark.yml,
+# so behaviour can be adjusted in one place. It uses the Workflow Auth app to
+# start the central `StressHouse dispatch` workflow in
+# ClickHouse/clickhouse-client-benchmarks; when the run finishes, StressHouse
+# posts a sticky comparison comment back onto this PR.
+#
+# Trigger: a `/benchmark-compare` PR comment from a maintainer, or manually from
+# the Actions tab (supply the PR number).
+---
+name: StressHouse Benchmark (PR vs main)
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to benchmark and comment on."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  benchmark:
+    # Comment path: only on PRs, only `/benchmark-compare`, only from someone
+    # with write access. Manual path: always allowed.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, '/benchmark-compare') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    uses: ClickHouse/integrations-shared-workflows/.github/workflows/clickhouse-benchmark.yml@main
+    with:
+      client: clickhouse-go
+      profile: pr-compare
+      pr_number: ${{ github.event.issue.number || inputs.pr_number }}
+    secrets: inherit


### PR DESCRIPTION
Adds `.github/workflows/stresshouse-benchmark-compare.yml` — a thin caller for the shared reusable workflow (`ClickHouse/integrations-shared-workflows` → `clickhouse-benchmark.yml`).

## What it does

A `/benchmark-compare` comment from a maintainer (or a manual `workflow_dispatch` with a PR number) benchmarks this PR's build against `main` on StressHouse and posts a sticky comparison comment back on the PR. The `client:` input is set to `clickhouse-go`.

This mirrors the workflow already running successfully in [`clickhouse-cs`](https://github.com/ClickHouse/clickhouse-cs/blob/main/.github/workflows/stresshouse-benchmark-compare.yml).

## Prerequisites (org-level, one-time)

- The shared **Workflow Auth** app secrets (`WORKFLOW_AUTH_PUBLIC_APP_ID`, `WORKFLOW_AUTH_PUBLIC_PRIVATE_KEY`) must be available to this repo; `secrets: inherit` forwards them to the reusable workflow.
- That app must be installed on `ClickHouse/clickhouse-client-benchmarks` with `actions: write` so it can start the dispatch workflow there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)