### PR TITLE
test: add unit coverage for churl DSN parsing, query parameter bindin…

### DIFF
--- a/lib/binary/string_test.go
+++ b/lib/binary/string_test.go
@@ -1,7 +1,6 @@
 package binary
 
 import (
-	"runtime"
 	"strings"
 	"testing"
 
@@ -45,19 +44,10 @@ func TestStr2BytesAliasesSourceWhenNoPaddingNeeded(t *testing.T) {
 	// lifetime — mutating it corrupts the "immutable" Go string in place.
 	// This test pins that contract down so a future change can't flip it
 	// silently.
-	//
-	// Str2Bytes has an arch-specific implementation: on amd64/arm64 it uses
-	// an unsafe zero-copy conversion and the returned slice aliases the
-	// source string, while on other architectures it uses []byte(str),
-	// which copies.
 	s := strings.Repeat("a", 8)
 	got := Str2Bytes(s, 4)
 	got[0] = 'z'
-	if runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64" {
-		assert.Equal(t, byte('z'), s[0], "expected the returned slice to alias the source string's memory on this architecture")
-		return
-	}
-	assert.Equal(t, byte('a'), s[0], "expected the returned slice to be a copy on this architecture")
+	assert.Equal(t, byte('z'), s[0], "expected the returned slice to alias the source string's memory")
 }
 
 func TestStr2BytesLargeInputNoPanic(t *testing.T) {

--- a/lib/binary/string_test.go
+++ b/lib/binary/string_test.go
@@ -4,6 +4,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -31,7 +32,8 @@ func TestStr2Bytes(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := Str2Bytes(tc.str, tc.expectedLen)
-			assert.Equal(t, tc.want, got)
+			// compared as strings: Str2Bytes("", 0) may be nil, not empty
+			assert.Equal(t, string(tc.want), string(got))
 			assert.Len(t, got, len(tc.want))
 		})
 	}
@@ -52,12 +54,13 @@ func TestStr2BytesAliasesSourceWhenNoPaddingNeeded(t *testing.T) {
 	// which copies.
 	s := strings.Repeat("a", 8)
 	got := Str2Bytes(s, 4)
-	got[0] = 'z'
+	// pointer identity, not a write: modifying the bytes would be undefined
+	aliases := unsafe.SliceData(got) == unsafe.StringData(s)
 	if runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64" {
-		assert.Equal(t, byte('z'), s[0], "expected the returned slice to alias the source string's memory on this architecture")
+		assert.True(t, aliases, "expected the returned slice to alias the source string's memory on this architecture")
 		return
 	}
-	assert.Equal(t, byte('a'), s[0], "expected the returned slice to be a copy on this architecture")
+	assert.False(t, aliases, "expected the returned slice to be a copy on this architecture")
 }
 
 func TestStr2BytesLargeInputNoPanic(t *testing.T) {

--- a/lib/binary/string_test.go
+++ b/lib/binary/string_test.go
@@ -1,0 +1,79 @@
+package binary
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Str2Bytes backs FixedString encoding (see lib/column/fixed_string.go): a
+// value shorter than the column's declared size must be zero-padded to
+// exactly that size, or the bytes written to the wire are misaligned.
+
+func TestStr2BytesExactLength(t *testing.T) {
+	got := Str2Bytes("hello", 5)
+	assert.Equal(t, []byte("hello"), got)
+	assert.Len(t, got, 5)
+}
+
+func TestStr2BytesLongerThanExpected(t *testing.T) {
+	// expectedLen smaller than the string: the string is returned as-is,
+	// no truncation happens.
+	got := Str2Bytes("hello world", 5)
+	assert.Equal(t, []byte("hello world"), got)
+}
+
+func TestStr2BytesPadsShorterStringWithZeroBytes(t *testing.T) {
+	got := Str2Bytes("hi", 5)
+	assert.Len(t, got, 5)
+	assert.Equal(t, []byte{'h', 'i', 0, 0, 0}, got)
+}
+
+func TestStr2BytesEmptyStringNoPadding(t *testing.T) {
+	got := Str2Bytes("", 0)
+	assert.Len(t, got, 0)
+}
+
+func TestStr2BytesEmptyStringWithPadding(t *testing.T) {
+	got := Str2Bytes("", 4)
+	assert.Equal(t, []byte{0, 0, 0, 0}, got)
+}
+
+func TestStr2BytesMultiByteUTF8(t *testing.T) {
+	// FixedString sizes count bytes, not runes; multi-byte characters must
+	// come through unmangled and byte-for-byte.
+	s := "日本語"
+	got := Str2Bytes(s, len(s))
+	assert.Equal(t, []byte(s), got)
+	assert.Len(t, got, len(s))
+}
+
+func TestStr2BytesMultiByteUTF8Padded(t *testing.T) {
+	s := "日" // 3 bytes in UTF-8
+	got := Str2Bytes(s, 6)
+	want := append([]byte(s), 0, 0, 0)
+	assert.Equal(t, want, got)
+}
+
+func TestStr2BytesAliasesSourceWhenNoPaddingNeeded(t *testing.T) {
+	// When expectedLen <= len(str), Str2Bytes hands back a slice that
+	// aliases the string's own backing memory (no copy, for speed) rather
+	// than a fresh copy. That is intentional, but it means callers must
+	// treat the result as read-only and not retain it past the string's
+	// lifetime — mutating it corrupts the "immutable" Go string in place.
+	// This test pins that contract down so a future change can't flip it
+	// silently.
+	s := strings.Repeat("a", 8)
+	got := Str2Bytes(s, 4)
+	got[0] = 'z'
+	assert.Equal(t, byte('z'), s[0], "expected the returned slice to alias the source string's memory")
+}
+
+func TestStr2BytesLargeInputNoPanic(t *testing.T) {
+	s := strings.Repeat("x", 1<<16)
+	assert.NotPanics(t, func() {
+		got := Str2Bytes(s, len(s))
+		assert.Len(t, got, len(s))
+	})
+}

--- a/lib/binary/string_test.go
+++ b/lib/binary/string_test.go
@@ -10,50 +10,30 @@ import (
 // Str2Bytes backs FixedString encoding (see lib/column/fixed_string.go): a
 // value shorter than the column's declared size must be zero-padded to
 // exactly that size, or the bytes written to the wire are misaligned.
-
-func TestStr2BytesExactLength(t *testing.T) {
-	got := Str2Bytes("hello", 5)
-	assert.Equal(t, []byte("hello"), got)
-	assert.Len(t, got, 5)
-}
-
-func TestStr2BytesLongerThanExpected(t *testing.T) {
-	// expectedLen smaller than the string: the string is returned as-is,
-	// no truncation happens.
-	got := Str2Bytes("hello world", 5)
-	assert.Equal(t, []byte("hello world"), got)
-}
-
-func TestStr2BytesPadsShorterStringWithZeroBytes(t *testing.T) {
-	got := Str2Bytes("hi", 5)
-	assert.Len(t, got, 5)
-	assert.Equal(t, []byte{'h', 'i', 0, 0, 0}, got)
-}
-
-func TestStr2BytesEmptyStringNoPadding(t *testing.T) {
-	got := Str2Bytes("", 0)
-	assert.Len(t, got, 0)
-}
-
-func TestStr2BytesEmptyStringWithPadding(t *testing.T) {
-	got := Str2Bytes("", 4)
-	assert.Equal(t, []byte{0, 0, 0, 0}, got)
-}
-
-func TestStr2BytesMultiByteUTF8(t *testing.T) {
-	// FixedString sizes count bytes, not runes; multi-byte characters must
-	// come through unmangled and byte-for-byte.
-	s := "日本語"
-	got := Str2Bytes(s, len(s))
-	assert.Equal(t, []byte(s), got)
-	assert.Len(t, got, len(s))
-}
-
-func TestStr2BytesMultiByteUTF8Padded(t *testing.T) {
-	s := "日" // 3 bytes in UTF-8
-	got := Str2Bytes(s, 6)
-	want := append([]byte(s), 0, 0, 0)
-	assert.Equal(t, want, got)
+func TestStr2Bytes(t *testing.T) {
+	cases := []struct {
+		name        string
+		str         string
+		expectedLen int
+		want        []byte
+	}{
+		{"exact length", "hello", 5, []byte("hello")},
+		{"longer than expected returns the string as-is, no truncation", "hello world", 5, []byte("hello world")},
+		{"shorter string is zero-padded", "hi", 5, []byte{'h', 'i', 0, 0, 0}},
+		{"empty string, no padding", "", 0, []byte{}},
+		{"empty string, zero-padded", "", 4, []byte{0, 0, 0, 0}},
+		// FixedString sizes count bytes, not runes; multi-byte characters
+		// must come through unmangled and byte-for-byte.
+		{"multi-byte UTF-8, exact length", "日本語", len("日本語"), []byte("日本語")},
+		{"multi-byte UTF-8, zero-padded", "日", 6, append([]byte("日"), 0, 0, 0)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Str2Bytes(tc.str, tc.expectedLen)
+			assert.Equal(t, tc.want, got)
+			assert.Len(t, got, len(tc.want))
+		})
+	}
 }
 
 func TestStr2BytesAliasesSourceWhenNoPaddingNeeded(t *testing.T) {

--- a/lib/binary/string_test.go
+++ b/lib/binary/string_test.go
@@ -1,6 +1,7 @@
 package binary
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 
@@ -44,10 +45,19 @@ func TestStr2BytesAliasesSourceWhenNoPaddingNeeded(t *testing.T) {
 	// lifetime — mutating it corrupts the "immutable" Go string in place.
 	// This test pins that contract down so a future change can't flip it
 	// silently.
+	//
+	// Str2Bytes has an arch-specific implementation: on amd64/arm64 it uses
+	// an unsafe zero-copy conversion and the returned slice aliases the
+	// source string, while on other architectures it uses []byte(str),
+	// which copies.
 	s := strings.Repeat("a", 8)
 	got := Str2Bytes(s, 4)
 	got[0] = 'z'
-	assert.Equal(t, byte('z'), s[0], "expected the returned slice to alias the source string's memory")
+	if runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64" {
+		assert.Equal(t, byte('z'), s[0], "expected the returned slice to alias the source string's memory on this architecture")
+		return
+	}
+	assert.Equal(t, byte('a'), s[0], "expected the returned slice to be a copy on this architecture")
 }
 
 func TestStr2BytesLargeInputNoPanic(t *testing.T) {

--- a/lib/churl/churl_test.go
+++ b/lib/churl/churl_test.go
@@ -15,89 +15,193 @@ import (
 // the sole caller, so a regression here breaks every multi-host connection
 // string silently or loudly, depending on the bug.
 
-func TestParseBasicDSN(t *testing.T) {
-	u, err := Parse("clickhouse://user:pass@localhost:9000/default?dial_timeout=1s")
-	require.NoError(t, err)
-	assert.Equal(t, "clickhouse", u.Scheme)
-	assert.Equal(t, "localhost:9000", u.Host)
-	assert.Equal(t, "/default", u.Path)
-	assert.Equal(t, "dial_timeout=1s", u.RawQuery)
-	require.NotNil(t, u.User)
-	assert.Equal(t, "user", u.User.Username())
-	pass, ok := u.User.Password()
-	assert.True(t, ok)
-	assert.Equal(t, "pass", pass)
+func TestParseHosts(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"basic DSN", "clickhouse://user:pass@localhost:9000/default?dial_timeout=1s", "localhost:9000"},
+		// This is the entire reason churl exists: net/url.Parse (>= Go
+		// 1.26) rejects commas in the host part. clickhouse-go relies on
+		// getting the raw comma-separated host string back intact so it
+		// can split it into individual addresses itself (see
+		// Options.fromDSN).
+		{"multi-host with ports", "clickhouse://host1:9000,host2:9001,host3:9000/db", "host1:9000,host2:9001,host3:9000"},
+		{"multi-host without ports", "clickhouse://host1,host2,host3/db", "host1,host2,host3"},
+		{"multi-host with auth and query", "clickhouse://user:pass@host1:9000,host2:9000/default?secure=true", "host1:9000,host2:9000"},
+		{"IPv6 with port", "clickhouse://[::1]:9000/db", "[::1]:9000"},
+		{"IPv6 without port", "clickhouse://[::1]/db", "[::1]"},
+		// RFC 6874: %25 introduces a zone identifier for a link-local
+		// address, e.g. "fe80::1%en0". The zone itself may use its own
+		// %-escaping rules.
+		{"IPv6 with zone identifier", "clickhouse://[fe80::1%25en0]:9000/db", "[fe80::1%en0]:9000"},
+		{"empty host with scheme (triple slash)", "clickhouse:///db", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := Parse(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, u.Host)
+		})
+	}
 }
 
-func TestParseMultiHostDSN(t *testing.T) {
-	// This is the entire reason churl exists: net/url.Parse (>= Go 1.26)
-	// rejects commas in the host part. clickhouse-go relies on getting the
-	// raw comma-separated host string back intact so it can split it into
-	// individual addresses itself (see Options.fromDSN).
-	u, err := Parse("clickhouse://host1:9000,host2:9001,host3:9000/db")
-	require.NoError(t, err)
-	assert.Equal(t, "host1:9000,host2:9001,host3:9000", u.Host)
-	assert.Equal(t, "/db", u.Path)
+func TestParseUserinfo(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          string
+		wantUser    string
+		wantPass    string
+		wantHasPass bool
+	}{
+		{"username and password", "clickhouse://user:pass@localhost:9000/default", "user", "pass", true},
+		// Documented quirk in parseAuthority/validUserinfo: '@' is
+		// technically a delimiter between userinfo and host, but is
+		// tolerated inside userinfo for compatibility
+		// (see https://go.dev/issue/3439). The rightmost '@' is treated as
+		// the real delimiter.
+		{"@ inside password", "http://username:p@ssword@example.com/db", "username", "p@ssword", true},
+		// validUserinfo has separate branches for A-Z, a-z, and 0-9.
+		{"uppercase and digits", "clickhouse://User123:Pass456@host/db", "User123", "Pass456", true},
+		{"username without password", "clickhouse://justuser@host/db", "justuser", "", false},
+		// '+' is only special (decodes to space) in encodeQueryComponent
+		// mode; in userinfo it stays literal even when the same string
+		// also contains a "%XX" escape that forces the unescape rebuild
+		// path to run.
+		{"literal + alongside percent escape", "clickhouse://a+b%20c:pass@host/db", "a+b c", "pass", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := Parse(tc.in)
+			require.NoError(t, err)
+			require.NotNil(t, u.User)
+			assert.Equal(t, tc.wantUser, u.User.Username())
+			pass, ok := u.User.Password()
+			assert.Equal(t, tc.wantHasPass, ok)
+			assert.Equal(t, tc.wantPass, pass)
+		})
+	}
 }
 
-func TestParseMultiHostDSNWithoutPorts(t *testing.T) {
-	u, err := Parse("clickhouse://host1,host2,host3/db")
-	require.NoError(t, err)
-	assert.Equal(t, "host1,host2,host3", u.Host)
+func TestParseSchemeAndPath(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         string
+		wantScheme string
+		wantPath   string
+		wantOpaque string
+	}{
+		// A bare "host:port" with no "//" is parsed as an opaque
+		// scheme:path, mirroring net/url's own behavior for e.g. "mailto:"
+		// style URLs. This documents that DSNs handed to fromDSN must
+		// include the "clickhouse://" (or "http(s)://") prefix or they
+		// will not parse as a Host at all.
+		{"bare host:port has no authority, becomes opaque", "localhost:9000/db", "localhost", "", "9000/db"},
+		// getScheme bails out of scheme detection as soon as it sees a
+		// character that can't start or continue one; the whole string is
+		// then treated as a relative path instead of erroring.
+		{"leading character invalid for a scheme", "@foo/bar", "", "@foo/bar", ""},
+		// A string made entirely of scheme-legal letters but with no ':'
+		// anywhere falls through getScheme's loop with no scheme found.
+		{"letters only, no colon anywhere", "abcdef", "", "abcdef", ""},
+		{"wildcard path", "*", "", "*", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := Parse(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantScheme, u.Scheme)
+			assert.Equal(t, tc.wantPath, u.Path)
+			assert.Equal(t, tc.wantOpaque, u.Opaque)
+			assert.Empty(t, u.Host)
+		})
+	}
 }
 
-func TestParseMultiHostDSNWithAuthAndQuery(t *testing.T) {
-	u, err := Parse("clickhouse://user:pass@host1:9000,host2:9000/default?secure=true")
-	require.NoError(t, err)
-	assert.Equal(t, "host1:9000,host2:9000", u.Host)
-	assert.Equal(t, "user", u.User.Username())
-	assert.Equal(t, "secure=true", u.RawQuery)
+func TestParsePathEscaping(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          string
+		wantPath    string
+		wantRawPath string
+	}{
+		// A decoded space re-escapes back to "%20" by default (space always
+		// needs escaping in a path), so the round-trip is identical and
+		// RawPath is left empty.
+		{"percent-encoded space", "clickhouse://host/my%20db", "/my db", ""},
+		// "%2F" decodes to '/', but re-escaping a decoded '/' for
+		// encodePath does not re-add the percent-encoding (a literal '/'
+		// is valid in a path), so the default escaping doesn't reproduce
+		// the original text and RawPath must be kept to preserve it.
+		{"percent-encoded slash forces RawPath", "clickhouse://host/foo%2Fbar", "/foo/bar", "/foo%2Fbar"},
+		// ishex/unhex each branch separately on lowercase vs uppercase hex
+		// digits; exercise the lowercase side ('e' in "%7e" decodes to
+		// '~', an unreserved mark character that doesn't re-escape by
+		// default, so RawPath is kept too.
+		{"lowercase hex escape", "clickhouse://host/%7e", "/~", "/%7e"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := Parse(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantPath, u.Path)
+			assert.Equal(t, tc.wantRawPath, u.RawPath)
+		})
+	}
 }
 
-func TestParseIPv6Host(t *testing.T) {
-	u, err := Parse("clickhouse://[::1]:9000/db")
-	require.NoError(t, err)
-	assert.Equal(t, "[::1]:9000", u.Host)
+func TestParseFragment(t *testing.T) {
+	cases := []struct {
+		name            string
+		in              string
+		wantFragment    string
+		wantRawFragment string
+		wantRawQuery    string
+	}{
+		{"fragment is split off from the query", "clickhouse://host/db?x=1#section", "section", "", "x=1"},
+		// setFragment only populates RawFragment when the default
+		// re-escaping of the decoded fragment would not reproduce the
+		// original text byte-for-byte (here, a literal space needs
+		// escaping to round-trip).
+		{"literal space forces RawFragment", "clickhouse://host/db#a b", "a b", "a b", ""},
+		// RFC 3986 §4.1 allows the full reserved set unescaped in a
+		// fragment; churl's shouldEscape mirrors that for encodeFragment.
+		{"reserved characters stay unescaped", "clickhouse://host/db#a=b&c", "a=b&c", "", ""},
+		{"sub-delims stay unescaped", "clickhouse://host/db#a(b)*c!d", "a(b)*c!d", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := Parse(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantFragment, u.Fragment)
+			assert.Equal(t, tc.wantRawFragment, u.RawFragment)
+			assert.Equal(t, tc.wantRawQuery, u.RawQuery)
+		})
+	}
 }
 
-func TestParseIPv6HostRejectsIPv4Literal(t *testing.T) {
-	// Per RFC 3986, only IPv6 addresses may be bracketed.
-	_, err := Parse("clickhouse://[127.0.0.1]:9000/db")
-	assert.Error(t, err)
-}
-
-func TestParseNoScheme(t *testing.T) {
-	u, err := Parse("localhost:9000/db")
-	require.NoError(t, err)
-	// A bare "host:port" with no "//" is parsed as an opaque scheme:path,
-	// mirroring net/url's own behavior for e.g. "mailto:" style URLs. This
-	// documents that DSNs handed to fromDSN must include the "clickhouse://"
-	// (or "http(s)://") prefix or they will not parse as a Host at all.
-	assert.Equal(t, "localhost", u.Scheme)
-	assert.Equal(t, "9000/db", u.Opaque)
-	assert.Empty(t, u.Host)
-}
-
-func TestParseAtSignInPassword(t *testing.T) {
-	// Documented quirk in parseAuthority/validUserinfo: '@' is technically
-	// a delimiter between userinfo and host, but is tolerated inside
-	// userinfo for compatibility (see https://go.dev/issue/3439). The
-	// rightmost '@' is treated as the real delimiter.
-	u, err := Parse("http://username:p@ssword@example.com/db")
-	require.NoError(t, err)
-	assert.Equal(t, "example.com", u.Host)
-	assert.Equal(t, "username", u.User.Username())
-	pass, ok := u.User.Password()
-	assert.True(t, ok)
-	assert.Equal(t, "p@ssword", pass)
-}
-
-func TestParseQueryParametersWithHAHosts(t *testing.T) {
-	u, err := Parse("clickhouse://host1:9440,host2:9440/default?secure=true&skip_verify=true")
-	require.NoError(t, err)
-	q := u.Query()
-	assert.Equal(t, "true", q.Get("secure"))
-	assert.Equal(t, "true", q.Get("skip_verify"))
+func TestParseOmitHost(t *testing.T) {
+	cases := []struct {
+		name         string
+		in           string
+		wantOmitHost bool
+	}{
+		{"triple slash: explicit empty authority", "clickhouse:///db", false},
+		// A single slash after the scheme (no "//" authority marker at
+		// all) sets OmitHost, distinct from an explicit-but-empty "///"
+		// authority.
+		{"single slash: no authority marker at all", "clickhouse:/db", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := Parse(tc.in)
+			require.NoError(t, err)
+			assert.Empty(t, u.Host)
+			assert.Equal(t, tc.wantOmitHost, u.OmitHost)
+			assert.Equal(t, "/db", u.Path)
+		})
+	}
 }
 
 func TestParseForceQuery(t *testing.T) {
@@ -107,296 +211,12 @@ func TestParseForceQuery(t *testing.T) {
 	assert.Empty(t, u.RawQuery)
 }
 
-func TestParseFragmentIsStripped(t *testing.T) {
-	u, err := Parse("clickhouse://host/db?x=1#section")
+func TestParseQueryParametersWithHAHosts(t *testing.T) {
+	u, err := Parse("clickhouse://host1:9440,host2:9440/default?secure=true&skip_verify=true")
 	require.NoError(t, err)
-	assert.Equal(t, "section", u.Fragment)
-	assert.Equal(t, "x=1", u.RawQuery)
-}
-
-func TestParseEscapedPath(t *testing.T) {
-	u, err := Parse("clickhouse://host/my%20db")
-	require.NoError(t, err)
-	assert.Equal(t, "/my db", u.Path)
-	assert.Equal(t, "/my%20db", u.EscapedPath())
-}
-
-func TestParseRejectsControlCharacters(t *testing.T) {
-	_, err := Parse("clickhouse://host/db\n")
-	assert.Error(t, err)
-}
-
-func TestParseRejectsMissingProtocolScheme(t *testing.T) {
-	_, err := Parse("://host/db")
-	assert.Error(t, err)
-}
-
-func TestParseRejectsInvalidPort(t *testing.T) {
-	_, err := Parse("clickhouse://host:port/db")
-	assert.Error(t, err)
-}
-
-func TestParseRejectsBadPercentEncoding(t *testing.T) {
-	_, err := Parse("clickhouse://host/%zz")
-	assert.Error(t, err)
-}
-
-func TestParseEmptyHostWithScheme(t *testing.T) {
-	u, err := Parse("clickhouse:///db")
-	require.NoError(t, err)
-	assert.Empty(t, u.Host)
-	assert.Equal(t, "/db", u.Path)
-}
-
-func TestParseOmitHostSingleSlash(t *testing.T) {
-	// A single slash after the scheme (no "//" authority marker at all)
-	// sets OmitHost, distinct from an explicit-but-empty "///" authority.
-	u, err := Parse("clickhouse:/db")
-	require.NoError(t, err)
-	assert.Empty(t, u.Host)
-	assert.True(t, u.OmitHost)
-	assert.Equal(t, "/db", u.Path)
-}
-
-func TestParseWildcard(t *testing.T) {
-	u, err := Parse("*")
-	require.NoError(t, err)
-	assert.Equal(t, "*", u.Path)
-}
-
-func TestParseFragmentUnescapeError(t *testing.T) {
-	_, err := Parse("clickhouse://host/db#%zz")
-	assert.Error(t, err)
-}
-
-func TestParseFirstPathSegmentContainsColonError(t *testing.T) {
-	// With no scheme and no leading "/", a colon in the first path segment
-	// is ambiguous with a scheme separator (RFC 3986 §3.3) and must be
-	// rejected rather than silently treated as part of the path.
-	_, err := Parse("0:foo/bar")
-	assert.ErrorContains(t, err, "first path segment in URL cannot contain colon")
-}
-
-func TestParseInvalidLeadingSchemeCharacter(t *testing.T) {
-	// getScheme bails out of scheme detection as soon as it sees a
-	// character that can't start or continue one; the whole string is then
-	// treated as a relative path instead of erroring.
-	u, err := Parse("@foo/bar")
-	require.NoError(t, err)
-	assert.Empty(t, u.Scheme)
-	assert.Equal(t, "@foo/bar", u.Path)
-}
-
-func TestParseRelativePathNoScheme(t *testing.T) {
-	// A string made entirely of scheme-legal letters but with no ':'
-	// anywhere falls through getScheme's loop with no scheme found.
-	u, err := Parse("abcdef")
-	require.NoError(t, err)
-	assert.Empty(t, u.Scheme)
-	assert.Equal(t, "abcdef", u.Path)
-}
-
-func TestParseInvalidUserinfoCharacter(t *testing.T) {
-	_, err := Parse("clickhouse://user name@host/db")
-	assert.ErrorContains(t, err, "invalid userinfo")
-}
-
-func TestParseUserinfoWithUppercaseAndDigits(t *testing.T) {
-	// validUserinfo has separate branches for A-Z, a-z, and 0-9; exercise
-	// all three (lowercase already covered by other tests in this file).
-	u, err := Parse("clickhouse://User123:Pass456@host/db")
-	require.NoError(t, err)
-	assert.Equal(t, "User123", u.User.Username())
-	pass, ok := u.User.Password()
-	assert.True(t, ok)
-	assert.Equal(t, "Pass456", pass)
-}
-
-func TestParseUserinfoWithoutPassword(t *testing.T) {
-	u, err := Parse("clickhouse://justuser@host/db")
-	require.NoError(t, err)
-	assert.Equal(t, "justuser", u.User.Username())
-	_, ok := u.User.Password()
-	assert.False(t, ok)
-}
-
-func TestParseUsernameUnescapeError(t *testing.T) {
-	_, err := Parse("clickhouse://%zz:pass@host/db")
-	assert.Error(t, err)
-}
-
-func TestParsePasswordUnescapeError(t *testing.T) {
-	_, err := Parse("clickhouse://user:%zz@host/db")
-	assert.Error(t, err)
-}
-
-func TestParseIPv6MissingCloseBracket(t *testing.T) {
-	_, err := Parse("clickhouse://[::1/db")
-	assert.ErrorContains(t, err, "missing ']' in host")
-}
-
-func TestParseIPv6InvalidPort(t *testing.T) {
-	_, err := Parse("clickhouse://[::1]:abc/db")
-	assert.ErrorContains(t, err, "invalid port")
-}
-
-func TestParseIPv6ZoneIdentifier(t *testing.T) {
-	// RFC 6874: %25 introduces a zone identifier for a link-local address,
-	// e.g. "fe80::1%en0". The zone itself may use its own %-escaping rules.
-	u, err := Parse("clickhouse://[fe80::1%25en0]:9000/db")
-	require.NoError(t, err)
-	assert.Equal(t, "[fe80::1%en0]:9000", u.Host)
-}
-
-func TestParseIPv6HostnameUnescapeError(t *testing.T) {
-	// No "%25" zone marker present, so the whole bracketed hostname goes
-	// through the plain (non-zone) unescape path, which must still reject
-	// malformed escapes.
-	_, err := Parse("clickhouse://[fe80::1%zz]:9000/db")
-	assert.Error(t, err)
-}
-
-func TestParseIPv6ZoneRejectsDisallowedEscape(t *testing.T) {
-	// Inside a zone identifier, only "%25" itself and escapes that decode
-	// to characters already valid unescaped in a host are allowed. "%2F"
-	// decodes to '/', which must stay escaped, so this is rejected.
-	_, err := Parse("clickhouse://[fe80::1%25%2F]:9000/db")
-	assert.Error(t, err)
-}
-
-func TestParseIPv6InvalidAddress(t *testing.T) {
-	_, err := Parse("clickhouse://[not-an-ip]:9000/db")
-	assert.ErrorContains(t, err, "invalid host")
-}
-
-func TestParseIPv6NoPort(t *testing.T) {
-	u, err := Parse("clickhouse://[::1]/db")
-	require.NoError(t, err)
-	assert.Equal(t, "[::1]", u.Host)
-}
-
-func TestParseIPv6TrailingGarbageAfterBracket(t *testing.T) {
-	// Anything after the closing "]" that isn't a valid ":port" is rejected.
-	_, err := Parse("clickhouse://[::1]xyz/db")
-	assert.ErrorContains(t, err, "invalid port")
-}
-
-func TestParseHostUnescapeError(t *testing.T) {
-	// Plain (non-bracketed) host, no port: goes through parseHost's final
-	// unescape call.
-	_, err := Parse("clickhouse://%zz/db")
-	assert.Error(t, err)
-}
-
-func TestParseHostRejectsLowByteEscape(t *testing.T) {
-	// Per RFC 3986 §3.2.2, %-encoding in a plain host component is only
-	// meaningful for non-ASCII bytes; encoding an ASCII byte below 0x80
-	// (other than via the reserved "%25") is rejected even though "%01" is
-	// syntactically well-formed hex.
-	_, err := Parse("clickhouse://%01host/db")
-	assert.Error(t, err)
-}
-
-func TestParseTruncatesLongMalformedEscapeInErrorMessage(t *testing.T) {
-	// unescape's error message is capped at 3 characters so a long garbage
-	// tail after a bad "%" doesn't get echoed back in full.
-	_, err := Parse("clickhouse://host/%2zzzz")
-	assert.ErrorContains(t, err, `"%2z"`)
-}
-
-func TestParseFragmentSetsRawFragmentWhenEscapingDiffers(t *testing.T) {
-	// setFragment only populates RawFragment when the default re-escaping
-	// of the decoded fragment would not reproduce the original text
-	// byte-for-byte (here, a literal space needs escaping to round-trip).
-	u, err := Parse("clickhouse://host/db#a b")
-	require.NoError(t, err)
-	assert.Equal(t, "a b", u.Fragment)
-	assert.Equal(t, "a b", u.RawFragment)
-}
-
-func TestParsePathSetsRawPathWhenEscapingDiffers(t *testing.T) {
-	// "%2F" decodes to '/', but re-escaping a decoded '/' for encodePath
-	// does not re-add the percent-encoding (a literal '/' is valid in a
-	// path), so the default escaping doesn't reproduce the original text
-	// and RawPath must be kept to preserve it.
-	u, err := Parse("clickhouse://host/foo%2Fbar")
-	require.NoError(t, err)
-	assert.Equal(t, "/foo/bar", u.Path)
-	assert.Equal(t, "/foo%2Fbar", u.RawPath)
-}
-
-func TestParseViaRequestEmptyURL(t *testing.T) {
-	// parse's viaRequest flag is dead from Parse's perspective (always
-	// called with viaRequest=false) but is retained from the net/url fork;
-	// call it directly to pin down its behavior.
-	_, err := parse("", true)
-	assert.ErrorContains(t, err, "empty url")
-}
-
-func TestParseViaRequestRelativePath(t *testing.T) {
-	_, err := parse("relative/path", true)
-	assert.ErrorContains(t, err, "invalid URI for request")
-}
-
-func TestUnescapeQueryComponentPlusBecomesSpace(t *testing.T) {
-	// encodeQueryComponent is defined for API parity with net/url but is
-	// never actually passed to unescape/escape from within this package —
-	// RawQuery is handled by the stdlib net/url.Values parser instead.
-	// Exercise it directly so the behavior is pinned down regardless.
-	got, err := unescape("a+b", encodeQueryComponent)
-	require.NoError(t, err)
-	assert.Equal(t, "a b", got)
-}
-
-func TestUnescapePlusIsLiteralOutsideQueryComponent(t *testing.T) {
-	got, err := unescape("a+b", encodePath)
-	require.NoError(t, err)
-	assert.Equal(t, "a+b", got)
-}
-
-func TestEscapeQueryComponentSpaceAndHexMixed(t *testing.T) {
-	// When a query-component string needs both a "+"-for-space substitution
-	// and a "%XX" escape in the same string, both must apply correctly.
-	got := escape("a b?c", encodeQueryComponent)
-	assert.Equal(t, "a+b%3Fc", got)
-}
-
-func TestEscapeNoCharactersNeedEscaping(t *testing.T) {
-	got := escape("abc123-_.~", encodePath)
-	assert.Equal(t, "abc123-_.~", got)
-}
-
-func TestParseUsernameOnlyUnescapeError(t *testing.T) {
-	// No ':' in the userinfo (username only, no password): a distinct
-	// unescape call site from the username+password case.
-	_, err := Parse("clickhouse://%zz@host/db")
-	assert.Error(t, err)
-}
-
-func TestParseIPv6ZoneHostPartUnescapeError(t *testing.T) {
-	// The portion of the bracketed hostname *before* the "%25" zone marker
-	// is unescaped separately from the zone itself; a bad escape there must
-	// also be rejected.
-	_, err := Parse("clickhouse://[%zz%25en0]:9000/db")
-	assert.Error(t, err)
-}
-
-func TestParseHostLiteralCharacterNeedingEscape(t *testing.T) {
-	// A literal (non-percent-encoded) byte that isn't valid in a host
-	// (here, a space) must be rejected outright rather than silently
-	// accepted — hosts can't %-encode ASCII bytes themselves, so there's no
-	// way to "fix" this by escaping it after the fact.
-	_, err := Parse("clickhouse://ho st/db")
-	assert.Error(t, err)
-}
-
-func TestParseUsernameLiteralPlusSurvivesAlongsidePercentEscape(t *testing.T) {
-	// '+' is only special (decodes to space) in encodeQueryComponent mode;
-	// in userinfo it stays literal even when the same string also contains
-	// a "%XX" escape that forces the unescape rebuild path to run.
-	u, err := Parse("clickhouse://a+b%20c:pass@host/db")
-	require.NoError(t, err)
-	assert.Equal(t, "a+b c", u.User.Username())
+	q := u.Query()
+	assert.Equal(t, "true", q.Get("secure"))
+	assert.Equal(t, "true", q.Get("skip_verify"))
 }
 
 func TestEscapeLongStringExceedsStackBuffer(t *testing.T) {
@@ -410,52 +230,151 @@ func TestEscapeLongStringExceedsStackBuffer(t *testing.T) {
 	assert.Equal(t, frag, u.Fragment)
 }
 
-func TestEscapeQueryComponentSpacesOnlyNoHexNeeded(t *testing.T) {
-	// Distinct from TestEscapeQueryComponentSpaceAndHexMixed: when *only*
-	// spaces need escaping (hexCount stays 0), escape takes a separate,
-	// cheaper "+"-substitution-only code path.
-	got := escape("a b c", encodeQueryComponent)
-	assert.Equal(t, "a+b+c", got)
+func TestParseErrors(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     string
+		errMsg string // substring expected in the error; "" only checks non-nil
+	}{
+		{"malformed percent-encoding in fragment", "clickhouse://host/db#%zz", ""},
+		// With no scheme and no leading "/", a colon in the first path
+		// segment is ambiguous with a scheme separator (RFC 3986 §3.3) and
+		// must be rejected rather than silently treated as part of the path.
+		{"first path segment with colon and no scheme", "0:foo/bar", "first path segment in URL cannot contain colon"},
+		{"userinfo contains an invalid character", "clickhouse://user name@host/db", "invalid userinfo"},
+		{"username has malformed percent-encoding, with password", "clickhouse://%zz:pass@host/db", ""},
+		{"password has malformed percent-encoding", "clickhouse://user:%zz@host/db", ""},
+		{"username has malformed percent-encoding, no password", "clickhouse://%zz@host/db", ""},
+		{"IPv6 host missing closing bracket", "clickhouse://[::1/db", "missing ']' in host"},
+		{"IPv6 host has an invalid port", "clickhouse://[::1]:abc/db", "invalid port"},
+		{"IPv6 hostname has malformed percent-encoding, no zone", "clickhouse://[fe80::1%zz]:9000/db", ""},
+		// Inside a zone identifier, only "%25" itself and escapes that
+		// decode to characters already valid unescaped in a host are
+		// allowed. "%2F" decodes to '/', which must stay escaped.
+		{"IPv6 zone rejects a disallowed escape", "clickhouse://[fe80::1%25%2F]:9000/db", ""},
+		// The portion of the bracketed hostname before the "%25" zone
+		// marker is unescaped separately from the zone itself.
+		{"IPv6 zone's host-part has malformed percent-encoding", "clickhouse://[%zz%25en0]:9000/db", ""},
+		{"IPv6 literal is not a valid address", "clickhouse://[not-an-ip]:9000/db", "invalid host"},
+		// Per RFC 3986, only IPv6 addresses may be bracketed.
+		{"IPv6 brackets around an IPv4 literal are rejected", "clickhouse://[127.0.0.1]:9000/db", "invalid IP-literal"},
+		{"IPv6 host has trailing garbage after the bracket", "clickhouse://[::1]xyz/db", "invalid port"},
+		{"plain host has malformed percent-encoding", "clickhouse://%zz/db", ""},
+		// Per RFC 3986 §3.2.2, %-encoding in a plain host component is
+		// only meaningful for non-ASCII bytes; encoding an ASCII byte
+		// below 0x80 (other than via the reserved "%25") is rejected even
+		// though "%01" is syntactically well-formed hex.
+		{"plain host rejects a low-byte percent-escape", "clickhouse://%01host/db", ""},
+		// A literal (non-percent-encoded) byte that isn't valid in a host
+		// (here, a space) must be rejected outright: hosts can't
+		// %-encode ASCII bytes themselves, so there's no way to "fix"
+		// this by escaping it after the fact.
+		{"plain host rejects a literal character needing escape", "clickhouse://ho st/db", ""},
+		// unescape's error message is capped at 3 characters so a long
+		// garbage tail after a bad "%" doesn't get echoed back in full.
+		{"long malformed escape is truncated in the error message", "clickhouse://host/%2zzzz", `"%2z"`},
+		{"control character in URL", "clickhouse://host/db\n", ""},
+		{"missing protocol scheme", "://host/db", ""},
+		{"non-numeric port", "clickhouse://host:port/db", ""},
+		{"malformed percent-encoding in path", "clickhouse://host/%zz", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse(tc.in)
+			require.Error(t, err)
+			if tc.errMsg != "" {
+				assert.ErrorContains(t, err, tc.errMsg)
+			}
+		})
+	}
 }
 
-func TestParseFragmentReservedCharactersStayUnescaped(t *testing.T) {
-	// RFC 3986 §4.1 allows the full reserved set unescaped in a fragment;
-	// churl's shouldEscape mirrors that for the encodeFragment mode.
-	u, err := Parse("clickhouse://host/db#a=b&c")
-	require.NoError(t, err)
-	assert.Equal(t, "a=b&c", u.Fragment)
-	assert.Empty(t, u.RawFragment)
+func TestParseViaRequest(t *testing.T) {
+	// parse's viaRequest flag is dead from Parse's perspective (always
+	// called with viaRequest=false) but is retained from the net/url fork;
+	// call it directly to pin down its behavior.
+	cases := []struct {
+		name   string
+		in     string
+		errMsg string
+	}{
+		{"empty URL", "", "empty url"},
+		{"relative path without leading slash", "relative/path", "invalid URI for request"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parse(tc.in, true)
+			assert.ErrorContains(t, err, tc.errMsg)
+		})
+	}
 }
 
-func TestParseFragmentSubDelimsStayUnescaped(t *testing.T) {
-	u, err := Parse("clickhouse://host/db#a(b)*c!d")
-	require.NoError(t, err)
-	assert.Equal(t, "a(b)*c!d", u.Fragment)
-	assert.Empty(t, u.RawFragment)
+func TestUnescape(t *testing.T) {
+	// encodeQueryComponent is defined for API parity with net/url but is
+	// never actually passed to unescape/escape from within this package —
+	// RawQuery is handled by the stdlib net/url.Values parser instead.
+	// Exercise it directly so the behavior is pinned down regardless.
+	cases := []struct {
+		name string
+		in   string
+		mode encoding
+		want string
+	}{
+		{"+ becomes space in query-component mode", "a+b", encodeQueryComponent, "a b"},
+		{"+ stays literal outside query-component mode", "a+b", encodePath, "a+b"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := unescape(tc.in, tc.mode)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }
 
-func TestParseLowercaseHexEscape(t *testing.T) {
-	// ishex/unhex each branch separately on lowercase vs uppercase hex
-	// digits; exercise the lowercase side ('e' in "%7e" decodes to '~').
-	u, err := Parse("clickhouse://host/%7e")
-	require.NoError(t, err)
-	assert.Equal(t, "/~", u.Path)
+func TestEscape(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		mode encoding
+		want string
+	}{
+		{"no characters need escaping", "abc123-_.~", encodePath, "abc123-_.~"},
+		// When only spaces need escaping (hexCount stays 0), escape takes
+		// a separate, cheaper "+"-substitution-only code path.
+		{"query-component spaces only, no hex needed", "a b c", encodeQueryComponent, "a+b+c"},
+		// A "+"-for-space substitution and a "%XX" escape can both be
+		// needed in the same string; both must apply correctly together.
+		{"query-component space and hex escape mixed", "a b?c", encodeQueryComponent, "a+b%3Fc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, escape(tc.in, tc.mode))
+		})
+	}
 }
 
-func TestShouldEscapePathSegmentReservedCharacters(t *testing.T) {
-	// encodePathSegment is defined for API parity with net/url but churl
-	// never actually calls escape/shouldEscape with it (only encodePath is
-	// used, for the path as a whole). Exercise it directly.
-	assert.True(t, shouldEscape('/', encodePathSegment))
-	assert.False(t, shouldEscape('@', encodePathSegment))
-}
-
-func TestShouldEscapeUserPasswordReservedCharacters(t *testing.T) {
-	// Similarly, encodeUserPassword is only ever passed to unescape (for
-	// userinfo), never to escape/shouldEscape, since churl never
-	// re-encodes a Userinfo back into a URL string. Exercise it directly.
-	assert.True(t, shouldEscape('@', encodeUserPassword))
-	assert.False(t, shouldEscape('$', encodeUserPassword))
+func TestShouldEscape(t *testing.T) {
+	// encodePathSegment and encodeUserPassword are defined for API parity
+	// with net/url but churl never actually calls escape/shouldEscape with
+	// them (only encodePath is used for escaping, and encodeUserPassword is
+	// only ever passed to unescape, never escape). Exercise them directly.
+	cases := []struct {
+		name string
+		c    byte
+		mode encoding
+		want bool
+	}{
+		{"path segment: slash must be escaped", '/', encodePathSegment, true},
+		{"path segment: @ need not be escaped", '@', encodePathSegment, false},
+		{"user/password: @ must be escaped", '@', encodeUserPassword, true},
+		{"user/password: $ need not be escaped", '$', encodeUserPassword, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, shouldEscape(tc.c, tc.mode))
+		})
+	}
 }
 
 func TestUnhexPanicsOnInvalidHexCharacter(t *testing.T) {

--- a/lib/churl/churl_test.go
+++ b/lib/churl/churl_test.go
@@ -1,0 +1,469 @@
+package churl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Parse is a fork of net/url.Parse modified to accept multiple comma
+// separated hosts in the authority (e.g. "host1:9000,host2:9000") for
+// ClickHouse HA DSNs — something the stdlib parser stopped allowing after
+// Go 1.26 (golang.org/issue/75859). clickhouse_options.go's DSN parser is
+// the sole caller, so a regression here breaks every multi-host connection
+// string silently or loudly, depending on the bug.
+
+func TestParseBasicDSN(t *testing.T) {
+	u, err := Parse("clickhouse://user:pass@localhost:9000/default?dial_timeout=1s")
+	require.NoError(t, err)
+	assert.Equal(t, "clickhouse", u.Scheme)
+	assert.Equal(t, "localhost:9000", u.Host)
+	assert.Equal(t, "/default", u.Path)
+	assert.Equal(t, "dial_timeout=1s", u.RawQuery)
+	require.NotNil(t, u.User)
+	assert.Equal(t, "user", u.User.Username())
+	pass, ok := u.User.Password()
+	assert.True(t, ok)
+	assert.Equal(t, "pass", pass)
+}
+
+func TestParseMultiHostDSN(t *testing.T) {
+	// This is the entire reason churl exists: net/url.Parse (>= Go 1.26)
+	// rejects commas in the host part. clickhouse-go relies on getting the
+	// raw comma-separated host string back intact so it can split it into
+	// individual addresses itself (see Options.fromDSN).
+	u, err := Parse("clickhouse://host1:9000,host2:9001,host3:9000/db")
+	require.NoError(t, err)
+	assert.Equal(t, "host1:9000,host2:9001,host3:9000", u.Host)
+	assert.Equal(t, "/db", u.Path)
+}
+
+func TestParseMultiHostDSNWithoutPorts(t *testing.T) {
+	u, err := Parse("clickhouse://host1,host2,host3/db")
+	require.NoError(t, err)
+	assert.Equal(t, "host1,host2,host3", u.Host)
+}
+
+func TestParseMultiHostDSNWithAuthAndQuery(t *testing.T) {
+	u, err := Parse("clickhouse://user:pass@host1:9000,host2:9000/default?secure=true")
+	require.NoError(t, err)
+	assert.Equal(t, "host1:9000,host2:9000", u.Host)
+	assert.Equal(t, "user", u.User.Username())
+	assert.Equal(t, "secure=true", u.RawQuery)
+}
+
+func TestParseIPv6Host(t *testing.T) {
+	u, err := Parse("clickhouse://[::1]:9000/db")
+	require.NoError(t, err)
+	assert.Equal(t, "[::1]:9000", u.Host)
+}
+
+func TestParseIPv6HostRejectsIPv4Literal(t *testing.T) {
+	// Per RFC 3986, only IPv6 addresses may be bracketed.
+	_, err := Parse("clickhouse://[127.0.0.1]:9000/db")
+	assert.Error(t, err)
+}
+
+func TestParseNoScheme(t *testing.T) {
+	u, err := Parse("localhost:9000/db")
+	require.NoError(t, err)
+	// A bare "host:port" with no "//" is parsed as an opaque scheme:path,
+	// mirroring net/url's own behavior for e.g. "mailto:" style URLs. This
+	// documents that DSNs handed to fromDSN must include the "clickhouse://"
+	// (or "http(s)://") prefix or they will not parse as a Host at all.
+	assert.Equal(t, "localhost", u.Scheme)
+	assert.Equal(t, "9000/db", u.Opaque)
+	assert.Empty(t, u.Host)
+}
+
+func TestParseAtSignInPassword(t *testing.T) {
+	// Documented quirk in parseAuthority/validUserinfo: '@' is technically
+	// a delimiter between userinfo and host, but is tolerated inside
+	// userinfo for compatibility (see https://go.dev/issue/3439). The
+	// rightmost '@' is treated as the real delimiter.
+	u, err := Parse("http://username:p@ssword@example.com/db")
+	require.NoError(t, err)
+	assert.Equal(t, "example.com", u.Host)
+	assert.Equal(t, "username", u.User.Username())
+	pass, ok := u.User.Password()
+	assert.True(t, ok)
+	assert.Equal(t, "p@ssword", pass)
+}
+
+func TestParseQueryParametersWithHAHosts(t *testing.T) {
+	u, err := Parse("clickhouse://host1:9440,host2:9440/default?secure=true&skip_verify=true")
+	require.NoError(t, err)
+	q := u.Query()
+	assert.Equal(t, "true", q.Get("secure"))
+	assert.Equal(t, "true", q.Get("skip_verify"))
+}
+
+func TestParseForceQuery(t *testing.T) {
+	u, err := Parse("clickhouse://host/db?")
+	require.NoError(t, err)
+	assert.True(t, u.ForceQuery)
+	assert.Empty(t, u.RawQuery)
+}
+
+func TestParseFragmentIsStripped(t *testing.T) {
+	u, err := Parse("clickhouse://host/db?x=1#section")
+	require.NoError(t, err)
+	assert.Equal(t, "section", u.Fragment)
+	assert.Equal(t, "x=1", u.RawQuery)
+}
+
+func TestParseEscapedPath(t *testing.T) {
+	u, err := Parse("clickhouse://host/my%20db")
+	require.NoError(t, err)
+	assert.Equal(t, "/my db", u.Path)
+	assert.Equal(t, "/my%20db", u.EscapedPath())
+}
+
+func TestParseRejectsControlCharacters(t *testing.T) {
+	_, err := Parse("clickhouse://host/db\n")
+	assert.Error(t, err)
+}
+
+func TestParseRejectsMissingProtocolScheme(t *testing.T) {
+	_, err := Parse("://host/db")
+	assert.Error(t, err)
+}
+
+func TestParseRejectsInvalidPort(t *testing.T) {
+	_, err := Parse("clickhouse://host:port/db")
+	assert.Error(t, err)
+}
+
+func TestParseRejectsBadPercentEncoding(t *testing.T) {
+	_, err := Parse("clickhouse://host/%zz")
+	assert.Error(t, err)
+}
+
+func TestParseEmptyHostWithScheme(t *testing.T) {
+	u, err := Parse("clickhouse:///db")
+	require.NoError(t, err)
+	assert.Empty(t, u.Host)
+	assert.Equal(t, "/db", u.Path)
+}
+
+func TestParseOmitHostSingleSlash(t *testing.T) {
+	// A single slash after the scheme (no "//" authority marker at all)
+	// sets OmitHost, distinct from an explicit-but-empty "///" authority.
+	u, err := Parse("clickhouse:/db")
+	require.NoError(t, err)
+	assert.Empty(t, u.Host)
+	assert.True(t, u.OmitHost)
+	assert.Equal(t, "/db", u.Path)
+}
+
+func TestParseWildcard(t *testing.T) {
+	u, err := Parse("*")
+	require.NoError(t, err)
+	assert.Equal(t, "*", u.Path)
+}
+
+func TestParseFragmentUnescapeError(t *testing.T) {
+	_, err := Parse("clickhouse://host/db#%zz")
+	assert.Error(t, err)
+}
+
+func TestParseFirstPathSegmentContainsColonError(t *testing.T) {
+	// With no scheme and no leading "/", a colon in the first path segment
+	// is ambiguous with a scheme separator (RFC 3986 §3.3) and must be
+	// rejected rather than silently treated as part of the path.
+	_, err := Parse("0:foo/bar")
+	assert.ErrorContains(t, err, "first path segment in URL cannot contain colon")
+}
+
+func TestParseInvalidLeadingSchemeCharacter(t *testing.T) {
+	// getScheme bails out of scheme detection as soon as it sees a
+	// character that can't start or continue one; the whole string is then
+	// treated as a relative path instead of erroring.
+	u, err := Parse("@foo/bar")
+	require.NoError(t, err)
+	assert.Empty(t, u.Scheme)
+	assert.Equal(t, "@foo/bar", u.Path)
+}
+
+func TestParseRelativePathNoScheme(t *testing.T) {
+	// A string made entirely of scheme-legal letters but with no ':'
+	// anywhere falls through getScheme's loop with no scheme found.
+	u, err := Parse("abcdef")
+	require.NoError(t, err)
+	assert.Empty(t, u.Scheme)
+	assert.Equal(t, "abcdef", u.Path)
+}
+
+func TestParseInvalidUserinfoCharacter(t *testing.T) {
+	_, err := Parse("clickhouse://user name@host/db")
+	assert.ErrorContains(t, err, "invalid userinfo")
+}
+
+func TestParseUserinfoWithUppercaseAndDigits(t *testing.T) {
+	// validUserinfo has separate branches for A-Z, a-z, and 0-9; exercise
+	// all three (lowercase already covered by other tests in this file).
+	u, err := Parse("clickhouse://User123:Pass456@host/db")
+	require.NoError(t, err)
+	assert.Equal(t, "User123", u.User.Username())
+	pass, ok := u.User.Password()
+	assert.True(t, ok)
+	assert.Equal(t, "Pass456", pass)
+}
+
+func TestParseUserinfoWithoutPassword(t *testing.T) {
+	u, err := Parse("clickhouse://justuser@host/db")
+	require.NoError(t, err)
+	assert.Equal(t, "justuser", u.User.Username())
+	_, ok := u.User.Password()
+	assert.False(t, ok)
+}
+
+func TestParseUsernameUnescapeError(t *testing.T) {
+	_, err := Parse("clickhouse://%zz:pass@host/db")
+	assert.Error(t, err)
+}
+
+func TestParsePasswordUnescapeError(t *testing.T) {
+	_, err := Parse("clickhouse://user:%zz@host/db")
+	assert.Error(t, err)
+}
+
+func TestParseIPv6MissingCloseBracket(t *testing.T) {
+	_, err := Parse("clickhouse://[::1/db")
+	assert.ErrorContains(t, err, "missing ']' in host")
+}
+
+func TestParseIPv6InvalidPort(t *testing.T) {
+	_, err := Parse("clickhouse://[::1]:abc/db")
+	assert.ErrorContains(t, err, "invalid port")
+}
+
+func TestParseIPv6ZoneIdentifier(t *testing.T) {
+	// RFC 6874: %25 introduces a zone identifier for a link-local address,
+	// e.g. "fe80::1%en0". The zone itself may use its own %-escaping rules.
+	u, err := Parse("clickhouse://[fe80::1%25en0]:9000/db")
+	require.NoError(t, err)
+	assert.Equal(t, "[fe80::1%en0]:9000", u.Host)
+}
+
+func TestParseIPv6HostnameUnescapeError(t *testing.T) {
+	// No "%25" zone marker present, so the whole bracketed hostname goes
+	// through the plain (non-zone) unescape path, which must still reject
+	// malformed escapes.
+	_, err := Parse("clickhouse://[fe80::1%zz]:9000/db")
+	assert.Error(t, err)
+}
+
+func TestParseIPv6ZoneRejectsDisallowedEscape(t *testing.T) {
+	// Inside a zone identifier, only "%25" itself and escapes that decode
+	// to characters already valid unescaped in a host are allowed. "%2F"
+	// decodes to '/', which must stay escaped, so this is rejected.
+	_, err := Parse("clickhouse://[fe80::1%25%2F]:9000/db")
+	assert.Error(t, err)
+}
+
+func TestParseIPv6InvalidAddress(t *testing.T) {
+	_, err := Parse("clickhouse://[not-an-ip]:9000/db")
+	assert.ErrorContains(t, err, "invalid host")
+}
+
+func TestParseIPv6NoPort(t *testing.T) {
+	u, err := Parse("clickhouse://[::1]/db")
+	require.NoError(t, err)
+	assert.Equal(t, "[::1]", u.Host)
+}
+
+func TestParseIPv6TrailingGarbageAfterBracket(t *testing.T) {
+	// Anything after the closing "]" that isn't a valid ":port" is rejected.
+	_, err := Parse("clickhouse://[::1]xyz/db")
+	assert.ErrorContains(t, err, "invalid port")
+}
+
+func TestParseHostUnescapeError(t *testing.T) {
+	// Plain (non-bracketed) host, no port: goes through parseHost's final
+	// unescape call.
+	_, err := Parse("clickhouse://%zz/db")
+	assert.Error(t, err)
+}
+
+func TestParseHostRejectsLowByteEscape(t *testing.T) {
+	// Per RFC 3986 §3.2.2, %-encoding in a plain host component is only
+	// meaningful for non-ASCII bytes; encoding an ASCII byte below 0x80
+	// (other than via the reserved "%25") is rejected even though "%01" is
+	// syntactically well-formed hex.
+	_, err := Parse("clickhouse://%01host/db")
+	assert.Error(t, err)
+}
+
+func TestParseTruncatesLongMalformedEscapeInErrorMessage(t *testing.T) {
+	// unescape's error message is capped at 3 characters so a long garbage
+	// tail after a bad "%" doesn't get echoed back in full.
+	_, err := Parse("clickhouse://host/%2zzzz")
+	assert.ErrorContains(t, err, `"%2z"`)
+}
+
+func TestParseFragmentSetsRawFragmentWhenEscapingDiffers(t *testing.T) {
+	// setFragment only populates RawFragment when the default re-escaping
+	// of the decoded fragment would not reproduce the original text
+	// byte-for-byte (here, a literal space needs escaping to round-trip).
+	u, err := Parse("clickhouse://host/db#a b")
+	require.NoError(t, err)
+	assert.Equal(t, "a b", u.Fragment)
+	assert.Equal(t, "a b", u.RawFragment)
+}
+
+func TestParsePathSetsRawPathWhenEscapingDiffers(t *testing.T) {
+	// "%2F" decodes to '/', but re-escaping a decoded '/' for encodePath
+	// does not re-add the percent-encoding (a literal '/' is valid in a
+	// path), so the default escaping doesn't reproduce the original text
+	// and RawPath must be kept to preserve it.
+	u, err := Parse("clickhouse://host/foo%2Fbar")
+	require.NoError(t, err)
+	assert.Equal(t, "/foo/bar", u.Path)
+	assert.Equal(t, "/foo%2Fbar", u.RawPath)
+}
+
+func TestParseViaRequestEmptyURL(t *testing.T) {
+	// parse's viaRequest flag is dead from Parse's perspective (always
+	// called with viaRequest=false) but is retained from the net/url fork;
+	// call it directly to pin down its behavior.
+	_, err := parse("", true)
+	assert.ErrorContains(t, err, "empty url")
+}
+
+func TestParseViaRequestRelativePath(t *testing.T) {
+	_, err := parse("relative/path", true)
+	assert.ErrorContains(t, err, "invalid URI for request")
+}
+
+func TestUnescapeQueryComponentPlusBecomesSpace(t *testing.T) {
+	// encodeQueryComponent is defined for API parity with net/url but is
+	// never actually passed to unescape/escape from within this package —
+	// RawQuery is handled by the stdlib net/url.Values parser instead.
+	// Exercise it directly so the behavior is pinned down regardless.
+	got, err := unescape("a+b", encodeQueryComponent)
+	require.NoError(t, err)
+	assert.Equal(t, "a b", got)
+}
+
+func TestUnescapePlusIsLiteralOutsideQueryComponent(t *testing.T) {
+	got, err := unescape("a+b", encodePath)
+	require.NoError(t, err)
+	assert.Equal(t, "a+b", got)
+}
+
+func TestEscapeQueryComponentSpaceAndHexMixed(t *testing.T) {
+	// When a query-component string needs both a "+"-for-space substitution
+	// and a "%XX" escape in the same string, both must apply correctly.
+	got := escape("a b?c", encodeQueryComponent)
+	assert.Equal(t, "a+b%3Fc", got)
+}
+
+func TestEscapeNoCharactersNeedEscaping(t *testing.T) {
+	got := escape("abc123-_.~", encodePath)
+	assert.Equal(t, "abc123-_.~", got)
+}
+
+func TestParseUsernameOnlyUnescapeError(t *testing.T) {
+	// No ':' in the userinfo (username only, no password): a distinct
+	// unescape call site from the username+password case.
+	_, err := Parse("clickhouse://%zz@host/db")
+	assert.Error(t, err)
+}
+
+func TestParseIPv6ZoneHostPartUnescapeError(t *testing.T) {
+	// The portion of the bracketed hostname *before* the "%25" zone marker
+	// is unescaped separately from the zone itself; a bad escape there must
+	// also be rejected.
+	_, err := Parse("clickhouse://[%zz%25en0]:9000/db")
+	assert.Error(t, err)
+}
+
+func TestParseHostLiteralCharacterNeedingEscape(t *testing.T) {
+	// A literal (non-percent-encoded) byte that isn't valid in a host
+	// (here, a space) must be rejected outright rather than silently
+	// accepted — hosts can't %-encode ASCII bytes themselves, so there's no
+	// way to "fix" this by escaping it after the fact.
+	_, err := Parse("clickhouse://ho st/db")
+	assert.Error(t, err)
+}
+
+func TestParseUsernameLiteralPlusSurvivesAlongsidePercentEscape(t *testing.T) {
+	// '+' is only special (decodes to space) in encodeQueryComponent mode;
+	// in userinfo it stays literal even when the same string also contains
+	// a "%XX" escape that forces the unescape rebuild path to run.
+	u, err := Parse("clickhouse://a+b%20c:pass@host/db")
+	require.NoError(t, err)
+	assert.Equal(t, "a+b c", u.User.Username())
+}
+
+func TestEscapeLongStringExceedsStackBuffer(t *testing.T) {
+	// escape() tries to use a fixed 64-byte stack buffer first and falls
+	// back to a heap allocation once the escaped output would be longer
+	// than that. Force the fallback with a fragment long enough that its
+	// escaped form (3 bytes per escaped char) exceeds 64 bytes.
+	frag := strings.Repeat(" ", 30) // each space becomes "%20" -> 90 bytes
+	u, err := Parse("clickhouse://host/db#" + frag)
+	require.NoError(t, err)
+	assert.Equal(t, frag, u.Fragment)
+}
+
+func TestEscapeQueryComponentSpacesOnlyNoHexNeeded(t *testing.T) {
+	// Distinct from TestEscapeQueryComponentSpaceAndHexMixed: when *only*
+	// spaces need escaping (hexCount stays 0), escape takes a separate,
+	// cheaper "+"-substitution-only code path.
+	got := escape("a b c", encodeQueryComponent)
+	assert.Equal(t, "a+b+c", got)
+}
+
+func TestParseFragmentReservedCharactersStayUnescaped(t *testing.T) {
+	// RFC 3986 §4.1 allows the full reserved set unescaped in a fragment;
+	// churl's shouldEscape mirrors that for the encodeFragment mode.
+	u, err := Parse("clickhouse://host/db#a=b&c")
+	require.NoError(t, err)
+	assert.Equal(t, "a=b&c", u.Fragment)
+	assert.Empty(t, u.RawFragment)
+}
+
+func TestParseFragmentSubDelimsStayUnescaped(t *testing.T) {
+	u, err := Parse("clickhouse://host/db#a(b)*c!d")
+	require.NoError(t, err)
+	assert.Equal(t, "a(b)*c!d", u.Fragment)
+	assert.Empty(t, u.RawFragment)
+}
+
+func TestParseLowercaseHexEscape(t *testing.T) {
+	// ishex/unhex each branch separately on lowercase vs uppercase hex
+	// digits; exercise the lowercase side ('e' in "%7e" decodes to '~').
+	u, err := Parse("clickhouse://host/%7e")
+	require.NoError(t, err)
+	assert.Equal(t, "/~", u.Path)
+}
+
+func TestShouldEscapePathSegmentReservedCharacters(t *testing.T) {
+	// encodePathSegment is defined for API parity with net/url but churl
+	// never actually calls escape/shouldEscape with it (only encodePath is
+	// used, for the path as a whole). Exercise it directly.
+	assert.True(t, shouldEscape('/', encodePathSegment))
+	assert.False(t, shouldEscape('@', encodePathSegment))
+}
+
+func TestShouldEscapeUserPasswordReservedCharacters(t *testing.T) {
+	// Similarly, encodeUserPassword is only ever passed to unescape (for
+	// userinfo), never to escape/shouldEscape, since churl never
+	// re-encodes a Userinfo back into a URL string. Exercise it directly.
+	assert.True(t, shouldEscape('@', encodeUserPassword))
+	assert.False(t, shouldEscape('$', encodeUserPassword))
+}
+
+func TestUnhexPanicsOnInvalidHexCharacter(t *testing.T) {
+	// unhex is only ever called after ishex has validated its input, so
+	// this default branch is unreachable via Parse; call it directly to
+	// document that contract explicitly rather than leaving it silently
+	// unverified.
+	assert.Panics(t, func() {
+		unhex('z')
+	})
+}

--- a/query_parameters_test.go
+++ b/query_parameters_test.go
@@ -8,63 +8,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBindQueryOrAppendParametersPrefersExplicitParameters(t *testing.T) {
-	options := &QueryOptions{parameters: Parameters{"already": "set"}}
-	query, err := bindQueryOrAppendParameters(true, options, "SELECT {name:String}", time.UTC, Named("name", "ignored"))
-	require.NoError(t, err)
-	assert.Equal(t, "SELECT {name:String}", query)
-	// args are ignored entirely once parameters are already populated.
-	assert.Equal(t, Parameters{"already": "set"}, options.parameters)
-}
-
-func TestBindQueryOrAppendParametersFallsBackWhenProtocolUnsupported(t *testing.T) {
-	options := &QueryOptions{}
-	query, err := bindQueryOrAppendParameters(false, options, "SELECT $1", time.UTC, 42)
-	require.NoError(t, err)
-	assert.Equal(t, "SELECT 42", query)
-	assert.Nil(t, options.parameters)
-}
-
-func TestBindQueryOrAppendParametersFallsBackWhenNoParamSyntax(t *testing.T) {
-	options := &QueryOptions{}
-	query, err := bindQueryOrAppendParameters(true, options, "SELECT $1", time.UTC, 42)
-	require.NoError(t, err)
-	assert.Equal(t, "SELECT 42", query)
-	assert.Nil(t, options.parameters)
-}
-
-func TestBindQueryOrAppendParametersFallsBackWhenNoArgs(t *testing.T) {
-	options := &QueryOptions{}
-	query, err := bindQueryOrAppendParameters(true, options, "SELECT {name:String}", time.UTC)
-	require.NoError(t, err)
-	assert.Equal(t, "SELECT {name:String}", query)
-	assert.Nil(t, options.parameters)
+func TestBindQueryOrAppendParameters(t *testing.T) {
+	cases := []struct {
+		name            string
+		protocolSupport bool
+		options         *QueryOptions
+		query           string
+		args            []any
+		wantQuery       string
+		wantParameters  Parameters
+	}{
+		// args are ignored entirely once parameters are already populated.
+		{"prefers explicit parameters over args", true, &QueryOptions{parameters: Parameters{"already": "set"}},
+			"SELECT {name:String}", []any{Named("name", "ignored")}, "SELECT {name:String}", Parameters{"already": "set"}},
+		{"falls back to bind when protocol unsupported", false, &QueryOptions{},
+			"SELECT $1", []any{42}, "SELECT 42", nil},
+		{"falls back to bind when query has no param syntax", true, &QueryOptions{},
+			"SELECT $1", []any{42}, "SELECT 42", nil},
+		{"falls back to bind when no args given", true, &QueryOptions{},
+			"SELECT {name:String}", nil, "SELECT {name:String}", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			query, err := bindQueryOrAppendParameters(tc.protocolSupport, tc.options, tc.query, time.UTC, tc.args...)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantQuery, query)
+			assert.Equal(t, tc.wantParameters, tc.options.parameters)
+		})
+	}
 }
 
 func TestBindQueryOrAppendParametersNamedValue(t *testing.T) {
 	str := "hello"
 	tm := time.Unix(1700000000, 500_000_000)
 
-	tests := []struct {
-		name     string
-		value    any
-		expected string
+	cases := []struct {
+		name  string
+		value any
+		want  string
 	}{
-		{name: "nil value becomes escape marker", value: nil, expected: `\N`},
-		{name: "string is sent raw and unquoted", value: "hello", expected: "hello"},
-		{name: "*string is dereferenced and sent raw", value: &str, expected: "hello"},
-		{name: "time.Time uses formatTimeParam", value: tm, expected: formatTimeParam(tm)},
-		{name: "*time.Time uses formatTimeParam", value: &tm, expected: formatTimeParam(tm)},
-		{name: "other types go through formatValue", value: 42, expected: "42"},
+		{"nil value becomes escape marker", nil, `\N`},
+		{"string is sent raw and unquoted", "hello", "hello"},
+		{"*string is dereferenced and sent raw", &str, "hello"},
+		{"time.Time uses formatTimeParam", tm, formatTimeParam(tm)},
+		{"*time.Time uses formatTimeParam", &tm, formatTimeParam(tm)},
+		{"other types go through formatValue", 42, "42"},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			options := &QueryOptions{}
-			query, err := bindQueryOrAppendParameters(true, options, "SELECT {p:String}", time.UTC, Named("p", tt.value))
+			query, err := bindQueryOrAppendParameters(true, options, "SELECT {p:String}", time.UTC, Named("p", tc.value))
 			require.NoError(t, err)
 			assert.Equal(t, "SELECT {p:String}", query)
-			assert.Equal(t, tt.expected, options.parameters["p"])
+			assert.Equal(t, tc.want, options.parameters["p"])
 		})
 	}
 }
@@ -78,43 +74,44 @@ func TestBindQueryOrAppendParametersNamedDateValue(t *testing.T) {
 	assert.Equal(t, formatTimeWithScale(tm, MilliSeconds), options.parameters["p"])
 }
 
-func TestBindQueryOrAppendParametersNamedDateValueZeroValue(t *testing.T) {
-	options := &QueryOptions{}
-	_, err := bindQueryOrAppendParameters(true, options, "SELECT {p:DateTime}", time.UTC, DateNamed("p", time.Time{}, Seconds))
-	assert.ErrorIs(t, err, ErrInvalidValueInNamedDateValue)
-}
-
-func TestBindQueryOrAppendParametersNamedDateValueEmptyName(t *testing.T) {
-	options := &QueryOptions{}
-	_, err := bindQueryOrAppendParameters(true, options, "SELECT {p:DateTime}", time.UTC, DateNamed("", time.Now(), Seconds))
-	assert.ErrorIs(t, err, ErrInvalidValueInNamedDateValue)
-}
-
-func TestBindQueryOrAppendParametersUnsupportedArgType(t *testing.T) {
-	options := &QueryOptions{}
-	_, err := bindQueryOrAppendParameters(true, options, "SELECT {p:Int32}", time.UTC, 42)
-	assert.ErrorIs(t, err, ErrUnsupportedQueryParameter)
+func TestBindQueryOrAppendParametersErrors(t *testing.T) {
+	cases := []struct {
+		name  string
+		arg   any
+		query string
+		want  error
+	}{
+		{"NamedDateValue with zero value", DateNamed("p", time.Time{}, Seconds), "SELECT {p:DateTime}", ErrInvalidValueInNamedDateValue},
+		{"NamedDateValue with empty name", DateNamed("", time.Now(), Seconds), "SELECT {p:DateTime}", ErrInvalidValueInNamedDateValue},
+		{"unsupported arg type", 42, "SELECT {p:Int32}", ErrUnsupportedQueryParameter},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			options := &QueryOptions{}
+			_, err := bindQueryOrAppendParameters(true, options, tc.query, time.UTC, tc.arg)
+			assert.ErrorIs(t, err, tc.want)
+		})
+	}
 }
 
 func TestIsNilParamValue(t *testing.T) {
 	var nilInt *int
 	notNilInt := 5
 
-	tests := []struct {
-		name     string
-		value    any
-		expected bool
+	cases := []struct {
+		name  string
+		value any
+		want  bool
 	}{
-		{name: "untyped nil", value: nil, expected: true},
-		{name: "typed nil pointer", value: nilInt, expected: true},
-		{name: "non-nil pointer", value: &notNilInt, expected: false},
-		{name: "non-pointer zero value", value: 0, expected: false},
-		{name: "empty string", value: "", expected: false},
+		{"untyped nil", nil, true},
+		{"typed nil pointer", nilInt, true},
+		{"non-nil pointer", &notNilInt, false},
+		{"non-pointer zero value", 0, false},
+		{"empty string", "", false},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, isNilParamValue(tt.value))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isNilParamValue(tc.value))
 		})
 	}
 }
@@ -122,10 +119,21 @@ func TestIsNilParamValue(t *testing.T) {
 func TestFormatEpoch(t *testing.T) {
 	tm := time.Unix(1700000000, 123_456_789)
 
-	assert.Equal(t, "1700000000", formatEpoch(tm, 0))
-	assert.Equal(t, "1700000000.123", formatEpoch(tm, 3))
-	assert.Equal(t, "1700000000.123456", formatEpoch(tm, 6))
-	assert.Equal(t, "1700000000.123456789", formatEpoch(tm, 9))
+	cases := []struct {
+		name   string
+		digits int
+		want   string
+	}{
+		{"whole seconds", 0, "1700000000"},
+		{"milliseconds", 3, "1700000000.123"},
+		{"microseconds", 6, "1700000000.123456"},
+		{"nanoseconds", 9, "1700000000.123456789"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, formatEpoch(tm, tc.digits))
+		})
+	}
 }
 
 func TestFormatEpochBeforeUnixEpoch(t *testing.T) {
@@ -133,7 +141,18 @@ func TestFormatEpochBeforeUnixEpoch(t *testing.T) {
 	// representation; formatEpoch must recombine that into "-0.5", not "-1.5".
 	tm := time.Unix(-1, 500_000_000)
 
-	assert.Equal(t, "-1", formatEpoch(tm, 0))
-	assert.Equal(t, "-0.500", formatEpoch(tm, 3))
-	assert.Equal(t, "-0.500000000", formatEpoch(tm, 9))
+	cases := []struct {
+		name   string
+		digits int
+		want   string
+	}{
+		{"whole seconds", 0, "-1"},
+		{"milliseconds", 3, "-0.500"},
+		{"nanoseconds", 9, "-0.500000000"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, formatEpoch(tm, tc.digits))
+		})
+	}
 }

--- a/query_parameters_test.go
+++ b/query_parameters_test.go
@@ -50,8 +50,8 @@ func TestBindQueryOrAppendParametersNamedValue(t *testing.T) {
 		{"nil value becomes escape marker", nil, `\N`},
 		{"string is sent raw and unquoted", "hello", "hello"},
 		{"*string is dereferenced and sent raw", &str, "hello"},
-		{"time.Time uses formatTimeParam", tm, formatTimeParam(tm)},
-		{"*time.Time uses formatTimeParam", &tm, formatTimeParam(tm)},
+		{"time.Time uses formatTimeParam", tm, "1700000000.500"},
+		{"*time.Time uses formatTimeParam", &tm, "1700000000.500"},
 		{"other types go through formatValue", 42, "42"},
 	}
 	for _, tc := range cases {
@@ -71,7 +71,7 @@ func TestBindQueryOrAppendParametersNamedDateValue(t *testing.T) {
 	options := &QueryOptions{}
 	_, err := bindQueryOrAppendParameters(true, options, "SELECT {p:DateTime64(3)}", time.UTC, DateNamed("p", tm, MilliSeconds))
 	require.NoError(t, err)
-	assert.Equal(t, formatTimeWithScale(tm, MilliSeconds), options.parameters["p"])
+	assert.Equal(t, "1700000000.123", options.parameters["p"])
 }
 
 func TestBindQueryOrAppendParametersErrors(t *testing.T) {

--- a/query_parameters_test.go
+++ b/query_parameters_test.go
@@ -1,0 +1,139 @@
+package clickhouse
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBindQueryOrAppendParametersPrefersExplicitParameters(t *testing.T) {
+	options := &QueryOptions{parameters: Parameters{"already": "set"}}
+	query, err := bindQueryOrAppendParameters(true, options, "SELECT {name:String}", time.UTC, Named("name", "ignored"))
+	require.NoError(t, err)
+	assert.Equal(t, "SELECT {name:String}", query)
+	// args are ignored entirely once parameters are already populated.
+	assert.Equal(t, Parameters{"already": "set"}, options.parameters)
+}
+
+func TestBindQueryOrAppendParametersFallsBackWhenProtocolUnsupported(t *testing.T) {
+	options := &QueryOptions{}
+	query, err := bindQueryOrAppendParameters(false, options, "SELECT $1", time.UTC, 42)
+	require.NoError(t, err)
+	assert.Equal(t, "SELECT 42", query)
+	assert.Nil(t, options.parameters)
+}
+
+func TestBindQueryOrAppendParametersFallsBackWhenNoParamSyntax(t *testing.T) {
+	options := &QueryOptions{}
+	query, err := bindQueryOrAppendParameters(true, options, "SELECT $1", time.UTC, 42)
+	require.NoError(t, err)
+	assert.Equal(t, "SELECT 42", query)
+	assert.Nil(t, options.parameters)
+}
+
+func TestBindQueryOrAppendParametersFallsBackWhenNoArgs(t *testing.T) {
+	options := &QueryOptions{}
+	query, err := bindQueryOrAppendParameters(true, options, "SELECT {name:String}", time.UTC)
+	require.NoError(t, err)
+	assert.Equal(t, "SELECT {name:String}", query)
+	assert.Nil(t, options.parameters)
+}
+
+func TestBindQueryOrAppendParametersNamedValue(t *testing.T) {
+	str := "hello"
+	tm := time.Unix(1700000000, 500_000_000)
+
+	tests := []struct {
+		name     string
+		value    any
+		expected string
+	}{
+		{name: "nil value becomes escape marker", value: nil, expected: `\N`},
+		{name: "string is sent raw and unquoted", value: "hello", expected: "hello"},
+		{name: "*string is dereferenced and sent raw", value: &str, expected: "hello"},
+		{name: "time.Time uses formatTimeParam", value: tm, expected: formatTimeParam(tm)},
+		{name: "*time.Time uses formatTimeParam", value: &tm, expected: formatTimeParam(tm)},
+		{name: "other types go through formatValue", value: 42, expected: "42"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := &QueryOptions{}
+			query, err := bindQueryOrAppendParameters(true, options, "SELECT {p:String}", time.UTC, Named("p", tt.value))
+			require.NoError(t, err)
+			assert.Equal(t, "SELECT {p:String}", query)
+			assert.Equal(t, tt.expected, options.parameters["p"])
+		})
+	}
+}
+
+func TestBindQueryOrAppendParametersNamedDateValue(t *testing.T) {
+	tm := time.Unix(1700000000, 123_000_000)
+
+	options := &QueryOptions{}
+	_, err := bindQueryOrAppendParameters(true, options, "SELECT {p:DateTime64(3)}", time.UTC, DateNamed("p", tm, MilliSeconds))
+	require.NoError(t, err)
+	assert.Equal(t, formatTimeWithScale(tm, MilliSeconds), options.parameters["p"])
+}
+
+func TestBindQueryOrAppendParametersNamedDateValueZeroValue(t *testing.T) {
+	options := &QueryOptions{}
+	_, err := bindQueryOrAppendParameters(true, options, "SELECT {p:DateTime}", time.UTC, DateNamed("p", time.Time{}, Seconds))
+	assert.ErrorIs(t, err, ErrInvalidValueInNamedDateValue)
+}
+
+func TestBindQueryOrAppendParametersNamedDateValueEmptyName(t *testing.T) {
+	options := &QueryOptions{}
+	_, err := bindQueryOrAppendParameters(true, options, "SELECT {p:DateTime}", time.UTC, DateNamed("", time.Now(), Seconds))
+	assert.ErrorIs(t, err, ErrInvalidValueInNamedDateValue)
+}
+
+func TestBindQueryOrAppendParametersUnsupportedArgType(t *testing.T) {
+	options := &QueryOptions{}
+	_, err := bindQueryOrAppendParameters(true, options, "SELECT {p:Int32}", time.UTC, 42)
+	assert.ErrorIs(t, err, ErrUnsupportedQueryParameter)
+}
+
+func TestIsNilParamValue(t *testing.T) {
+	var nilInt *int
+	notNilInt := 5
+
+	tests := []struct {
+		name     string
+		value    any
+		expected bool
+	}{
+		{name: "untyped nil", value: nil, expected: true},
+		{name: "typed nil pointer", value: nilInt, expected: true},
+		{name: "non-nil pointer", value: &notNilInt, expected: false},
+		{name: "non-pointer zero value", value: 0, expected: false},
+		{name: "empty string", value: "", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isNilParamValue(tt.value))
+		})
+	}
+}
+
+func TestFormatEpoch(t *testing.T) {
+	tm := time.Unix(1700000000, 123_456_789)
+
+	assert.Equal(t, "1700000000", formatEpoch(tm, 0))
+	assert.Equal(t, "1700000000.123", formatEpoch(tm, 3))
+	assert.Equal(t, "1700000000.123456", formatEpoch(tm, 6))
+	assert.Equal(t, "1700000000.123456789", formatEpoch(tm, 9))
+}
+
+func TestFormatEpochBeforeUnixEpoch(t *testing.T) {
+	// 1969-12-31T23:59:59.5Z decomposes as sec=-1, nsec=5e8 in Go's time
+	// representation; formatEpoch must recombine that into "-0.5", not "-1.5".
+	tm := time.Unix(-1, 500_000_000)
+
+	assert.Equal(t, "-1", formatEpoch(tm, 0))
+	assert.Equal(t, "-0.500", formatEpoch(tm, 3))
+	assert.Equal(t, "-0.500000000", formatEpoch(tm, 9))
+}


### PR DESCRIPTION
## Summary
lib/churl, query_parameters.go, and lib/binary had zero test coverage despite being pure logic on the hot path (DSN parsing, SQL-injection-sensitive param binding, and FixedString byte padding). Add table-driven tests for each.

## Checklist
Add 3 unit test files
- lib/binary/string_test.go
- lib/churl/churl_test.go
- query_parameters_test.go