### PR TITLE
perf: make `safeLen()` linear runtime in exception parser

### DIFF
--- a/conn_http_format.go
+++ b/conn_http_format.go
@@ -54,9 +54,8 @@ type exceptionScanReader struct {
 	// terminal error: parsed exception or upstream read error
 	err error
 
-	// srcDone make sure if upstream reader has anything left.
-	// Say any EOF or error from upstream makes this true. Meaning
-	// no more input is coming.
+	// srcDone is true once the upstream reader is exhausted (EOF or error).
+	// no more input is coming
 	srcDone bool
 }
 
@@ -137,8 +136,10 @@ func (r *exceptionScanReader) scan() {
 	for {
 		i := bytes.Index(r.pending[r.scanOffset:], exceptionFrame)
 		if i < 0 {
-			// instead of safeLen() to scale "whole" pending buffer, we can make
-			// safeLen() make it check only new reads.
+			// No complete frame exists at or after scanOffset, so every byte
+			// except the split-frame holdback tail is decided data; advancing
+			// scanOffset keeps safeLen bounded per Read instead of rescanning
+			// all of pending
 			if cleared := len(r.pending) - (len(exceptionFrame) - 1); cleared > r.scanOffset {
 				r.scanOffset = cleared
 			}

--- a/conn_http_format.go
+++ b/conn_http_format.go
@@ -31,19 +31,33 @@ var exceptionFrame = []byte(exceptionMarker + "\r\n")
 //
 // A frame candidate is treated as a genuine exception only if the marker is
 // followed by the per-response random tag the server announced in the
-// X-ClickHouse-Exception-Tag header (tag) - that is what the tag exists for:
-// result data cannot contain a value generated after the response started, so
-// data that happens to contain the marker bytes is served verbatim. On older
-// servers that send no tag header, tag is empty and the marker alone is
-// trusted (best-effort).
+// X-ClickHouse-Exception-Tag HTTP header (tag). On older servers that send no tag header,
+// tag is empty and the marker alone is trusted (best-effort).
 type exceptionScanReader struct {
-	src      io.Reader
-	tag      string // from X-ClickHouse-Exception-Tag; empty disables validation
-	buf      []byte
-	pending  []byte
-	scanFrom int   // pending[:scanFrom] holds no undecided frame candidates
-	err      error // terminal error: parsed exception or upstream read error
-	srcDone  bool
+	// src is the upstream reader
+	src io.Reader
+
+	// tag is from X-ClickHouse-Exception-Tag HTTP header;
+	// empty disables validation (older version)
+	tag string
+
+	// buf is the scratch buffer (max exceptionScanLimit)
+	buf []byte
+
+	// pending is every byte that is not returned to the caller.
+	// it may or may not contain exception.
+	pending []byte
+
+	// pending[:scanOffset] holds plain text and are not exception candidates.
+	scanOffset int
+
+	// terminal error: parsed exception or upstream read error
+	err error
+
+	// srcDone make sure if upstream reader has anything left.
+	// Say any EOF or error from upstream makes this true. Meaning
+	// no more input is coming.
+	srcDone bool
 }
 
 func newExceptionScanReader(src io.Reader, tag string) *exceptionScanReader {
@@ -87,8 +101,8 @@ func (r *exceptionScanReader) Read(p []byte) (int, error) {
 		if safe := r.safeLen(); safe > 0 {
 			n := copy(p, r.pending[:safe])
 			r.pending = r.pending[n:]
-			if r.scanFrom -= n; r.scanFrom < 0 {
-				r.scanFrom = 0
+			if r.scanOffset -= n; r.scanOffset < 0 {
+				r.scanOffset = 0
 			}
 			return n, nil
 		}
@@ -121,11 +135,16 @@ func (r *exceptionScanReader) Read(p []byte) (int, error) {
 // of the stream) settles the question.
 func (r *exceptionScanReader) scan() {
 	for {
-		i := bytes.Index(r.pending[r.scanFrom:], exceptionFrame)
+		i := bytes.Index(r.pending[r.scanOffset:], exceptionFrame)
 		if i < 0 {
+			// instead of safeLen() to scale "whole" pending buffer, we can make
+			// safeLen() make it check only new reads.
+			if cleared := len(r.pending) - (len(exceptionFrame) - 1); cleared > r.scanOffset {
+				r.scanOffset = cleared
+			}
 			return
 		}
-		i += r.scanFrom
+		i += r.scanOffset
 		if r.tag == "" {
 			// Old servers (<= 25.8) announce no tag: the marker alone has to
 			// be trusted.
@@ -140,7 +159,7 @@ func (r *exceptionScanReader) scan() {
 			}
 			// The stream ended inside the candidate - a genuine frame cannot
 			// be truncated here, so these are data bytes.
-			r.scanFrom = i + 1
+			r.scanOffset = i + 1
 			continue
 		}
 		if string(r.pending[tagStart:tagStart+len(r.tag)]) == r.tag &&
@@ -149,23 +168,23 @@ func (r *exceptionScanReader) scan() {
 			return
 		}
 		// Marker bytes that happen to appear in the result data.
-		r.scanFrom = i + 1
+		r.scanOffset = i + 1
 	}
 }
 
 // safeLen returns how many pending bytes can be served without risking that
 // their tail is the beginning of an exception frame split across reads.
-// Candidates already dismissed by scan (below scanFrom) are plain data and
+// Candidates already dismissed by scan (below scanOffset) are plain data and
 // never held back.
 func (r *exceptionScanReader) safeLen() int {
 	if r.srcDone || r.err != nil {
 		return len(r.pending)
 	}
-	tail := r.pending[r.scanFrom:]
+	tail := r.pending[r.scanOffset:]
 	if i := bytes.Index(tail, exceptionFrame); i >= 0 {
 		// A complete marker whose tag bytes are still in flight: serve
 		// everything before it, hold the candidate.
-		return r.scanFrom + i
+		return r.scanOffset + i
 	}
 	holdback := len(exceptionFrame) - 1
 	if holdback > len(tail) {

--- a/conn_http_format.go
+++ b/conn_http_format.go
@@ -129,7 +129,7 @@ func (r *exceptionScanReader) Read(p []byte) (int, error) {
 }
 
 // scan classifies every complete frame candidate in pending. Candidates whose
-// tag bytes have not arrived yet stay undecided: scanFrom keeps pointing
+// tag bytes have not arrived yet stay undecided: scanOffset keeps pointing
 // before them and safeLen holds those bytes back until more input (or the end
 // of the stream) settles the question.
 func (r *exceptionScanReader) scan() {
@@ -156,7 +156,12 @@ func (r *exceptionScanReader) scan() {
 		tagEnd := tagStart + len(r.tag) + 2 // tag + CRLF
 		if len(r.pending) < tagEnd {
 			if !r.srcDone {
-				return // undecided: wait for the tag bytes
+				// Undecided: wait for the tag bytes. Everything before the
+				// candidate is decided data, so park scanOffset right at it -
+				// safeLen then re-examines only the candidate, not the data
+				// preceding it, while the caller drains that data.
+				r.scanOffset = i
+				return
 			}
 			// The stream ended inside the candidate - a genuine frame cannot
 			// be truncated here, so these are data bytes.

--- a/conn_http_format_bench_test.go
+++ b/conn_http_format_bench_test.go
@@ -1,0 +1,81 @@
+package clickhouse
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// benchScanPayload returns size bytes of payload. The "clean" flavor contains
+// no exception-frame bytes at all; the "markerish" flavor carries a full bare
+// marker (without CRLF framing) in every 16 bytes, forcing the scanner through
+// the edge cases of near-miss and split-boundary holdback paths on every fill.
+func benchScanPayload(flavor string, size int) []byte {
+	var unit []byte
+	switch flavor {
+	case "clean":
+		unit = []byte("0123456789abcdef")
+	case "markerish":
+		unit = []byte("x__exception__xx")
+	default:
+		panic("unknown payload flavor: " + flavor)
+	}
+	return bytes.Repeat(unit, size/len(unit))
+}
+
+// BenchmarkExceptionScanReader measures the pass-through overhead of the
+// mid-stream exception scan on a clean 1 MiB response drained with various
+// caller read sizes.
+// Small read sizes are the regression trap: the scan cost
+// per Read must stay bounded by the holdback window, not by the amount of
+// data pending
+func BenchmarkExceptionScanReader(b *testing.B) {
+	const payloadSize = 1 << 20
+	for _, flavor := range []string{"clean", "markerish"} {
+		payload := benchScanPayload(flavor, payloadSize)
+		for _, readSize := range []int{16, 512, 4096, 64 << 10} {
+			b.Run(fmt.Sprintf("%s/readSize=%d", flavor, readSize), func(b *testing.B) {
+				p := make([]byte, readSize)
+				b.SetBytes(payloadSize)
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					r := newExceptionScanReader(bytes.NewReader(payload), "tag123")
+					for {
+						if _, err := r.Read(p); err != nil {
+							if errors.Is(err, io.EOF) {
+								break
+							}
+							b.Fatal(err)
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestExceptionScanReaderScanOffsetBounded pins the property that keeps Read
+// linear.
+// After scan sees a fill with no complete frame, everything except
+// the split-frame holdback window is marked decided, so safeLen re-examines
+// at most len(exceptionFrame)-1 bytes per Read instead of rescanning the
+// whole pending buffer on every call.
+func TestExceptionScanReaderScanOffsetBounded(t *testing.T) {
+	r := newExceptionScanReader(bytes.NewReader(nil), "tag123")
+	r.pending = bytes.Repeat([]byte("x"), 8<<10)
+	r.scan()
+	require.Equal(t, len(r.pending)-(len(exceptionFrame)-1), r.scanOffset,
+		"clean fill: scanOffset must advance to the holdback boundary")
+
+	// An undecided candidate (complete frame, tag bytes still in flight) must
+	// stay at or right of scanOffset so safeLen keeps holding it back.
+	r = newExceptionScanReader(bytes.NewReader(nil), "tag123")
+	r.pending = append(bytes.Repeat([]byte("x"), 100), exceptionFrame...)
+	r.scan()
+	require.LessOrEqual(t, r.scanOffset, 100,
+		"undecided candidate must remain inside the scanned window")
+}

--- a/conn_http_format_bench_test.go
+++ b/conn_http_format_bench_test.go
@@ -76,6 +76,6 @@ func TestExceptionScanReaderScanOffsetBounded(t *testing.T) {
 	r = newExceptionScanReader(bytes.NewReader(nil), "tag123")
 	r.pending = append(bytes.Repeat([]byte("x"), 100), exceptionFrame...)
 	r.scan()
-	require.LessOrEqual(t, r.scanOffset, 100,
+	require.Equal(t, r.scanOffset, 100,
 		"undecided candidate must remain inside the scanned window")
 }


### PR DESCRIPTION


## Summary
<!-- A short description of the changes with a link to an open issue. -->

1. The `read()` loop try to decide if the bytes scanned so far is safe to return to caller (making sure no legit exception is in there)
2. To make this decision, we have `safeLen()` api. But this becomes O(n^2) by not incrementing scanOffset correctly.
3. This PR updates it during `scan()` api that makes the `safeLen` linear runtime.

### Before
<img width="1691" height="351" alt="screenshot5" src="https://github.com/user-attachments/assets/be0ae954-1249-4e92-9adb-ecff63c28b69" />


### After
<img width="1675" height="375" alt="screenshot4" src="https://github.com/user-attachments/assets/f8ff6782-b711-4541-892d-46632d7bb826" />


Fixes: #1940 

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
