### PR TITLE
fix: preserve per-query JWT in QueryOptions.clone()

### DIFF
--- a/conn_http_test.go
+++ b/conn_http_test.go
@@ -2,6 +2,7 @@ package clickhouse
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
 	"testing"
 )
@@ -83,6 +84,78 @@ func TestApplyOptionsToRequest_HostHeader(t *testing.T) {
 
 			if req.Host != tt.expectedHost {
 				t.Errorf("req.Host = %q, want %q", req.Host, tt.expectedHost)
+			}
+
+			for k, v := range tt.expectedInMap {
+				if got := req.Header.Get(k); got != v {
+					t.Errorf("req.Header[%q] = %q, want %q", k, got, v)
+				}
+			}
+
+			for _, k := range tt.unexpectedInMap {
+				if got := req.Header.Get(k); got != "" {
+					t.Errorf("req.Header[%q] = %q, want it absent", k, got)
+				}
+			}
+		})
+	}
+}
+
+func TestApplyOptionsToRequest_JWTAuth(t *testing.T) {
+	tests := []struct {
+		name            string
+		ctx             context.Context
+		opts            *Options
+		expectedInMap   map[string]string
+		unexpectedInMap []string
+	}{
+		{
+			// Regression for #1914: a per-query JWT must take precedence over the
+			// connection's basic-auth credentials, not silently downgrade to them.
+			name: "per-query JWT wins over basic auth",
+			ctx:  Context(context.Background(), WithJWT("tok-123")),
+			opts: &Options{
+				TLS:  &tls.Config{},
+				Auth: Auth{Username: "service", Password: "secret"},
+			},
+			expectedInMap:   map[string]string{"Authorization": "Bearer tok-123"},
+			unexpectedInMap: []string{"X-ClickHouse-User", "X-ClickHouse-Key"},
+		},
+		{
+			name: "no JWT falls back to basic auth headers",
+			ctx:  context.Background(),
+			opts: &Options{
+				TLS:  &tls.Config{},
+				Auth: Auth{Username: "service", Password: "secret"},
+			},
+			expectedInMap: map[string]string{
+				"X-ClickHouse-User": "service",
+				"X-ClickHouse-Key":  "secret",
+			},
+			unexpectedInMap: []string{"Authorization"},
+		},
+		{
+			name: "per-query JWT wins over GetJWT",
+			ctx:  Context(context.Background(), WithJWT("tok-123")),
+			opts: &Options{
+				TLS: &tls.Config{},
+				GetJWT: func(ctx context.Context) (string, error) {
+					return "conn-tok", nil
+				},
+			},
+			expectedInMap: map[string]string{"Authorization": "Bearer tok-123"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, "https://localhost:8443/", nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %s", err)
+			}
+
+			if err := applyOptionsToRequest(tt.ctx, req, tt.opts); err != nil {
+				t.Fatalf("applyOptionsToRequest failed: %s", err)
 			}
 
 			for k, v := range tt.expectedInMap {

--- a/context.go
+++ b/context.go
@@ -243,16 +243,6 @@ func queryOptions(ctx context.Context) QueryOptions {
 	return opt
 }
 
-// queryOptionsJWT returns the JWT within the given context's QueryOptions.
-// Empty string if not present.
-func queryOptionsJWT(ctx context.Context) string {
-	if opt, ok := ctx.Value(_contextOptionKey).(QueryOptions); ok {
-		return opt.jwt
-	}
-
-	return ""
-}
-
 // queryOptionsAsync returns the AsyncOptions struct within the given context's QueryOptions.
 func queryOptionsAsync(ctx context.Context) AsyncOptions {
 	if opt, ok := ctx.Value(_contextOptionKey).(QueryOptions); ok {

--- a/context.go
+++ b/context.go
@@ -322,6 +322,7 @@ func (q *QueryOptions) clone() QueryOptions {
 		async:               q.async,
 		queryID:             q.queryID,
 		quotaKey:            q.quotaKey,
+		jwt:                 q.jwt,
 		events:              q.events,
 		settings:            nil,
 		parameters:          nil,

--- a/context_test.go
+++ b/context_test.go
@@ -183,6 +183,26 @@ func TestContext(t *testing.T) {
 	)
 }
 
+func TestContextJWTPreserved(t *testing.T) {
+	// Regression: queryOptions() returns a clone of the context's QueryOptions,
+	// and clone() must carry the per-query JWT set via WithJWT. Otherwise the
+	// HTTPS transport reads an empty token and silently falls back to the
+	// connection's basic-auth credentials.
+	t.Run("clone preserves WithJWT token", func(t *testing.T) {
+		ctx := Context(context.Background(), WithJWT("tok-123"))
+		require.Equal(t, "tok-123", queryOptions(ctx).jwt)
+	})
+
+	t.Run("jwt survives alongside other options", func(t *testing.T) {
+		ctx := Context(context.Background(), WithJWT("tok-123"), WithQueryID("q1"))
+		ctx = Context(ctx, WithQuotaKey("k1"))
+		opts := queryOptions(ctx)
+		require.Equal(t, "tok-123", opts.jwt)
+		require.Equal(t, "q1", opts.queryID)
+		require.Equal(t, "k1", opts.quotaKey)
+	})
+}
+
 func TestWithoutProfileEvents(t *testing.T) {
 	t.Run("sets send_profile_events=0", func(t *testing.T) {
 		ctx := Context(context.Background(), WithoutProfileEvents())


### PR DESCRIPTION
## Summary

Since v2.42.0, a per-query JWT set with `clickhouse.WithJWT` is silently ignored on the HTTP interface: the request falls back to the connection's basic-auth credentials and the query runs as the wrong principal, with no error surfaced.

**Root cause.** `applyOptionsToRequest` reads the per-query JWT from `queryOptions(ctx)`, which returns a `clone()` of the context's `QueryOptions`. `clone()` copies every field except `jwt`, so the token set via `WithJWT` is always empty by the time the request headers are built: `useJWT` evaluates to false, the `Authorization: Bearer` arm is skipped, and the request authenticates with `X-ClickHouse-User`/`X-ClickHouse-Key` instead.

The regression came in 55bfc3e ("Add context option to append more ClientInfo to the system.query_log", first released in v2.42.0), which switched `applyOptionsToRequest` from `queryOptionsJWT(ctx)` — which read `jwt` straight off the context without cloning — to `queryOpt.jwt` on the clone, without adding `jwt` to `clone()`.

**Impact.** Any HTTPS connection that combines connection-level basic-auth credentials with per-query `WithJWT` tokens (e.g. a shared pool where service queries use a password and user queries carry a JWT) executes the user's queries as the service account on affected versions. Because the query succeeds, the credential downgrade is invisible to the application — results simply reflect the wrong user's grants and row policies.

**Fix.** Copy `jwt` in `QueryOptions.clone()`, plus a regression test covering the round-trip (`Context(ctx, WithJWT(...))` → `queryOptions(ctx).jwt`), including the case where a second `Context(ctx, ...)` call re-clones existing options.

The regression test lives in `context_test.go` rather than `tests/issues/` because it exercises unexported internals (`queryOptions`/`clone`), and JWT auth is a ClickHouse Cloud feature that the Docker-based integration suite can't reproduce.

`make lint` and the unit tests pass locally.

**Provenance.** The root-cause investigation and initial patch were done with an AI assistant (Claude Code, noted as co-author on the commit). I reviewed the change manually and verified it end-to-end against ClickHouse Cloud: with the fix, a query issued with `WithJWT` over HTTPS runs as the JWT principal; without it, it runs as the connection's basic-auth user.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
