### PR TITLE
fix: parse JSON typed paths with spaces inside backticks

### DIFF
--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -70,6 +70,45 @@ const (
 	jsonModeString                 // string, []byte, json.RawMessage, sql.NullString, Stringer, Valuer
 )
 
+// splitTypedPath splits a typed path spec "path Type" or "`path with spaces` Type"
+// into path and typeName. Surrounding path backticks are stripped. ok is false if
+// the spec does not contain a usable path/type separator.
+func splitTypedPath(typePart string) (path, typeName string, ok bool) {
+	typePart = strings.TrimSpace(typePart)
+	if typePart == "" {
+		return "", "", false
+	}
+
+	var pathPart string
+	var rest string
+
+	if typePart[0] == '`' {
+		// Backtick-quoted path may contain spaces; find the closing backtick.
+		end := strings.IndexByte(typePart[1:], '`')
+		if end < 0 {
+			return "", "", false
+		}
+		end++ // index of closing backtick in typePart
+		pathPart = typePart[:end+1]
+		rest = typePart[end+1:]
+	} else {
+		// Unquoted path cannot contain spaces; split on the first space.
+		idx := strings.IndexByte(typePart, ' ')
+		if idx < 0 {
+			return "", "", false
+		}
+		pathPart = typePart[:idx]
+		rest = typePart[idx+1:]
+	}
+
+	typeName = strings.TrimSpace(rest)
+	if typeName == "" {
+		return "", "", false
+	}
+	path = strings.Trim(pathPart, "`")
+	return path, typeName, true
+}
+
 func (c *JSON) parse(t Type, sc *ServerContext) (_ *JSON, err error) {
 	c.chType = t
 	c.sc = sc
@@ -133,13 +172,10 @@ func (c *JSON) parse(t Type, sc *ServerContext) (_ *JSON, err error) {
 			continue
 		}
 
-		typedPathParts := strings.SplitN(typePart, " ", 2)
-		if len(typedPathParts) != 2 {
+		typedPath, typeName, ok := splitTypedPath(typePart)
+		if !ok {
 			continue
 		}
-
-		typedPath := strings.Trim(typedPathParts[0], "`")
-		typeName := strings.TrimSpace(typedPathParts[1])
 
 		c.typedPaths = append(c.typedPaths, typedPath)
 		c.typedPathsIndex[typedPath] = len(c.typedPaths) - 1

--- a/lib/column/json_test.go
+++ b/lib/column/json_test.go
@@ -21,6 +21,64 @@ func newTestJSONColumn(t *testing.T) *JSON {
 	return col
 }
 
+func TestJSONParseTypedPathWithSpace(t *testing.T) {
+	sc := &ServerContext{}
+
+	tests := []struct {
+		name     string
+		chType   Type
+		wantPath string
+		wantType string
+	}{
+		{
+			name:     "backtick path with space",
+			chType:   "JSON(`a b` Int64)",
+			wantPath: "a b",
+			wantType: "Int64",
+		},
+		{
+			name:     "backtick path with space and Decimal",
+			chType:   "JSON(`a b` Decimal(10, 2))",
+			wantPath: "a b",
+			wantType: "Decimal(10, 2)",
+		},
+		{
+			name:     "dotted path",
+			chType:   "JSON(a.b Int64)",
+			wantPath: "a.b",
+			wantType: "Int64",
+		},
+		{
+			name:     "backtick path with comma",
+			chType:   "JSON(`a,b` Int64)",
+			wantPath: "a,b",
+			wantType: "Int64",
+		},
+		{
+			name:     "simple path",
+			chType:   "JSON(a Int64)",
+			wantPath: "a",
+			wantType: "Int64",
+		},
+		{
+			name:     "backtick path with dot",
+			chType:   "JSON(`a.b` Int64)",
+			wantPath: "a.b",
+			wantType: "Int64",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			col, err := (&JSON{}).parse(tt.chType, sc)
+			require.NoError(t, err)
+			require.Len(t, col.typedPaths, 1)
+			assert.Equal(t, tt.wantPath, col.typedPaths[0])
+			assert.Equal(t, Type(tt.wantType), col.typedColumns[0].Type())
+		})
+	}
+}
+
 // TestJSONAppendRowNilConsistency verifies the contract for AppendRow(nil).
 // Key rules:
 //  1. A nil row carries no mode preference — it does NOT latch the column.


### PR DESCRIPTION
## What
Replace first-space `SplitN` when parsing JSON typed paths with a backtick-aware `splitTypedPath` helper so paths like `` `a b` Int64 `` and `` `a b` Decimal(10, 2) `` parse correctly.

## Why
`(*JSON).parse` split on the first space, so a backtick-quoted path containing a space became path=`a` and type=`b` Int64`, causing `unsupported column type` and failing the query.

## Test
- Unit coverage for spaced backtick paths, Decimal types, dotted/unquoted paths, and comma-in-path cases.
- Existing JSON parse/append tests remain valid.

Generated by Radar — human must review

---
*Opened by Radar — human-approved. Review carefully before merge.*