### PR TITLE
fix: replace panic in unhex with error return

### DIFF
--- a/lib/churl/churl.go
+++ b/lib/churl/churl.go
@@ -321,8 +321,14 @@ func unescape(s string, mode encoding) (string, error) {
 			// But https://tools.ietf.org/html/rfc6874#section-2
 			// introduces %25 being allowed to escape a percent sign
 			// in IPv6 scoped-address literals. Yay.
-			if mode == encodeHost && unhex(s[i+1]) < 8 && s[i:i+3] != "%25" {
-				return "", neturl.EscapeError(s[i : i+3])
+			if mode == encodeHost {
+				h, err := unhex(s[i+1])
+				if err != nil {
+					return "", err
+				}
+				if h < 8 && s[i:i+3] != "%25" {
+					return "", neturl.EscapeError(s[i : i+3])
+				}
 			}
 			if mode == encodeZone {
 				// RFC 6874 says basically "anything goes" for zone identifiers
@@ -332,7 +338,15 @@ func unescape(s string, mode encoding) (string, error) {
 				// That is, you can use escaping in the zone identifier but not
 				// to introduce bytes you couldn't just write directly.
 				// But Windows puts spaces here! Yay.
-				v := unhex(s[i+1])<<4 | unhex(s[i+2])
+				hi, err := unhex(s[i+1])
+				if err != nil {
+					return "", err
+				}
+				lo, err := unhex(s[i+2])
+				if err != nil {
+					return "", err
+				}
+				v := hi<<4 | lo
 				if s[i:i+3] != "%25" && v != ' ' && shouldEscape(v, encodeHost) {
 					return "", neturl.EscapeError(s[i : i+3])
 				}
@@ -358,7 +372,15 @@ func unescape(s string, mode encoding) (string, error) {
 	for i := 0; i < len(s); i++ {
 		switch s[i] {
 		case '%':
-			t.WriteByte(unhex(s[i+1])<<4 | unhex(s[i+2]))
+			hi, err := unhex(s[i+1])
+			if err != nil {
+				return "", err
+			}
+			lo, err := unhex(s[i+2])
+			if err != nil {
+				return "", err
+			}
+			t.WriteByte(hi<<4 | lo)
 			i += 2
 		case '+':
 			if mode == encodeQueryComponent {
@@ -517,16 +539,16 @@ func ishex(c byte) bool {
 	return false
 }
 
-func unhex(c byte) byte {
+func unhex(c byte) (byte, error) {
 	switch {
 	case '0' <= c && c <= '9':
-		return c - '0'
+		return c - '0', nil
 	case 'a' <= c && c <= 'f':
-		return c - 'a' + 10
+		return c - 'a' + 10, nil
 	case 'A' <= c && c <= 'F':
-		return c - 'A' + 10
+		return c - 'A' + 10, nil
 	default:
-		panic("invalid hex character")
+		return 0, fmt.Errorf("invalid hex character %q", c)
 	}
 }
 

--- a/lib/churl/churl_test.go
+++ b/lib/churl/churl_test.go
@@ -1,0 +1,71 @@
+package churl
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnhex_Valid(t *testing.T) {
+	tests := []struct {
+		input byte
+		want  byte
+	}{
+		{'0', 0},
+		{'9', 9},
+		{'a', 10},
+		{'f', 15},
+		{'A', 10},
+		{'F', 15},
+	}
+	for _, tt := range tests {
+		got, err := unhex(tt.input)
+		require.NoError(t, err)
+		assert.Equal(t, tt.want, got)
+	}
+}
+
+func TestUnhex_Invalid(t *testing.T) {
+	invalid := []byte{'G', 'z', '%', ' ', 'x', 0xFF}
+	for _, c := range invalid {
+		_, err := unhex(c)
+		assert.Error(t, err, "expected error for input %q", c)
+	}
+}
+
+func TestUnescape_InvalidHex(t *testing.T) {
+	_, err := unescape("%GG", encodePath)
+	require.Error(t, err)
+}
+
+func TestUnescape_Truncated(t *testing.T) {
+	_, err := unescape("%G", encodePath)
+	require.Error(t, err)
+}
+
+func TestUnescape_Valid(t *testing.T) {
+	got, err := unescape("%48%65%6C%6C%6F", encodePath)
+	require.NoError(t, err)
+	assert.Equal(t, "Hello", got)
+}
+
+func TestParse_InvalidPercentEncoding(t *testing.T) {
+	_, err := Parse("http://host:8123/%GG")
+	var urlErr *url.Error
+	require.ErrorAs(t, err, &urlErr)
+}
+
+func TestParse_InvalidPercentEncodingInHost(t *testing.T) {
+	_, err := Parse("http://host%GG:8123")
+	require.Error(t, err)
+}
+
+func TestParse_ValidURL(t *testing.T) {
+	u, err := Parse("http://user:pass@host:8123/default?param=value")
+	require.NoError(t, err)
+	assert.Equal(t, "host:8123", u.Host)
+	assert.Equal(t, "/default", u.Path)
+	assert.Equal(t, "param=value", u.RawQuery)
+}


### PR DESCRIPTION
## Summary
Replace `panic("invalid hex character")` in `lib/churl.unhex()` with a proper `(byte, error)` return. Fixes #1908.

The `unhex` helper previously panicked on invalid hex input (e.g., `%GG` in a DSN), crashing the entire Go process. Now it returns an error that propagates through `unescape()` → `Parse()` → caller, so malformed URLs are handled gracefully.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
