### PR TITLE
fix: return errors when scanning Tuple maps

### DIFF
--- a/lib/column/tuple.go
+++ b/lib/column/tuple.go
@@ -422,7 +422,7 @@ func (col *Tuple) scan(targetType reflect.Type, row int) (reflect.Value, error) 
 		}
 		rMap := reflect.MakeMap(targetType)
 		if err := col.scanMap(rMap, row); err != nil {
-			return reflect.Value{}, nil
+			return reflect.Value{}, err
 		}
 		return rMap, nil
 	case reflect.Slice:

--- a/lib/column/tuple_test.go
+++ b/lib/column/tuple_test.go
@@ -1,0 +1,19 @@
+package column
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTupleScanRowReturnsMapKeyError(t *testing.T) {
+	col, err := Type("Tuple(name String, value UInt64)").Column("tuple", nil)
+	require.NoError(t, err)
+
+	err = col.AppendRow(map[string]any{"name": "hello", "value": uint64(42)})
+	require.NoError(t, err)
+
+	var result map[int]any
+	err = col.ScanRow(&result, 0)
+	require.EqualError(t, err, "int: column tuple - map keys must be a string")
+}


### PR DESCRIPTION
## Summary

Return the existing conversion error when scanning a named Tuple into a map with an unsupported key type. Previously, the error was discarded and `ScanRow` attempted to assign an invalid reflection value, causing a panic.

Add a regression test covering the invalid map key path.

## Checklist

- [x] Unit and integration tests covering the common scenarios were added