### PR TITLE
feat: support pre-compressed HTTP insert payloads

### DIFF
--- a/conn_http.go
+++ b/conn_http.go
@@ -147,6 +147,13 @@ func applyOptionsToRequest(ctx context.Context, req *http.Request, opt *Options)
 		}
 	}
 
+	if queryOpt.precompressed != CompressionNone {
+		if opt.Compression != nil && opt.Compression.Method != CompressionNone {
+			return errors.New("cannot combine Options.Compression with WithPrecompressedInput")
+		}
+		req.Header.Set("Content-Encoding", queryOpt.precompressed.String())
+	}
+
 	return nil
 }
 

--- a/context.go
+++ b/context.go
@@ -2,6 +2,8 @@ package clickhouse
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"maps"
 	"slices"
 	"time"
@@ -58,6 +60,9 @@ type (
 		userLocation        *time.Location
 		columnNamesAndTypes []ColumnNameAndType
 		clientInfo          ClientInfo
+		// precompressed, when non-zero, declares the insert body is already
+		// compressed. Content-Encoding is set and the client must not wrap the body.
+		precompressed CompressionMethod
 	}
 )
 
@@ -187,6 +192,25 @@ func WithUserLocation(location *time.Location) QueryOption {
 	return func(o *QueryOptions) error {
 		o.userLocation = location
 		return nil
+	}
+}
+
+// WithPrecompressedInput declares that the request body is already compressed
+// with the given method. The HTTP Content-Encoding header is set to match and
+// the body should be streamed as-is (no additional client-side compression).
+// The payload must already match the declared encoding (e.g. a .parquet.gz file
+// with CompressionGZIP). Only supported for HTTP insert/InsertFormat paths.
+func WithPrecompressedInput(method CompressionMethod) QueryOption {
+	return func(o *QueryOptions) error {
+		switch method {
+		case CompressionGZIP, CompressionDeflate, CompressionBrotli:
+			o.precompressed = method
+			return nil
+		case CompressionNone:
+			return errors.New("precompressed input requires a compression method")
+		default:
+			return fmt.Errorf("unsupported precompressed encoding: %s", method)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Adds `WithPrecompressedInput` so callers can stream already-compressed insert bodies (e.g. `.parquet.gz`) over HTTP without the client compressing them again.

- Sets `Content-Encoding` from the context option in `applyOptionsToRequest`
- Rejects combining `Options.Compression` with `WithPrecompressedInput`
- Documents that the payload must already match the declared encoding

## Notes
Human must review: confirm HTTP insert/InsertFormat paths honor `queryOptions(ctx).precompressed` by skipping the compression pool/writer (stream body as-is). Only GZIP/Deflate/Brotli are accepted as HTTP content encodings.

Fixes ClickHouse/clickhouse-go#1936

---
*Opened by Radar — human-approved. Review carefully before merge.*