### PR TITLE
fix JSON typed path parsing for paths containing spaces

### DIFF
--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -133,13 +133,26 @@ func (c *JSON) parse(t Type, sc *ServerContext) (_ *JSON, err error) {
 			continue
 		}
 
-		typedPathParts := strings.SplitN(typePart, " ", 2)
-		if len(typedPathParts) != 2 {
+		// Split on the last space that is not inside backticks so paths like
+		// `a b` Int64 parse as path "a b" and type "Int64".
+		lastSpace := -1
+		inBackticks := false
+		for i := 0; i < len(typePart); i++ {
+			switch typePart[i] {
+			case '`':
+				inBackticks = !inBackticks
+			case ' ':
+				if !inBackticks {
+					lastSpace = i
+				}
+			}
+		}
+		if lastSpace < 0 {
 			continue
 		}
 
-		typedPath := strings.Trim(typedPathParts[0], "`")
-		typeName := strings.TrimSpace(typedPathParts[1])
+		typedPath := strings.Trim(typePart[:lastSpace], "`")
+		typeName := strings.TrimSpace(typePart[lastSpace+1:])
 
 		c.typedPaths = append(c.typedPaths, typedPath)
 		c.typedPathsIndex[typedPath] = len(c.typedPaths) - 1


### PR DESCRIPTION
## Summary
Fixes unparseable JSON typed paths that contain spaces inside backticks (e.g. `JSON(\`a b\` Int64)`), which previously split on the first space and produced a bogus type name like `b\` Int64`.

## Changes
- Replace `strings.SplitN(typePart, " ", 2)` in `(*JSON).parse` with a backtick-aware scan that splits on the last unquoted space.
- Preserve existing `strings.Trim` behavior so quoted path names still normalize correctly.

## Test plan
- [ ] Human must review
- [ ] Unit/integration coverage for `JSON(\`a b\` Int64)` and similar typed paths
- [ ] Confirm comma-containing backtick paths still parse via existing `splitWithDelimiters`

Fixes ClickHouse/clickhouse-go#1948

---
*Opened by Radar — human-approved. Review carefully before merge.*