### PR TITLE
fix: query parameter detection in quoted SQL

### DIFF
--- a/query_parameters.go
+++ b/query_parameters.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"regexp"
 	"strconv"
 	"time"
 
@@ -14,8 +13,6 @@ import (
 var (
 	ErrInvalidValueInNamedDateValue = errors.New("invalid value in NamedDateValue for query parameter")
 	ErrUnsupportedQueryParameter    = errors.New("unsupported query parameter type")
-
-	hasQueryParamsRe = regexp.MustCompile("{.+:.+}")
 )
 
 func bindQueryOrAppendParameters(paramsProtocolSupport bool, options *QueryOptions, query string, timezone *time.Location, args ...any) (string, error) {
@@ -28,7 +25,7 @@ func bindQueryOrAppendParameters(paramsProtocolSupport bool, options *QueryOptio
 	// parameter values will be loaded from `args ...any` for compatibility
 	if paramsProtocolSupport &&
 		len(args) > 0 &&
-		hasQueryParamsRe.MatchString(query) {
+		hasQueryParameters(query) {
 		options.parameters = make(Parameters, len(args))
 		for _, a := range args {
 			switch p := a.(type) {
@@ -84,6 +81,36 @@ func bindQueryOrAppendParameters(paramsProtocolSupport bool, options *QueryOptio
 	}
 
 	return bind(timezone, query, args...)
+}
+
+func hasQueryParameters(query string) bool {
+	var state bindQuoteState
+	for i := 0; i < len(query); i++ {
+		if !state.inProtectedContext() && query[i] == '{' && isQueryParameter(query[i+1:]) {
+			return true
+		}
+		i = state.update(query, i)
+	}
+	return false
+}
+
+func isQueryParameter(query string) bool {
+	nameEnd := 0
+	for nameEnd < len(query) && isNameChar(query[nameEnd]) {
+		nameEnd++
+	}
+	if nameEnd == 0 || nameEnd >= len(query) || query[nameEnd] != ':' {
+		return false
+	}
+
+	var state bindQuoteState
+	for i := nameEnd + 1; i < len(query); i++ {
+		if !state.inProtectedContext() && query[i] == '}' {
+			return i > nameEnd+1
+		}
+		i = state.update(query, i)
+	}
+	return false
 }
 
 // isNilParamValue reports whether v is nil itself or a typed nil pointer —

--- a/query_parameters.go
+++ b/query_parameters.go
@@ -83,6 +83,8 @@ func bindQueryOrAppendParameters(paramsProtocolSupport bool, options *QueryOptio
 	return bind(timezone, query, args...)
 }
 
+// hasQueryParameters reports whether query contains server-side parameter
+// syntax outside strings, quoted identifiers, and comments.
 func hasQueryParameters(query string) bool {
 	var state bindQuoteState
 	for i := 0; i < len(query); i++ {
@@ -94,23 +96,45 @@ func hasQueryParameters(query string) bool {
 	return false
 }
 
+// isQueryParameter reports whether query starts with a nonempty
+// {name:type} parameter declaration.
 func isQueryParameter(query string) bool {
-	nameEnd := 0
-	for nameEnd < len(query) && isNameChar(query[nameEnd]) {
-		nameEnd++
-	}
-	if nameEnd == 0 || nameEnd >= len(query) || query[nameEnd] != ':' {
+	nameStart := skipSpace(query, 0)
+	if nameStart >= len(query) || isDigit(query[nameStart]) {
 		return false
 	}
 
+	nameEnd := nameStart
+	for nameEnd < len(query) && isNameChar(query[nameEnd]) {
+		nameEnd++
+	}
+	colon := skipSpace(query, nameEnd)
+	if nameEnd == nameStart || colon >= len(query) || query[colon] != ':' {
+		return false
+	}
+
+	typeStart := skipSpace(query, colon+1)
 	var state bindQuoteState
-	for i := nameEnd + 1; i < len(query); i++ {
+	for i := typeStart; i < len(query); i++ {
 		if !state.inProtectedContext() && query[i] == '}' {
-			return i > nameEnd+1
+			return i > typeStart
 		}
 		i = state.update(query, i)
 	}
 	return false
+}
+
+// skipSpace returns the first index at or after start that is not SQL whitespace.
+func skipSpace(query string, start int) int {
+	for start < len(query) {
+		switch query[start] {
+		case ' ', '\t', '\r', '\n':
+			start++
+		default:
+			return start
+		}
+	}
+	return start
 }
 
 // isNilParamValue reports whether v is nil itself or a typed nil pointer —

--- a/query_parameters_test.go
+++ b/query_parameters_test.go
@@ -54,12 +54,36 @@ func TestBindQueryIgnoresParameterSyntaxInProtectedContexts(t *testing.T) {
 }
 
 func TestBindQueryDetectsQueryParameter(t *testing.T) {
-	options := QueryOptions{}
-	query := `SELECT {value:Enum8('enabled' = 1, 'disabled' = 0)}`
+	t.Run("quoted enum type", func(t *testing.T) {
+		options := QueryOptions{}
+		query := `SELECT {value:Enum8('enabled' = 1, 'disabled' = 0)}`
 
-	actual, err := bindQueryOrAppendParameters(true, &options, query, time.UTC, Named("value", 1))
+		actual, err := bindQueryOrAppendParameters(true, &options, query, time.UTC, Named("value", 1))
 
-	require.NoError(t, err)
-	assert.Equal(t, query, actual)
-	assert.Equal(t, Parameters{"value": "1"}, options.parameters)
+		require.NoError(t, err)
+		assert.Equal(t, query, actual)
+		assert.Equal(t, Parameters{"value": "1"}, options.parameters)
+	})
+
+	t.Run("whitespace around name and type", func(t *testing.T) {
+		options := QueryOptions{}
+		query := `SELECT { value : String }`
+
+		actual, err := bindQueryOrAppendParameters(true, &options, query, time.UTC, Named("value", "hello"))
+
+		require.NoError(t, err)
+		assert.Equal(t, query, actual)
+		assert.Equal(t, Parameters{"value": "hello"}, options.parameters)
+	})
+
+	t.Run("map literal with a positional argument", func(t *testing.T) {
+		options := QueryOptions{}
+		query := `SELECT {1:'a'}, ?`
+
+		actual, err := bindQueryOrAppendParameters(true, &options, query, time.UTC, 42)
+
+		require.NoError(t, err)
+		assert.Equal(t, `SELECT {1:'a'}, 42`, actual)
+		assert.Empty(t, options.parameters)
+	})
 }

--- a/query_parameters_test.go
+++ b/query_parameters_test.go
@@ -1,0 +1,65 @@
+package clickhouse
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBindQueryIgnoresParameterSyntaxInProtectedContexts(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		expected string
+	}{
+		{
+			name:     "string",
+			query:    `SELECT '{"key":"value"}', ?`,
+			expected: `SELECT '{"key":"value"}', 42`,
+		},
+		{
+			name:     "block comment",
+			query:    `SELECT ? /* {fake:UInt64} */`,
+			expected: `SELECT 42 /* {fake:UInt64} */`,
+		},
+		{
+			name:     "line comment",
+			query:    "SELECT ? -- {fake:UInt64}\n",
+			expected: "SELECT 42 -- {fake:UInt64}\n",
+		},
+		{
+			name:     "double quoted identifier",
+			query:    `SELECT "{fake:UInt64}", ?`,
+			expected: `SELECT "{fake:UInt64}", 42`,
+		},
+		{
+			name:     "backtick identifier",
+			query:    "SELECT `{fake:UInt64}`, ?",
+			expected: "SELECT `{fake:UInt64}`, 42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := QueryOptions{}
+			actual, err := bindQueryOrAppendParameters(true, &options, tt.query, time.UTC, 42)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+			assert.Empty(t, options.parameters)
+		})
+	}
+}
+
+func TestBindQueryDetectsQueryParameter(t *testing.T) {
+	options := QueryOptions{}
+	query := `SELECT {value:Enum8('enabled' = 1, 'disabled' = 0)}`
+
+	actual, err := bindQueryOrAppendParameters(true, &options, query, time.UTC, Named("value", 1))
+
+	require.NoError(t, err)
+	assert.Equal(t, query, actual)
+	assert.Equal(t, Parameters{"value": "1"}, options.parameters)
+}

--- a/tests/issues/issue_1938_test.go
+++ b/tests/issues/issue_1938_test.go
@@ -1,0 +1,31 @@
+package issues
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+)
+
+func TestIssue1938_SpacedQueryParameter(t *testing.T) {
+	clickhouse_tests.TestProtocols(t, func(t *testing.T, protocol clickhouse.Protocol) {
+		ctx := context.Background()
+		conn, err := clickhouse_tests.GetConnection("issues", t, protocol, nil, nil, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { conn.Close() })
+
+		if !clickhouse_tests.CheckMinServerServerVersion(conn, 22, 8, 0) {
+			t.Skip("server-side query parameters require ClickHouse 22.8+")
+		}
+
+		var actual uint64
+		require.NoError(t, conn.QueryRow(ctx,
+			"SELECT { value : UInt64 }",
+			clickhouse.Named("value", 42),
+		).Scan(&actual))
+		require.Equal(t, uint64(42), actual)
+	})
+}


### PR DESCRIPTION
## Summary

Server-side query parameter detection currently applies a regular expression to the complete SQL query. Parameter-like text inside a string, quoted identifier, or comment can therefore select the native parameter path and reject ordinary positional arguments with "unsupported query parameter type".

Detect parameter syntax only outside quoted and commented contexts by reusing the existing binding scanner. The detection also requires a nonempty parameter name and type. Regression tests cover strings, quoted identifiers, line and block comments, and a real native parameter with a quoted Enum type.

## Checklist

- [x] Unit and integration tests covering the common scenarios were added

## Testing

- go test ./...