### PR TITLE
fix: align go directive with documented 1.24 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ClickHouse/clickhouse-go/v2
 
-go 1.25.0
+go 1.24.0
 
 toolchain go1.25.4
 


### PR DESCRIPTION
## Summary
`go.mod` sets `go 1.25.0`, which makes 1.25 the minimum toolchain, but the README Supported Golang Versions table claims client `>= 2.41` supports Go **1.24 and 1.25**. That mismatch breaks consumers on Go 1.24.

## Change
- Lower the `go` directive from `1.25.0` to `1.24.0` so the module matches documented support.
- Leave the `toolchain` line unchanged so CI/dev can still pin a newer toolchain.

## Note
Human must review before merge. Please confirm intent of the `toolchain go1.25.4` pin and that no APIs requiring Go 1.25+ are in the public surface.

Fixes #113163

---
*Opened by Radar — human-approved. Review carefully before merge.*