### PR TITLE
Rework connection liveness checking and connection reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The following connection settings are available in both DSN strings and the `cli
 * **max_open_conns** - Maximum number of open connections to the database (default: MaxIdleConns + 5)
 * **max_idle_conns** - Maximum number of idle connections in the pool (default: 5)
 * **conn_max_lifetime** - Maximum amount of time a connection may be reused (default: 1h)
+* **conn_idle_ping_threshold** - How long a pooled connection may sit idle before it is verified with a protocol ping when acquired. Detects half-open connections (e.g. silently dropped by a load balancer or firewall) that a socket-level check cannot see. Connections used more recently than this skip the ping entirely (default: 1m; a negative value disables idle pings)
 
 ### Connection Strategy
 * **connection_open_strategy** - Strategy for selecting servers from the connection pool:

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -90,6 +90,12 @@ type nativeTransport interface {
 	asyncInsert(ctx context.Context, query string, wait bool, args ...any) error
 	ping(context.Context) error
 	isBad() bool
+	// markUnverified requires a successful revalidateIdle before the
+	// connection is handed out again.
+	markUnverified()
+	// revalidateIdle verifies liveness with a protocol ping when the
+	// connection is unverified or has idled past ConnIdlePingThreshold.
+	revalidateIdle(ctx context.Context) error
 	connID() int
 	connectedAtTime() time.Time
 	isReleased() bool
@@ -342,13 +348,16 @@ func (ch *clickhouse) acquire(ctx context.Context) (conn nativeTransport, err er
 	}
 
 	if err == nil && conn != nil {
-		if !conn.isBad() {
+		if conn.isBad() {
+			conn.close()
+		} else if rerr := conn.revalidateIdle(ctx); rerr != nil {
+			conn.getLogger().Debug("pooled connection failed liveness revalidation", slog.Any("error", rerr))
+			conn.close()
+		} else {
 			conn.setReleased(false)
 			conn.getLogger().Debug("connection acquired from pool")
 			return conn, nil
 		}
-
-		conn.close()
 	}
 
 	if conn, err = ch.dial(ctx); err != nil {
@@ -383,10 +392,22 @@ func (ch *clickhouse) release(conn nativeTransport, err error) {
 	}
 
 	if err != nil {
-		conn.getLogger().Debug("connection closed due to error", slog.Any("error", err))
-		conn.close()
-		return
-	} else if time.Since(conn.connectedAtTime()) >= ch.opt.ConnMaxLifetime {
+		var exc *Exception
+		if errors.As(err, &exc) {
+			// A server exception terminates the response stream at a packet
+			// boundary and the server usually preserves the connection, so it
+			// is reusable — but a ping must confirm the server did not choose
+			// to close it before it is handed out again.
+			conn.getLogger().Debug("connection kept after server exception", slog.Int("code", int(exc.Code)))
+			conn.markUnverified()
+		} else {
+			conn.getLogger().Debug("connection closed due to error", slog.Any("error", err))
+			conn.close()
+			return
+		}
+	}
+
+	if time.Since(conn.connectedAtTime()) >= ch.opt.ConnMaxLifetime {
 		conn.getLogger().Debug("connection closed: lifetime expired",
 			slog.Duration("age", time.Since(conn.connectedAtTime())),
 			slog.Duration("max_lifetime", ch.opt.ConnMaxLifetime))

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -90,11 +90,7 @@ type nativeTransport interface {
 	asyncInsert(ctx context.Context, query string, wait bool, args ...any) error
 	ping(context.Context) error
 	isBad() bool
-	// markUnverified requires a successful revalidateIdle before the
-	// connection is handed out again.
 	markUnverified()
-	// revalidateIdle verifies liveness with a protocol ping when the
-	// connection is unverified or has idled past ConnIdlePingThreshold.
 	revalidateIdle(ctx context.Context) error
 	connID() int
 	connectedAtTime() time.Time
@@ -394,10 +390,6 @@ func (ch *clickhouse) release(conn nativeTransport, err error) {
 	if err != nil {
 		var exc *Exception
 		if errors.As(err, &exc) {
-			// A server exception terminates the response stream at a packet
-			// boundary and the server usually preserves the connection, so it
-			// is reusable — but a ping must confirm the server did not choose
-			// to close it before it is handed out again.
 			conn.getLogger().Debug("connection kept after server exception", slog.Int("code", int(exc.Code)))
 			conn.markUnverified()
 		} else {

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -149,19 +149,24 @@ type Options struct {
 	// instead of Logger.
 	Logger *slog.Logger
 
-	Settings             Settings
-	Compression          *Compression
-	DialTimeout          time.Duration // default 30 second
-	MaxOpenConns         int           // default MaxIdleConns + 5
-	MaxIdleConns         int           // default 5
-	ConnMaxLifetime      time.Duration // default 1 hour
-	ConnOpenStrategy     ConnOpenStrategy
-	FreeBufOnConnRelease bool              // drop preserved memory buffer after each query
-	HttpHeaders          map[string]string // set additional headers on HTTP requests
-	HttpUrlPath          string            // set additional URL path for HTTP requests
-	HttpMaxConnsPerHost  int               // MaxConnsPerHost for http.Transport
-	BlockBufferSize      uint8             // default 2 - can be overwritten on query
-	MaxCompressionBuffer int               // default 10485760 - measured in bytes  i.e.
+	Settings        Settings
+	Compression     *Compression
+	DialTimeout     time.Duration // default 30 second
+	MaxOpenConns    int           // default MaxIdleConns + 5
+	MaxIdleConns    int           // default 5
+	ConnMaxLifetime time.Duration // default 1 hour
+	// ConnIdlePingThreshold is how long a pooled connection may sit idle
+	// before it is verified with a protocol ping on acquire. A socket-level
+	// check cannot detect half-open connections (e.g. silently dropped by a
+	// load balancer); the ping can. Default 1 minute; negative disables.
+	ConnIdlePingThreshold time.Duration
+	ConnOpenStrategy      ConnOpenStrategy
+	FreeBufOnConnRelease  bool              // drop preserved memory buffer after each query
+	HttpHeaders           map[string]string // set additional headers on HTTP requests
+	HttpUrlPath           string            // set additional URL path for HTTP requests
+	HttpMaxConnsPerHost   int               // MaxConnsPerHost for http.Transport
+	BlockBufferSize       uint8             // default 2 - can be overwritten on query
+	MaxCompressionBuffer  int               // default 10485760 - measured in bytes  i.e.
 
 	// HTTPProxy specifies an HTTP proxy URL to use for requests made by the client.
 	HTTPProxyURL *url.URL
@@ -327,6 +332,12 @@ func (o *Options) fromDSN(in string) error {
 				return fmt.Errorf("conn_max_lifetime invalid value: %w", err)
 			}
 			o.ConnMaxLifetime = connMaxLifetime
+		case "conn_idle_ping_threshold":
+			connIdlePingThreshold, err := time.ParseDuration(params.Get(v))
+			if err != nil {
+				return fmt.Errorf("conn_idle_ping_threshold invalid value: %w", err)
+			}
+			o.ConnIdlePingThreshold = connIdlePingThreshold
 		case "username":
 			o.Auth.Username = params.Get(v)
 		case "password":
@@ -417,6 +428,9 @@ func (o Options) setDefaults() *Options {
 	}
 	if o.ConnMaxLifetime == 0 {
 		o.ConnMaxLifetime = time.Hour
+	}
+	if o.ConnIdlePingThreshold == 0 {
+		o.ConnIdlePingThreshold = time.Minute
 	}
 	if o.BlockBufferSize <= 0 {
 		o.BlockBufferSize = 2

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -156,9 +156,8 @@ type Options struct {
 	MaxIdleConns    int           // default 5
 	ConnMaxLifetime time.Duration // default 1 hour
 	// ConnIdlePingThreshold is how long a pooled connection may sit idle
-	// before it is verified with a protocol ping on acquire. A socket-level
-	// check cannot detect half-open connections (e.g. silently dropped by a
-	// load balancer); the ping can. Default 1 minute; negative disables.
+	// before it is verified with a protocol ping on acquire.
+	// Default is 1 minute, negative value disables.
 	ConnIdlePingThreshold time.Duration
 	ConnOpenStrategy      ConnOpenStrategy
 	FreeBufOnConnRelease  bool              // drop preserved memory buffer after each query

--- a/clickhouse_options_test.go
+++ b/clickhouse_options_test.go
@@ -503,6 +503,21 @@ func TestParseDSN(t *testing.T) {
 			"",
 		},
 		{
+			"client connection idle ping threshold",
+			"clickhouse://127.0.0.1/test_database?conn_idle_ping_threshold=30s",
+			&Options{
+				Protocol:              Native,
+				ConnIdlePingThreshold: 30 * time.Second,
+				Addr:                  []string{"127.0.0.1"},
+				Settings:              Settings{},
+				Auth: Auth{
+					Database: "test_database",
+				},
+				scheme: "clickhouse",
+			},
+			"",
+		},
+		{
 			"http protocol with proxy",
 			"http://127.0.0.1/?http_proxy=http%3A%2F%2Fproxy.example.com%3A3128",
 			&Options{

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -202,8 +202,6 @@ func (std *stdDriver) ResetSession(ctx context.Context) error {
 		return driver.ErrBadConn
 	}
 
-	// database/sql calls ResetSession before reusing a pooled connection:
-	// the same point the native pool verifies long-idle connections
 	if err := std.conn.revalidateIdle(ctx); err != nil {
 		std.logger.Debug("resetting session: connection failed liveness revalidation", slog.Any("error", err))
 		return driver.ErrBadConn

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -181,6 +181,24 @@ func (std *stdDriver) Open(dsn string) (_ driver.Conn, err error) {
 
 var _ driver.Driver = (*stdDriver)(nil)
 
+// release is the transport release callback for database/sql mode. There is
+// no driver-level pool to return the connection to (database/sql owns the
+// lifecycle); its only job is to prevent reuse of a connection whose response
+// stream terminated uncleanly, since undelivered bytes may still be on the
+// socket or in the read buffer. A server exception is a clean terminator and
+// keeps the connection usable.
+func (std *stdDriver) release(_ nativeTransport, err error) {
+	if err == nil {
+		return
+	}
+	var exc *Exception
+	if errors.As(err, &exc) {
+		return
+	}
+	std.logger.Debug("closing connection after unclean stream termination", slog.Any("error", err))
+	_ = std.conn.close()
+}
+
 func (std *stdDriver) ResetSession(ctx context.Context) error {
 	if std.conn.isBad() {
 		std.logger.Debug("resetting session because connection is bad")
@@ -281,7 +299,7 @@ func (std *stdDriver) QueryContext(ctx context.Context, query string, args []dri
 		return nil, driver.ErrBadConn
 	}
 
-	r, err := std.conn.query(ctx, func(nativeTransport, error) {}, query, rebind(args)...)
+	r, err := std.conn.query(ctx, std.release, query, rebind(args)...)
 	if isConnBrokenError(err) {
 		std.logger.Error("query context got a fatal error, resetting connection", slog.Any("error", err))
 		return nil, driver.ErrBadConn
@@ -306,7 +324,7 @@ func (std *stdDriver) PrepareContext(ctx context.Context, query string) (driver.
 		return nil, driver.ErrBadConn
 	}
 
-	batch, err := std.conn.prepareBatch(ctx, func(nativeTransport, error) {}, func(context.Context) (nativeTransport, error) { return nil, nil }, query, chdriver.PrepareBatchOptions{})
+	batch, err := std.conn.prepareBatch(ctx, std.release, func(context.Context) (nativeTransport, error) { return nil, nil }, query, chdriver.PrepareBatchOptions{})
 	if err != nil {
 		if isConnBrokenError(err) {
 			std.logger.Error("prepare context got a fatal error, resetting connection", slog.Any("error", err))

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -181,20 +181,16 @@ func (std *stdDriver) Open(dsn string) (_ driver.Conn, err error) {
 
 var _ driver.Driver = (*stdDriver)(nil)
 
-// release is the transport release callback for database/sql mode. There is
-// no driver-level pool to return the connection to (database/sql owns the
-// lifecycle); its only job is to prevent reuse of a connection whose response
-// stream terminated uncleanly, since undelivered bytes may still be on the
-// socket or in the read buffer. A server exception is a clean terminator and
-// keeps the connection usable.
 func (std *stdDriver) release(_ nativeTransport, err error) {
 	if err == nil {
 		return
 	}
+
 	var exc *Exception
 	if errors.As(err, &exc) {
 		return
 	}
+
 	std.logger.Debug("closing connection after unclean stream termination", slog.Any("error", err))
 	_ = std.conn.close()
 }

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -146,6 +146,7 @@ func OpenDB(opt *Options) *sql.DB {
 
 type stdConnect interface {
 	isBad() bool
+	revalidateIdle(ctx context.Context) error
 	close() error
 	query(ctx context.Context, release nativeTransportRelease, query string, args ...any) (*rows, error)
 	exec(ctx context.Context, query string, args ...any) error
@@ -200,6 +201,14 @@ func (std *stdDriver) ResetSession(ctx context.Context) error {
 		std.logger.Debug("resetting session because connection is bad")
 		return driver.ErrBadConn
 	}
+
+	// database/sql calls ResetSession before reusing a pooled connection:
+	// the same point the native pool verifies long-idle connections
+	if err := std.conn.revalidateIdle(ctx); err != nil {
+		std.logger.Debug("resetting session: connection failed liveness revalidation", slog.Any("error", err))
+		return driver.ErrBadConn
+	}
+
 	return nil
 }
 

--- a/conn.go
+++ b/conn.go
@@ -22,17 +22,14 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
-// errUnexpectedRead is reported by connCheck when an idle connection has
-// readable bytes. The native protocol has no server-initiated packets between
-// queries, so this means the previous response was not fully drained — a
-// driver bug, not a network event.
+// errUnexpectedRead is reported when an idle connection has
+// readable bytes. The native protocol should have no server-initiated packets between
+// queries, so this means the previous response was not fully drained.
 var errUnexpectedRead = errors.New("unexpected read from socket")
 
-// connLivenessWindow is how long a liveness proof (a completed protocol
-// exchange or a passed connCheck) is trusted before the socket is probed
-// again. It avoids per-operation syscalls on hot connections while keeping
-// stale-connection detection for genuinely idle ones.
-const connLivenessWindow = time.Second
+// connLivenessWindow is how long a liveness proof is trusted
+// before the socket is probed again.
+const connLivenessWindow = 1 * time.Second
 
 func dial(ctx context.Context, addr string, num int, opt *Options) (*connect, error) {
 	var (
@@ -144,8 +141,8 @@ type connect struct {
 	structMap            *structMap
 	compression          CompressionMethod
 	connectedAt          time.Time
-	lastLiveAt           time.Time // last proof of liveness: completed exchange or passed connCheck
-	unverified           bool      // require a protocol ping before next reuse
+	lastLiveAt           time.Time
+	unverified           bool
 	compressor           *compress.Writer
 	readTimeout          time.Duration
 	blockBufferSize      uint8
@@ -216,45 +213,35 @@ func (c *connect) isBad() bool {
 			c.logger.Warn("closing connection: unread server data on idle connection, this indicates a driver bug, please report it",
 				slog.Int("conn_id", c.id))
 		}
+
 		return true
 	}
+
 	c.lastLiveAt = time.Now()
 
 	return false
 }
 
-// markUnverified requires a successful protocol ping (revalidateIdle) before
-// the connection is handed out again. Used when the connection is pooled in a
-// state the server may not have preserved, e.g. after a server exception.
 func (c *connect) markUnverified() {
 	c.unverified = true
 }
 
-// revalidateIdle verifies a pooled connection with a protocol ping when it is
-// unverified or has idled past Options.ConnIdlePingThreshold. A socket-level
-// check cannot detect a half-open connection (writes succeed into the void);
-// only a round-trip can.
 func (c *connect) revalidateIdle(ctx context.Context) error {
-	needPing := c.unverified
-	if !needPing {
+	if !c.unverified {
 		threshold := c.opt.ConnIdlePingThreshold
-		if threshold < 0 {
+		if threshold < 0 || time.Since(c.lastLiveAt) < threshold {
 			return nil
 		}
-		needPing = time.Since(c.lastLiveAt) >= threshold
-	}
-	if !needPing {
-		return nil
 	}
 
-	// Bound the ping to half the remaining acquire budget so a dead
-	// connection leaves room to dial a replacement.
 	pingCtx := ctx
+	// Limit ping deadline to allow time for re-dial
 	if deadline, ok := ctx.Deadline(); ok {
 		var cancel context.CancelFunc
 		pingCtx, cancel = context.WithDeadline(ctx, time.Now().Add(time.Until(deadline)/2))
 		defer cancel()
 	}
+
 	if err := c.ping(pingCtx); err != nil {
 		return err
 	}
@@ -271,7 +258,6 @@ func (c *connect) isReleased() bool {
 func (c *connect) setReleased(released bool) {
 	c.released = released
 	if released {
-		// a completed protocol exchange is itself proof of liveness
 		c.lastLiveAt = time.Now()
 	}
 }

--- a/conn.go
+++ b/conn.go
@@ -22,6 +22,18 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
+// errUnexpectedRead is reported by connCheck when an idle connection has
+// readable bytes. The native protocol has no server-initiated packets between
+// queries, so this means the previous response was not fully drained — a
+// driver bug, not a network event.
+var errUnexpectedRead = errors.New("unexpected read from socket")
+
+// connLivenessWindow is how long a liveness proof (a completed protocol
+// exchange or a passed connCheck) is trusted before the socket is probed
+// again. It avoids per-operation syscalls on hot connections while keeping
+// stale-connection detection for genuinely idle ones.
+const connLivenessWindow = time.Second
+
 func dial(ctx context.Context, addr string, num int, opt *Options) (*connect, error) {
 	var (
 		err  error
@@ -78,6 +90,7 @@ func dial(ctx context.Context, addr string, num int, opt *Options) (*connect, er
 			structMap:            &structMap{},
 			compression:          compression,
 			connectedAt:          time.Now(),
+			lastLiveAt:           time.Now(),
 			compressor:           compressor,
 			readTimeout:          opt.ReadTimeout,
 			blockBufferSize:      opt.BlockBufferSize,
@@ -131,6 +144,8 @@ type connect struct {
 	structMap            *structMap
 	compression          CompressionMethod
 	connectedAt          time.Time
+	lastLiveAt           time.Time // last proof of liveness: completed exchange or passed connCheck
+	unverified           bool      // require a protocol ping before next reuse
 	compressor           *compress.Writer
 	readTimeout          time.Duration
 	blockBufferSize      uint8
@@ -192,11 +207,61 @@ func (c *connect) isBad() bool {
 		return true
 	}
 
-	if err := c.connCheck(); err != nil {
-		return true
+	if time.Since(c.lastLiveAt) < connLivenessWindow {
+		return false
 	}
 
+	if err := c.connCheck(); err != nil {
+		if errors.Is(err, errUnexpectedRead) {
+			c.logger.Warn("closing connection: unread server data on idle connection, this indicates a driver bug, please report it",
+				slog.Int("conn_id", c.id))
+		}
+		return true
+	}
+	c.lastLiveAt = time.Now()
+
 	return false
+}
+
+// markUnverified requires a successful protocol ping (revalidateIdle) before
+// the connection is handed out again. Used when the connection is pooled in a
+// state the server may not have preserved, e.g. after a server exception.
+func (c *connect) markUnverified() {
+	c.unverified = true
+}
+
+// revalidateIdle verifies a pooled connection with a protocol ping when it is
+// unverified or has idled past Options.ConnIdlePingThreshold. A socket-level
+// check cannot detect a half-open connection (writes succeed into the void);
+// only a round-trip can.
+func (c *connect) revalidateIdle(ctx context.Context) error {
+	needPing := c.unverified
+	if !needPing {
+		threshold := c.opt.ConnIdlePingThreshold
+		if threshold < 0 {
+			return nil
+		}
+		needPing = time.Since(c.lastLiveAt) >= threshold
+	}
+	if !needPing {
+		return nil
+	}
+
+	// Bound the ping to half the remaining acquire budget so a dead
+	// connection leaves room to dial a replacement.
+	pingCtx := ctx
+	if deadline, ok := ctx.Deadline(); ok {
+		var cancel context.CancelFunc
+		pingCtx, cancel = context.WithDeadline(ctx, time.Now().Add(time.Until(deadline)/2))
+		defer cancel()
+	}
+	if err := c.ping(pingCtx); err != nil {
+		return err
+	}
+
+	c.unverified = false
+	c.lastLiveAt = time.Now()
+	return nil
 }
 
 func (c *connect) isReleased() bool {
@@ -205,6 +270,10 @@ func (c *connect) isReleased() bool {
 
 func (c *connect) setReleased(released bool) {
 	c.released = released
+	if released {
+		// a completed protocol exchange is itself proof of liveness
+		c.lastLiveAt = time.Now()
+	}
 }
 
 func (c *connect) isClosed() bool {

--- a/conn.go
+++ b/conn.go
@@ -141,8 +141,8 @@ type connect struct {
 	structMap            *structMap
 	compression          CompressionMethod
 	connectedAt          time.Time
-	lastLiveAt           time.Time // proof of peer liveness: dial, completed exchange, successful ping
-	lastPeekAt           time.Time // last passing socket peek; only gates connCheck frequency
+	lastLiveAt           time.Time
+	lastPeekAt           time.Time
 	unverified           bool
 	compressor           *compress.Writer
 	readTimeout          time.Duration
@@ -218,8 +218,6 @@ func (c *connect) isBad() bool {
 		return true
 	}
 
-	// a clean peek proves the socket is not closed or dirty, but not that the
-	// peer is alive; it must not reset the idle clock revalidateIdle pings on
 	c.lastPeekAt = time.Now()
 
 	return false
@@ -237,13 +235,12 @@ func (c *connect) revalidateIdle(ctx context.Context) error {
 		}
 	}
 
-	// Limit ping deadline to allow time for re-dial. A dead connection must
-	// not stall the caller: without this bound a half-open socket would block
-	// the ping until the read timeout.
+	// Limit ping deadline to allow time for re-dial.
 	pingDeadline := time.Now().Add(c.opt.DialTimeout / 2)
 	if deadline, ok := ctx.Deadline(); ok {
 		pingDeadline = time.Now().Add(time.Until(deadline) / 2)
 	}
+
 	pingCtx, cancel := context.WithDeadline(ctx, pingDeadline)
 	defer cancel()
 

--- a/conn.go
+++ b/conn.go
@@ -210,7 +210,7 @@ func (c *connect) isBad() bool {
 
 	if err := c.connCheck(); err != nil {
 		if errors.Is(err, errUnexpectedRead) {
-			c.logger.Warn("closing connection: unread server data on idle connection, this indicates a driver bug, please report it",
+			c.logger.Warn("closing connection: unread server data on idle connection",
 				slog.Int("conn_id", c.id))
 		}
 

--- a/conn.go
+++ b/conn.go
@@ -141,7 +141,8 @@ type connect struct {
 	structMap            *structMap
 	compression          CompressionMethod
 	connectedAt          time.Time
-	lastLiveAt           time.Time
+	lastLiveAt           time.Time // proof of peer liveness: dial, completed exchange, successful ping
+	lastPeekAt           time.Time // last passing socket peek; only gates connCheck frequency
 	unverified           bool
 	compressor           *compress.Writer
 	readTimeout          time.Duration
@@ -204,7 +205,7 @@ func (c *connect) isBad() bool {
 		return true
 	}
 
-	if time.Since(c.lastLiveAt) < connLivenessWindow {
+	if time.Since(c.lastLiveAt) < connLivenessWindow || time.Since(c.lastPeekAt) < connLivenessWindow {
 		return false
 	}
 
@@ -217,7 +218,9 @@ func (c *connect) isBad() bool {
 		return true
 	}
 
-	c.lastLiveAt = time.Now()
+	// a clean peek proves the socket is not closed or dirty, but not that the
+	// peer is alive; it must not reset the idle clock revalidateIdle pings on
+	c.lastPeekAt = time.Now()
 
 	return false
 }
@@ -234,13 +237,15 @@ func (c *connect) revalidateIdle(ctx context.Context) error {
 		}
 	}
 
-	pingCtx := ctx
-	// Limit ping deadline to allow time for re-dial
+	// Limit ping deadline to allow time for re-dial. A dead connection must
+	// not stall the caller: without this bound a half-open socket would block
+	// the ping until the read timeout.
+	pingDeadline := time.Now().Add(c.opt.DialTimeout / 2)
 	if deadline, ok := ctx.Deadline(); ok {
-		var cancel context.CancelFunc
-		pingCtx, cancel = context.WithDeadline(ctx, time.Now().Add(time.Until(deadline)/2))
-		defer cancel()
+		pingDeadline = time.Now().Add(time.Until(deadline) / 2)
 	}
+	pingCtx, cancel := context.WithDeadline(ctx, pingDeadline)
+	defer cancel()
 
 	if err := c.ping(pingCtx); err != nil {
 		return err

--- a/conn_batch.go
+++ b/conn_batch.go
@@ -22,6 +22,10 @@ var columnMatch = regexp.MustCompile(`INSERT INTO .+\s\((?P<Columns>.+)\)$`)
 func (c *connect) prepareBatch(ctx context.Context, release nativeTransportRelease, acquire nativeTransportAcquire, query string, opts driver.PrepareBatchOptions) (driver.Batch, error) {
 	query, _, queryColumns, verr := extractNormalizedInsertQueryAndColumns(query)
 	if verr != nil {
+		// validation failed before anything was written to the wire: the
+		// connection is untouched and must go back to the pool, otherwise its
+		// MaxOpenConns slot leaks
+		release(c, nil)
 		return nil, verr
 	}
 
@@ -205,6 +209,9 @@ func (b *batch) Send() (err error) {
 		// close TCP connection on context cancel. There is no other way simple way to interrupt underlying operations.
 		// as verified in the test, this is safe to do and cleanups resources later on
 		if b.conn != nil {
+			// flag the connection first so it can never be pooled or reused:
+			// closing only the raw socket leaves it looking healthy
+			b.conn.setClosed()
 			_ = b.conn.conn.Close()
 		}
 	})

--- a/conn_batch.go
+++ b/conn_batch.go
@@ -22,9 +22,6 @@ var columnMatch = regexp.MustCompile(`INSERT INTO .+\s\((?P<Columns>.+)\)$`)
 func (c *connect) prepareBatch(ctx context.Context, release nativeTransportRelease, acquire nativeTransportAcquire, query string, opts driver.PrepareBatchOptions) (driver.Batch, error) {
 	query, _, queryColumns, verr := extractNormalizedInsertQueryAndColumns(query)
 	if verr != nil {
-		// validation failed before anything was written to the wire: the
-		// connection is untouched and must go back to the pool, otherwise its
-		// MaxOpenConns slot leaks
 		release(c, nil)
 		return nil, verr
 	}
@@ -209,8 +206,6 @@ func (b *batch) Send() (err error) {
 		// close TCP connection on context cancel. There is no other way simple way to interrupt underlying operations.
 		// as verified in the test, this is safe to do and cleanups resources later on
 		if b.conn != nil {
-			// flag the connection first so it can never be pooled or reused:
-			// closing only the raw socket leaves it looking healthy
 			b.conn.setClosed()
 			_ = b.conn.conn.Close()
 		}

--- a/conn_check.go
+++ b/conn_check.go
@@ -9,11 +9,6 @@ import (
 	"syscall"
 )
 
-// connCheck probes the raw socket of an idle connection without consuming any
-// data (MSG_PEEK). A healthy idle connection has an empty receive buffer: the
-// ClickHouse native protocol has no server-initiated packets between queries,
-// so pending bytes mean the previous response was not fully drained, and a
-// zero-length read means the server closed the connection.
 func (c *connect) connCheck() error {
 	conn := c.conn
 	if tlsConn, ok := c.conn.(*tls.Conn); ok {
@@ -32,8 +27,6 @@ func (c *connect) connCheck() error {
 
 	err = rawConn.Read(func(fd uintptr) bool {
 		var buf [1]byte
-		// The runtime keeps the fd non-blocking, so an empty receive buffer
-		// returns EAGAIN rather than blocking.
 		n, _, err := syscall.Recvfrom(int(fd), buf[:], syscall.MSG_PEEK)
 		switch {
 		case n == 0 && err == nil:

--- a/conn_check.go
+++ b/conn_check.go
@@ -5,11 +5,15 @@ package clickhouse
 
 import (
 	"crypto/tls"
-	"errors"
 	"io"
 	"syscall"
 )
 
+// connCheck probes the raw socket of an idle connection without consuming any
+// data (MSG_PEEK). A healthy idle connection has an empty receive buffer: the
+// ClickHouse native protocol has no server-initiated packets between queries,
+// so pending bytes mean the previous response was not fully drained, and a
+// zero-length read means the server closed the connection.
 func (c *connect) connCheck() error {
 	conn := c.conn
 	if tlsConn, ok := c.conn.(*tls.Conn); ok {
@@ -28,12 +32,14 @@ func (c *connect) connCheck() error {
 
 	err = rawConn.Read(func(fd uintptr) bool {
 		var buf [1]byte
-		n, err := syscall.Read(int(fd), buf[:])
+		// The runtime keeps the fd non-blocking, so an empty receive buffer
+		// returns EAGAIN rather than blocking.
+		n, _, err := syscall.Recvfrom(int(fd), buf[:], syscall.MSG_PEEK)
 		switch {
 		case n == 0 && err == nil:
 			sysErr = io.EOF
 		case n > 0:
-			sysErr = errors.New("unexpected read from socket")
+			sysErr = errUnexpectedRead
 		case err == syscall.EAGAIN || err == syscall.EWOULDBLOCK:
 			sysErr = nil
 		default:

--- a/conn_http.go
+++ b/conn_http.go
@@ -317,6 +317,15 @@ func (h *httpConnect) isBad() bool {
 	return h.client == nil
 }
 
+// markUnverified is a no-op: HTTP transports are request-scoped and the
+// underlying http.Client manages socket reuse itself.
+func (h *httpConnect) markUnverified() {
+}
+
+func (h *httpConnect) revalidateIdle(ctx context.Context) error {
+	return nil
+}
+
 func (h *httpConnect) queryHello(ctx context.Context, release nativeTransportRelease) (proto.ServerHandshake, error) {
 	h.logger.Debug("querying server info via HTTP")
 	ctx = Context(ctx, ignoreExternalTables())

--- a/conn_http.go
+++ b/conn_http.go
@@ -317,8 +317,6 @@ func (h *httpConnect) isBad() bool {
 	return h.client == nil
 }
 
-// markUnverified is a no-op: HTTP transports are request-scoped and the
-// underlying http.Client manages socket reuse itself.
 func (h *httpConnect) markUnverified() {
 }
 

--- a/conn_pool_test.go
+++ b/conn_pool_test.go
@@ -474,6 +474,7 @@ type mockTransport struct {
 	released      bool
 	closed        bool
 	bad           bool
+	unverified    bool
 	bufferFreed   bool
 	debugMessages []string
 	mu            sync.Mutex
@@ -511,6 +512,16 @@ func (m *mockTransport) isBad() bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.bad
+}
+
+func (m *mockTransport) markUnverified() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.unverified = true
+}
+
+func (m *mockTransport) revalidateIdle(ctx context.Context) error {
+	return nil
 }
 
 func (m *mockTransport) connID() int {

--- a/conn_query.go
+++ b/conn_query.go
@@ -17,7 +17,9 @@ func (c *connect) query(ctx context.Context, release nativeTransportRelease, que
 
 	if err != nil {
 		c.logger.Error("failed to bind query parameters", slog.Any("error", err))
-		release(c, err)
+		// binding failed before anything was written to the wire, the
+		// connection itself is untouched and safe to reuse
+		release(c, nil)
 		return nil, err
 	}
 
@@ -48,13 +50,16 @@ func (c *connect) query(ctx context.Context, release nativeTransportRelease, que
 			stream <- b
 		}
 		err := c.process(ctx, onProcess)
+		// release before closing the channels: rows.Close() returns as soon
+		// as both channels are closed, and the caller must find the
+		// connection back in the pool by then, not mid-release
+		release(c, err)
 		if err != nil {
 			c.logger.Error("query processing failed", slog.Any("error", err))
 			errors <- err
 		}
 		close(stream)
 		close(errors)
-		release(c, err)
 	}()
 
 	return &rows{

--- a/conn_query.go
+++ b/conn_query.go
@@ -17,8 +17,6 @@ func (c *connect) query(ctx context.Context, release nativeTransportRelease, que
 
 	if err != nil {
 		c.logger.Error("failed to bind query parameters", slog.Any("error", err))
-		// binding failed before anything was written to the wire, the
-		// connection itself is untouched and safe to reuse
 		release(c, nil)
 		return nil, err
 	}
@@ -50,9 +48,6 @@ func (c *connect) query(ctx context.Context, release nativeTransportRelease, que
 			stream <- b
 		}
 		err := c.process(ctx, onProcess)
-		// release before closing the channels: rows.Close() returns as soon
-		// as both channels are closed, and the caller must find the
-		// connection back in the pool by then, not mid-release
 		release(c, err)
 		if err != nil {
 			c.logger.Error("query processing failed", slog.Any("error", err))

--- a/context_watchdog.go
+++ b/context_watchdog.go
@@ -11,7 +11,7 @@ import (
 // but you want to not bother about context cancellation if your logic is already done.
 //
 // The returned cancel function guarantees that once it returns, the callback
-// either already completed or will never run — even when the context is
+// either already completed or will never run even when the context is
 // cancelled concurrently with the cancel call.
 //
 // Example:

--- a/context_watchdog.go
+++ b/context_watchdog.go
@@ -1,11 +1,19 @@
 package clickhouse
 
-import "context"
+import (
+	"context"
+	"sync"
+)
 
 // contextWatchdog is a helper function to run a callback when the context is done.
 // It has a cancellation function to prevent the callback from running.
 // Useful for interrupting some logic when the context is done,
 // but you want to not bother about context cancellation if your logic is already done.
+//
+// The returned cancel function guarantees that once it returns, the callback
+// either already completed or will never run — even when the context is
+// cancelled concurrently with the cancel call.
+//
 // Example:
 // stopCW := contextWatchdog(ctx, func() { /* do something */ })
 // // do something else
@@ -13,17 +21,27 @@ import "context"
 func contextWatchdog(ctx context.Context, callback func()) (cancel func()) {
 	exit := make(chan struct{})
 
+	var mu sync.Mutex
+	stopped := false
+
 	go func() {
 		select {
 		case <-exit:
 			return
 		case <-ctx.Done():
+			mu.Lock()
+			defer mu.Unlock()
+			if stopped {
+				return
+			}
 			callback()
-			return
 		}
 	}()
 
 	return func() {
+		mu.Lock()
+		stopped = true
+		mu.Unlock()
 		close(exit)
 	}
 }

--- a/tests/conn_check_churn_test.go
+++ b/tests/conn_check_churn_test.go
@@ -566,19 +566,15 @@ func (tn *proxyTunnel) pump(dst, src net.Conn) {
 	tn.server.Close()
 }
 
-// TestConnCheckHalfOpenConnection verifies that a pooled connection whose
-// network path silently died is detected before reuse. No FIN ever reaches
-// the client, so connCheck's socket peek sees a healthy, empty socket; only
-// the idle revalidation ping (Options.ConnIdlePingThreshold) can catch it.
-func TestConnCheckHalfOpenConnection(t *testing.T) {
-	SkipOnCloud(t, "requires a local TCP proxy")
+// halfOpenOptions builds a pool routed through a blackhole proxy with a short
+// idle-ping threshold.
+func halfOpenOptions(t *testing.T, tracker *connTracker, pingThreshold time.Duration) (clickhouse.Options, *blackholeProxy) {
+	t.Helper()
 
 	env, err := GetNativeTestEnvironment()
 	require.NoError(t, err)
-
 	proxy := startBlackholeProxy(t, fmt.Sprintf("%s:%d", env.Host, env.Port))
 
-	tracker := &connTracker{}
 	opts := ClientOptionsFromEnv(env, nil, false)
 	opts.Addr = []string{proxy.addr()}
 	opts.DialContext = tracker.DialContext
@@ -586,24 +582,81 @@ func TestConnCheckHalfOpenConnection(t *testing.T) {
 	opts.MaxIdleConns = 2
 	opts.ConnMaxLifetime = time.Hour
 	opts.DialTimeout = 2 * time.Second
-	opts.ConnIdlePingThreshold = 200 * time.Millisecond
+	opts.ConnIdlePingThreshold = pingThreshold
 
-	conn, err := clickhouse.Open(&opts)
-	require.NoError(t, err)
-	t.Cleanup(func() { conn.Close() })
+	return opts, proxy
+}
 
-	var v uint8
-	require.NoError(t, conn.QueryRow(context.Background(), "SELECT 1").Scan(&v))
-	require.Equal(t, 1, tracker.Dials())
+// TestConnCheckHalfOpenConnection verifies that a pooled connection whose
+// network path silently died is detected before reuse. No FIN ever reaches
+// the client, so connCheck's socket peek sees a healthy, empty socket; only
+// the idle revalidation ping (Options.ConnIdlePingThreshold) can catch it.
+//
+// Both idle regimes must be covered: idle shorter than the internal 1s
+// liveness window (the socket peek is skipped entirely) and idle beyond it
+// (the peek runs, passes, and must NOT suppress the ping — a passing peek is
+// not proof of liveness).
+func TestConnCheckHalfOpenConnection(t *testing.T) {
+	SkipOnCloud(t, "requires a local TCP proxy")
 
-	proxy.silenceExisting()
-	time.Sleep(250 * time.Millisecond) // idle past ConnIdlePingThreshold
+	scenarios := []struct {
+		name      string
+		threshold time.Duration
+		idle      time.Duration
+	}{
+		{"idle within liveness window", 200 * time.Millisecond, 250 * time.Millisecond},
+		{"idle beyond liveness window", 1200 * time.Millisecond, 1500 * time.Millisecond},
+	}
 
-	start := time.Now()
-	require.NoError(t, conn.QueryRow(context.Background(), "SELECT 1").Scan(&v),
-		"query must succeed on a fresh connection after the half-open one is discarded")
-	require.Equalf(t, 2, tracker.Dials(),
-		"revalidation must discard the half-open connection and dial exactly one replacement")
-	require.Lessf(t, time.Since(start), 2*opts.DialTimeout,
-		"revalidation must fail fast, not hang until read timeout")
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			tracker := &connTracker{}
+			opts, proxy := halfOpenOptions(t, tracker, sc.threshold)
+
+			conn, err := clickhouse.Open(&opts)
+			require.NoError(t, err)
+			t.Cleanup(func() { conn.Close() })
+
+			var v uint8
+			require.NoError(t, conn.QueryRow(context.Background(), "SELECT 1").Scan(&v))
+			require.Equal(t, 1, tracker.Dials())
+
+			proxy.silenceExisting()
+			time.Sleep(sc.idle)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			start := time.Now()
+			require.NoError(t, conn.QueryRow(ctx, "SELECT 1").Scan(&v),
+				"query must succeed on a fresh connection after the half-open one is discarded")
+			require.Equalf(t, 2, tracker.Dials(),
+				"revalidation must discard the half-open connection and dial exactly one replacement")
+			require.Lessf(t, time.Since(start), 2*opts.DialTimeout,
+				"revalidation must fail fast, not hang until read timeout")
+		})
+	}
+
+	t.Run("database sql", func(t *testing.T) {
+		tracker := &connTracker{}
+		opts, proxy := halfOpenOptions(t, tracker, 1200*time.Millisecond)
+
+		db := clickhouse.OpenDB(&opts)
+		t.Cleanup(func() { db.Close() })
+		db.SetMaxOpenConns(1)
+		db.SetMaxIdleConns(1)
+		db.SetConnMaxLifetime(time.Hour)
+
+		var v uint8
+		require.NoError(t, db.QueryRow("SELECT 1").Scan(&v))
+		require.Equal(t, 1, tracker.Dials())
+
+		proxy.silenceExisting()
+		time.Sleep(1500 * time.Millisecond)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		require.NoError(t, db.QueryRowContext(ctx, "SELECT 1").Scan(&v),
+			"ResetSession must discard the half-open connection so database/sql retries on a fresh one")
+		require.Equal(t, 2, tracker.Dials())
+	})
 }

--- a/tests/conn_check_churn_test.go
+++ b/tests/conn_check_churn_test.go
@@ -1,0 +1,609 @@
+//go:build linux || darwin
+
+// Connection reuse regression suite. Guards against connection churn: healthy
+// pooled connections being killed and re-dialed (TCP + handshake + auth),
+// whether via isBad()/connCheck() reacting to unread bytes on an idle socket,
+// error releases, or pool ordering races. Also covers the inverse failure:
+// half-open connections that a socket-level check cannot detect.
+//
+// Instrumentation:
+//   - a counting DialContext records every physical dial the driver makes;
+//   - between operations (socket idle) each live connection is peeked with
+//     MSG_PEEK|MSG_DONTWAIT — the same signal connCheck() reacts to, but
+//     non-destructive, so a positive result can be observed and reported;
+//   - a blackhole proxy simulates a middlebox silently dropping idle flows.
+package tests
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+)
+
+// connTracker records every connection the driver dials and can inspect the
+// kernel receive buffer of live connections without consuming data.
+type connTracker struct {
+	iter atomic.Int64 // current workload iteration, stamped onto each dial
+
+	mu        sync.Mutex
+	dials     int
+	dialIters []int64
+	conns     []net.Conn
+}
+
+func (ct *connTracker) DialContext(ctx context.Context, addr string) (net.Conn, error) {
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	ct.mu.Lock()
+	ct.dials++
+	ct.dialIters = append(ct.dialIters, ct.iter.Load())
+	ct.conns = append(ct.conns, conn)
+	ct.mu.Unlock()
+	return conn, nil
+}
+
+func (ct *connTracker) Dials() int {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	return ct.dials
+}
+
+func (ct *connTracker) DialIterations() []int64 {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	return append([]int64(nil), ct.dialIters...)
+}
+
+// pendingByConn peeks each tracked connection with MSG_PEEK|MSG_DONTWAIT and
+// returns the number of readable bytes for every connection that has any.
+// Connections already closed by the driver are skipped. Must only be called
+// while no query is in flight, i.e. when every live connection is idle in the
+// pool — the exact state connCheck() probes in acquire()/Put().
+func (ct *connTracker) pendingByConn(t *testing.T) map[int]int {
+	t.Helper()
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+
+	pending := make(map[int]int)
+	for i, conn := range ct.conns {
+		sc, ok := conn.(syscall.Conn)
+		require.True(t, ok, "test dialer must produce syscall.Conn")
+		raw, err := sc.SyscallConn()
+		if err != nil {
+			continue // closed by the driver
+		}
+		var (
+			n      int
+			sysErr error
+		)
+		ctrlErr := raw.Control(func(fd uintptr) {
+			var buf [4096]byte
+			n, _, sysErr = syscall.Recvfrom(int(fd), buf[:], syscall.MSG_PEEK|syscall.MSG_DONTWAIT)
+		})
+		if ctrlErr != nil {
+			continue // closed by the driver
+		}
+		if sysErr == syscall.EAGAIN || sysErr == syscall.EWOULDBLOCK {
+			continue // empty receive buffer: what connCheck expects of a healthy idle conn
+		}
+		if sysErr != nil {
+			t.Logf("conn[%d]: peek error: %v", i, sysErr)
+			continue
+		}
+		if n > 0 {
+			pending[i] = n
+		}
+	}
+	return pending
+}
+
+type churnReport struct {
+	dials            int
+	pendingSightings int
+	maxPending       int
+}
+
+// runChurnScenario opens a fresh pool with roomy limits, runs op sequentially
+// `iterations` times, and after every iteration peeks all idle sockets.
+//
+// With useTLS the driver connects to the secure port. connCheck() peeks the
+// raw TCP socket beneath tls.Conn, so any TLS-layer record arriving while the
+// connection idles (session tickets, key updates, alerts) would be flagged as
+// unexpected bytes; this variant detects those too.
+func runChurnScenario(t *testing.T, settings clickhouse.Settings, useTLS bool, iterations int, op func(t *testing.T, conn clickhouse.Conn, i int)) churnReport {
+	t.Helper()
+
+	env, err := GetNativeTestEnvironment()
+	require.NoError(t, err)
+
+	tracker := &connTracker{}
+	opts := ClientOptionsFromEnv(env, settings, false)
+	opts.MaxOpenConns = 5
+	opts.MaxIdleConns = 5
+	opts.ConnMaxLifetime = time.Hour
+	if useTLS {
+		opts.Addr = []string{fmt.Sprintf("%s:%d", env.Host, env.SslPort)}
+		tlsConfig := &tls.Config{InsecureSkipVerify: true}
+		opts.TLS = tlsConfig
+		// Options.DialContext bypasses the driver's own TLS wrapping, so wrap
+		// here: count the physical dial, track the raw conn for peeking, and
+		// hand the tls.Conn to the driver.
+		opts.DialContext = func(ctx context.Context, addr string) (net.Conn, error) {
+			raw, err := tracker.DialContext(ctx, addr)
+			if err != nil {
+				return nil, err
+			}
+			tlsConn := tls.Client(raw, tlsConfig)
+			if err := tlsConn.HandshakeContext(ctx); err != nil {
+				raw.Close()
+				return nil, err
+			}
+			return tlsConn, nil
+		}
+	} else {
+		opts.DialContext = tracker.DialContext
+	}
+
+	conn, err := clickhouse.Open(&opts)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	report := churnReport{}
+	observePending := func(stage string) {
+		if pending := tracker.pendingByConn(t); len(pending) > 0 {
+			report.pendingSightings += len(pending)
+			for id, n := range pending {
+				if n > report.maxPending {
+					report.maxPending = n
+				}
+				t.Logf("REPRODUCED: %s: idle conn[%d] has %d unread bytes (connCheck would kill it)", stage, id, n)
+			}
+		}
+	}
+
+	for i := 0; i < iterations; i++ {
+		tracker.iter.Store(int64(i))
+		op(t, conn, i)
+		observePending(fmt.Sprintf("iteration %d", i))
+	}
+
+	// Late-arriving bytes: give the server a generous window to emit anything
+	// asynchronous (profile events, logs) after the last query completed.
+	for _, delay := range []time.Duration{50 * time.Millisecond, 250 * time.Millisecond} {
+		time.Sleep(delay)
+		observePending(fmt.Sprintf("idle after %s", delay))
+	}
+
+	// The pooled connection must still be usable without a re-dial.
+	dialsBefore := tracker.Dials()
+	var one uint8
+	require.NoError(t, conn.QueryRow(context.Background(), "SELECT 1").Scan(&one))
+	if tracker.Dials() > dialsBefore {
+		t.Logf("REPRODUCED: final query after idle period forced dial #%d", tracker.Dials())
+	}
+
+	report.dials = tracker.Dials()
+	stats := conn.Stats()
+	t.Logf("dials=%d (at iterations %v) iterations=%d pendingSightings=%d maxPending=%d stats=%+v",
+		report.dials, tracker.DialIterations(), iterations, report.pendingSightings, report.maxPending, stats)
+	return report
+}
+
+// requireNoChurn asserts a sequential workload reused a single physical
+// connection. query() releases the connection back to the pool before
+// rows.Close() returns, so even a tight loop must find the previous
+// connection in the pool. Any extra dial is a healthy connection killed and
+// re-established (TCP + handshake + auth), i.e. the reported slowdown.
+func requireNoChurn(t *testing.T, report churnReport) {
+	t.Helper()
+	require.Zerof(t, report.pendingSightings, "unread bytes observed on idle pooled connection")
+	require.Equalf(t, 1, report.dials,
+		"connection churn: %d dials for a sequential workload", report.dials)
+}
+
+// TestConnCheckChurnSequential runs single-goroutine workloads that must all
+// hold dials at ~1. Systematic extra dials are healthy connections killed and
+// re-established (TCP + native handshake + auth), i.e. the reported slowdown.
+func TestConnCheckChurnSequential(t *testing.T) {
+	SkipOnCloud(t, "requires local socket instrumentation")
+
+	t.Run("query row", func(t *testing.T) {
+		report := runChurnScenario(t, nil, false, 200, func(t *testing.T, conn clickhouse.Conn, i int) {
+			var v uint8
+			require.NoError(t, conn.QueryRow(context.Background(), "SELECT 1").Scan(&v))
+		})
+		requireNoChurn(t, report)
+	})
+
+	t.Run("query full read", func(t *testing.T) {
+		report := runChurnScenario(t, nil, false, 100, func(t *testing.T, conn clickhouse.Conn, i int) {
+			rows, err := conn.Query(context.Background(), "SELECT number FROM system.numbers LIMIT 100000")
+			require.NoError(t, err)
+			var n uint64
+			for rows.Next() {
+				require.NoError(t, rows.Scan(&n))
+			}
+			require.NoError(t, rows.Close())
+			require.NoError(t, rows.Err())
+		})
+		requireNoChurn(t, report)
+	})
+
+	t.Run("query with per-op timeout ctx", func(t *testing.T) {
+		report := runChurnScenario(t, nil, false, 200, func(t *testing.T, conn clickhouse.Conn, i int) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			var v uint64
+			require.NoError(t, conn.QueryRow(ctx, "SELECT sum(number) FROM numbers(1000)").Scan(&v))
+		})
+		requireNoChurn(t, report)
+	})
+
+	t.Run("query with server logs", func(t *testing.T) {
+		report := runChurnScenario(t, clickhouse.Settings{"send_logs_level": "trace"}, false, 100, func(t *testing.T, conn clickhouse.Conn, i int) {
+			rows, err := conn.Query(context.Background(), "SELECT number FROM system.numbers LIMIT 1000")
+			require.NoError(t, err)
+			for rows.Next() {
+			}
+			require.NoError(t, rows.Close())
+			require.NoError(t, rows.Err())
+		})
+		requireNoChurn(t, report)
+	})
+
+	t.Run("early rows close", func(t *testing.T) {
+		report := runChurnScenario(t, nil, false, 30, func(t *testing.T, conn clickhouse.Conn, i int) {
+			rows, err := conn.Query(context.Background(), "SELECT number FROM system.numbers LIMIT 1000000")
+			require.NoError(t, err)
+			require.True(t, rows.Next()) // abandon the rest
+			require.NoError(t, rows.Close())
+		})
+		requireNoChurn(t, report)
+	})
+
+	t.Run("exec", func(t *testing.T) {
+		table := "test_conncheck_exec"
+		report := runChurnScenario(t, nil, false, 100, func(t *testing.T, conn clickhouse.Conn, i int) {
+			if i == 0 {
+				require.NoError(t, conn.Exec(context.Background(),
+					fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (n UInt64) ENGINE = Null", table)))
+				t.Cleanup(func() {
+					conn.Exec(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", table))
+				})
+			}
+			require.NoError(t, conn.Exec(context.Background(),
+				fmt.Sprintf("INSERT INTO %s SELECT number FROM numbers(1000)", table)))
+		})
+		requireNoChurn(t, report)
+	})
+
+	t.Run("batch insert", func(t *testing.T) {
+		table := "test_conncheck_batch"
+		report := runChurnScenario(t, nil, false, 100, func(t *testing.T, conn clickhouse.Conn, i int) {
+			if i == 0 {
+				require.NoError(t, conn.Exec(context.Background(),
+					fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (n UInt64) ENGINE = Null", table)))
+				t.Cleanup(func() {
+					conn.Exec(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", table))
+				})
+			}
+			batch, err := conn.PrepareBatch(context.Background(), fmt.Sprintf("INSERT INTO %s", table))
+			require.NoError(t, err)
+			for j := 0; j < 1000; j++ {
+				require.NoError(t, batch.Append(uint64(j)))
+			}
+			require.NoError(t, batch.Send())
+		})
+		requireNoChurn(t, report)
+	})
+}
+
+// TestConnCheckChurnErrorPaths covers the error-release paths.
+//
+// A server exception terminates the response stream at a packet boundary and
+// the server preserves the connection, so the driver keeps it (verifying with
+// a ping before reuse). A context cancellation mid-query still closes the
+// socket by design: the response is not drained, so the connection cannot be
+// reused safely.
+func TestConnCheckChurnErrorPaths(t *testing.T) {
+	SkipOnCloud(t, "requires local socket instrumentation")
+
+	t.Run("server exception keeps connection", func(t *testing.T) {
+		report := runChurnScenario(t, nil, false, 50, func(t *testing.T, conn clickhouse.Conn, i int) {
+			var v uint8
+			err := conn.QueryRow(context.Background(), "SELECT throwIf(1)").Scan(&v)
+			require.Error(t, err)
+		})
+		requireNoChurn(t, report)
+	})
+
+	t.Run("mid-stream server exception keeps connection", func(t *testing.T) {
+		report := runChurnScenario(t, nil, false, 25, func(t *testing.T, conn clickhouse.Conn, i int) {
+			// exception is raised after several data blocks were streamed
+			rows, err := conn.Query(context.Background(),
+				"SELECT throwIf(number = 50000), number FROM system.numbers")
+			if err == nil {
+				for rows.Next() {
+				}
+				rows.Close()
+				err = rows.Err()
+			}
+			require.Error(t, err)
+			exc := &clickhouse.Exception{}
+			require.ErrorAsf(t, err, &exc, "expected a server exception, got: %v", err)
+		})
+		requireNoChurn(t, report)
+	})
+
+	t.Run("context cancel closes connection", func(t *testing.T) {
+		const iterations = 20
+		report := runChurnScenario(t, nil, false, iterations, func(t *testing.T, conn clickhouse.Conn, i int) {
+			ctx, cancel := context.WithCancel(context.Background())
+			rows, err := conn.Query(ctx, "SELECT number FROM system.numbers LIMIT 10000000")
+			if err == nil {
+				rows.Next()
+				cancel()
+				rows.Close()
+			} else {
+				cancel()
+			}
+		})
+		require.Zero(t, report.pendingSightings, "unread bytes observed on idle pooled connection")
+		t.Logf("cancellation workload re-dialed %d times in %d iterations", report.dials, iterations)
+		require.Greaterf(t, report.dials, iterations/2,
+			"every mid-query cancellation must burn the connection (undrained socket)")
+	})
+}
+
+// TestConnCheckChurnTLS repeats the key workloads over TLS. connCheck()
+// unwraps tls.Conn and peeks the raw TCP socket, so a TLS record arriving
+// while the connection idles in the pool (e.g. a late session ticket or key
+// update from the server's OpenSSL stack) would be indistinguishable from
+// protocol desync and would kill the connection.
+func TestConnCheckChurnTLS(t *testing.T) {
+	SkipOnCloud(t, "requires local socket instrumentation")
+
+	env, err := GetNativeTestEnvironment()
+	require.NoError(t, err)
+	if env.SslPort == 0 {
+		t.Skip("test environment has no TLS port")
+	}
+
+	t.Run("query row", func(t *testing.T) {
+		report := runChurnScenario(t, nil, true, 200, func(t *testing.T, conn clickhouse.Conn, i int) {
+			var v uint8
+			require.NoError(t, conn.QueryRow(context.Background(), "SELECT 1").Scan(&v))
+		})
+		requireNoChurn(t, report)
+	})
+
+	t.Run("query full read", func(t *testing.T) {
+		report := runChurnScenario(t, nil, true, 100, func(t *testing.T, conn clickhouse.Conn, i int) {
+			rows, err := conn.Query(context.Background(), "SELECT number FROM system.numbers LIMIT 100000")
+			require.NoError(t, err)
+			var n uint64
+			for rows.Next() {
+				require.NoError(t, rows.Scan(&n))
+			}
+			require.NoError(t, rows.Close())
+			require.NoError(t, rows.Err())
+		})
+		requireNoChurn(t, report)
+	})
+
+	t.Run("batch insert", func(t *testing.T) {
+		table := "test_conncheck_tls_batch"
+		report := runChurnScenario(t, nil, true, 50, func(t *testing.T, conn clickhouse.Conn, i int) {
+			if i == 0 {
+				require.NoError(t, conn.Exec(context.Background(),
+					fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (n UInt64) ENGINE = Null", table)))
+				t.Cleanup(func() {
+					conn.Exec(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", table))
+				})
+			}
+			batch, err := conn.PrepareBatch(context.Background(), fmt.Sprintf("INSERT INTO %s", table))
+			require.NoError(t, err)
+			for j := 0; j < 1000; j++ {
+				require.NoError(t, batch.Append(uint64(j)))
+			}
+			require.NoError(t, batch.Send())
+		})
+		requireNoChurn(t, report)
+	})
+}
+
+// TestConnCheckChurnConcurrent measures dial churn under concurrency. With
+// workers <= MaxOpenConns and roomy MaxIdleConns, the pool should converge on
+// at most `workers` physical connections; continued dial growth would indicate
+// healthy connections being discarded.
+func TestConnCheckChurnConcurrent(t *testing.T) {
+	SkipOnCloud(t, "requires local socket instrumentation")
+
+	env, err := GetNativeTestEnvironment()
+	require.NoError(t, err)
+
+	tracker := &connTracker{}
+	opts := ClientOptionsFromEnv(env, nil, false)
+	opts.DialContext = tracker.DialContext
+	opts.MaxOpenConns = 10
+	opts.MaxIdleConns = 10
+	opts.ConnMaxLifetime = time.Hour
+
+	conn, err := clickhouse.Open(&opts)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	const (
+		workers    = 8
+		iterations = 50
+	)
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				var v uint64
+				require.NoError(t, conn.QueryRow(context.Background(), "SELECT sum(number) FROM numbers(10000)").Scan(&v))
+			}
+		}()
+	}
+	wg.Wait()
+
+	pending := tracker.pendingByConn(t)
+	t.Logf("dials=%d workers=%d iterations=%d pending=%v stats=%+v",
+		tracker.Dials(), workers, iterations, pending, conn.Stats())
+	require.Empty(t, pending, "unread bytes observed on idle pooled connection")
+	require.LessOrEqualf(t, tracker.Dials(), workers*2,
+		"connection churn: %d dials for %d workers", tracker.Dials(), workers)
+}
+
+// blackholeProxy forwards TCP traffic to a target ClickHouse server.
+// silenceExisting simulates a stateful middlebox (NAT, load balancer)
+// silently dropping established idle flows: existing tunnels stop forwarding
+// in both directions but the client-side socket stays open and never receives
+// a FIN, leaving the client with a half-open connection. New connections
+// tunnel normally.
+type blackholeProxy struct {
+	ln net.Listener
+
+	mu      sync.Mutex
+	tunnels []*proxyTunnel
+	closed  bool
+}
+
+type proxyTunnel struct {
+	client, server net.Conn
+	silenced       atomic.Bool
+}
+
+func startBlackholeProxy(t *testing.T, target string) *blackholeProxy {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	p := &blackholeProxy{ln: ln}
+	t.Cleanup(p.close)
+
+	// accept loop; exits when the listener is closed via t.Cleanup
+	go func() {
+		for {
+			client, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			server, err := net.Dial("tcp", target)
+			if err != nil {
+				client.Close()
+				continue
+			}
+			tn := &proxyTunnel{client: client, server: server}
+			p.mu.Lock()
+			if p.closed {
+				p.mu.Unlock()
+				client.Close()
+				server.Close()
+				return
+			}
+			p.tunnels = append(p.tunnels, tn)
+			p.mu.Unlock()
+			// each copy goroutine exits when either side of its tunnel closes
+			go tn.pump(server, client)
+			go tn.pump(client, server)
+		}
+	}()
+
+	return p
+}
+
+func (p *blackholeProxy) addr() string {
+	return p.ln.Addr().String()
+}
+
+// silenceExisting makes every currently established tunnel go dark without
+// closing the client side.
+func (p *blackholeProxy) silenceExisting() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, tn := range p.tunnels {
+		tn.silenced.Store(true)
+		tn.server.Close()
+	}
+}
+
+func (p *blackholeProxy) close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closed = true
+	p.ln.Close()
+	for _, tn := range p.tunnels {
+		tn.client.Close()
+		tn.server.Close()
+	}
+}
+
+func (tn *proxyTunnel) pump(dst, src net.Conn) {
+	io.Copy(dst, src)
+	// propagate teardown to the client only for live tunnels: a silenced
+	// tunnel must leave the client half-open (no FIN)
+	if !tn.silenced.Load() {
+		tn.client.Close()
+	}
+	tn.server.Close()
+}
+
+// TestConnCheckHalfOpenConnection verifies that a pooled connection whose
+// network path silently died is detected before reuse. No FIN ever reaches
+// the client, so connCheck's socket peek sees a healthy, empty socket; only
+// the idle revalidation ping (Options.ConnIdlePingThreshold) can catch it.
+func TestConnCheckHalfOpenConnection(t *testing.T) {
+	SkipOnCloud(t, "requires a local TCP proxy")
+
+	env, err := GetNativeTestEnvironment()
+	require.NoError(t, err)
+
+	proxy := startBlackholeProxy(t, fmt.Sprintf("%s:%d", env.Host, env.Port))
+
+	tracker := &connTracker{}
+	opts := ClientOptionsFromEnv(env, nil, false)
+	opts.Addr = []string{proxy.addr()}
+	opts.DialContext = tracker.DialContext
+	opts.MaxOpenConns = 2
+	opts.MaxIdleConns = 2
+	opts.ConnMaxLifetime = time.Hour
+	opts.DialTimeout = 2 * time.Second
+	opts.ConnIdlePingThreshold = 200 * time.Millisecond
+
+	conn, err := clickhouse.Open(&opts)
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	var v uint8
+	require.NoError(t, conn.QueryRow(context.Background(), "SELECT 1").Scan(&v))
+	require.Equal(t, 1, tracker.Dials())
+
+	proxy.silenceExisting()
+	time.Sleep(250 * time.Millisecond) // idle past ConnIdlePingThreshold
+
+	start := time.Now()
+	require.NoError(t, conn.QueryRow(context.Background(), "SELECT 1").Scan(&v),
+		"query must succeed on a fresh connection after the half-open one is discarded")
+	require.Equalf(t, 2, tracker.Dials(),
+		"revalidation must discard the half-open connection and dial exactly one replacement")
+	require.Lessf(t, time.Since(start), 2*opts.DialTimeout,
+		"revalidation must fail fast, not hang until read timeout")
+}


### PR DESCRIPTION
## Summary

While investigating a performance issue related to connections, several issues were identified and fixed:

* **`connCheck` is now a non-destructive peek** (`recvfrom(MSG_PEEK)` instead of a 1-byte
  `read`). Pending bytes on an idle connection still mark it bad, which is correct for Native protocol. In these cases a debug message is logged.
* **Liveness results are trusted for 1s** (via `connLivenessWindow`): a connection that
  completed a command or passed a check within the last second skips the socket
  probe. This removes the per-operation connection checks that read from the TCP connection.
* **New `Options.ConnIdlePingThreshold`** (DSN: `conn_idle_ping_threshold`, default 1m,
  negative disables): This is used for proper client Ping commands to validate the connection is valid. For cloud there are often a lot of proxies and other errors, so instead of depending on a client side socket check, we can now use a ping command to validate the connection before executing a command.
* **Server exceptions no longer burn the connection.** `release()` keeps the connection
  and marks it *unverified*; the next acquire confirms liveness with a ping before handing
  it out (covering the rare exception classes where the server does close). This should reduce the number of new connections formed for non-fatal connection errors.
* **`query()` releases the connection before closing the rows channels**, so the
  connection is guaranteed to be back in the pool by the time `rows.Close()` returns.
  Parameter-binding failures now release the connection
  healthy instead of through the error path.
* **`prepareBatch` returns the connection to the pool on validation failure** instead of
  leaking it and its `MaxOpenConns` slot.
* **batch `contextWatchdog` stop is now race-free** (mutex + stopped flag): once `stop()`
  returns, the callback has either completed or will never run. The `Send` watchdog also
  flags the connection closed (`setClosed`) so a cancelled batch's socket can never be
  pooled looking healthy.

### Behavior changes

| Change | Old | New | Escape hatch |
|---|---|---|---|
| Server exception | connection closed, next query re-dials | connection kept, ping-verified on next acquire | (strictly fewer dials) |
| Idle ≥ `ConnIdlePingThreshold` | handed out unverified | one `Ping` round trip on acquire | raise threshold or set negative |
| Socket probe frequency | every acquire + every Put + every std op | at most once per second per connection | (strictly fewer syscalls) |

Context cancellation mid-query still closes the connection by design (the response is not
drained), and this is asserted in the regression tests.

### Testing

* New regression suite `tests/conn_check_churn_test.go`: counts physical dials via a
  custom `DialContext` and probes idle sockets with `MSG_PEEK` between operations. Asserts
  exactly **1 dial** for sequential query/exec/batch/server-logs/early-close/timeout-ctx
  workloads (plain TCP and TLS), including 50 consecutive failing queries and mid-stream
  exceptions (the probe also proves the socket is byte-clean at the exception boundary,
  validating reuse safety). A blackhole-proxy test simulates a silently dropped flow and
  verifies the idle ping discards the half-open connection and recovers within the dial
  timeout instead of hanging.
* Full `tests/`, `tests/std`, and `tests/issues` suites pass against ClickHouse 26.6;
  root unit tests pass with `-race`; cross-compiles clean for all `GOOS` targets covered
  by the conn-check build tags (the `Recvfrom` call matters on solaris/illumos).

## Checklist
- [X] Unit and integration tests covering the common scenarios were added
- [X] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

As always, let me know if you have any questions or want to split this into multiple PRs. Thanks!