### PR TITLE
Remove stray HTTP compression debug output

### DIFF
--- a/conn_http_query.go
+++ b/conn_http_query.go
@@ -53,7 +53,6 @@ func (h *httpConnect) query(ctx context.Context, release nativeTransportRelease,
 		options.settings["compress"] = "1"
 	case CompressionGZIP, CompressionDeflate, CompressionBrotli:
 		// request encoding
-		fmt.Println("Debug!!!!: Am i here??")
 		headers["Accept-Encoding"] = h.compression.String()
 	}
 


### PR DESCRIPTION
## Summary

Remove an unconditional `fmt.Println` from the HTTP query path. The message was emitted for every query using gzip, deflate, or Brotli compression, bypassing the configured logger and writing directly to application stdout.

## Background

Git history traces the line to commit [`af3085c`](https://github.com/ClickHouse/clickhouse-go/commit/af3085cfc02df8614e466adad5a5ac2e12cf5820), which documented how the driver handles uncompressed response formats. The stdout message was unrelated to that change and contains temporary debugging text.

Removing it restores the previous behavior while leaving the existing structured HTTP query logging and compression headers unchanged.

## Testing

- `go test ./...`
