### PR TITLE
fix: close connection when dial setup fails to avoid a file descriptor leak

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -22,11 +22,8 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
-func dial(ctx context.Context, addr string, num int, opt *Options) (*connect, error) {
-	var (
-		err  error
-		conn net.Conn
-	)
+func dial(ctx context.Context, addr string, num int, opt *Options) (c *connect, err error) {
+	var conn net.Conn
 
 	switch {
 	case opt.DialContext != nil:
@@ -43,6 +40,15 @@ func dial(ctx context.Context, addr string, num int, opt *Options) (*connect, er
 	if err != nil {
 		return nil, err
 	}
+
+	// Close the freshly dialed connection if any later setup step (compression,
+	// JWT, handshake, addendum) fails, otherwise the socket and its fd leak on
+	// every failed connection attempt.
+	defer func() {
+		if err != nil {
+			_ = conn.Close()
+		}
+	}()
 
 	// Get base logger and enrich with connection-specific context
 	baseLogger := opt.logger()

--- a/conn_fd_leak_test.go
+++ b/conn_fd_leak_test.go
@@ -1,0 +1,42 @@
+package clickhouse
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type closeTrackingConn struct {
+	net.Conn
+	closed *atomic.Bool
+}
+
+func (c *closeTrackingConn) Close() error {
+	c.closed.Store(true)
+
+	return c.Conn.Close()
+}
+
+// TestDialClosesConnectionOnSetupFailure ensures dial does not leak the underlying
+// socket (and its file descriptor) when a post-dial setup step fails. The server
+// side of the pipe is closed up front so the handshake fails.
+func TestDialClosesConnectionOnSetupFailure(t *testing.T) {
+	client, server := net.Pipe()
+	require.NoError(t, server.Close())
+
+	var closed atomic.Bool
+	tracked := &closeTrackingConn{Conn: client, closed: &closed}
+
+	_, err := dial(context.Background(), "127.0.0.1:9000", 1, &Options{
+		DialContext: func(_ context.Context, _ string) (net.Conn, error) {
+			return tracked, nil
+		},
+	})
+
+	require.Error(t, err)
+	assert.True(t, closed.Load(), "dial must close the connection when a post-dial setup step fails")
+}


### PR DESCRIPTION
## Summary

`dial` opens the TCP connection first, then runs the compression / JWT / handshake / addendum setup. if any of those steps fails it returns the error but never closes the socket, so the fd leaks on every failed connection attempt - a reconnect storm against a wrong password, a TLS failure or an unreachable server eventually exhausts the process file descriptors and no new sockets can be opened

reproduce: point a client at an endpoint that accepts the TCP connection but fails the handshake (or just use a wrong password), open connections in a loop and watch the open fd count climb without bound. the added `TestDialClosesConnectionOnSetupFailure` injects a connection whose handshake fails and asserts `dial` closed it - it fails on `main` and passes with this change

the fix closes the freshly dialed connection on any error after the dial succeeds, with a deferred conditional close on the named error return

## Checklist
- [x] Unit and integration tests covering the common scenarios were added