### PR TITLE
chore: fork clickhouse go v2 as rudderlabs clickhouse go v2

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # clickhouse-go — Agent Instructions
 
-`github.com/ClickHouse/clickhouse-go/v2` is the official Go client for ClickHouse. It exposes two surfaces:
+`github.com/rudderlabs/clickhouse-go/v2` is the official Go client for ClickHouse. It exposes two surfaces:
 - **Native API** (`clickhouse.Open`) — full-featured, direct `driver.Conn` interface.
 - **Standard library** (`database/sql`) — compatibility shim via `clickhouse_std.go`.
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -45,4 +45,4 @@ formatters:
           replacement: a[b:]
     goimports:
       local-prefixes:
-        - "github.com/ClickHouse/clickhouse-go/v2"
+        - "github.com/rudderlabs/clickhouse-go/v2"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 Golang SQL database client for [ClickHouse](https://clickhouse.com/).
 
+> ### RudderStack fork
+>
+> This is a fork of [`ClickHouse/clickhouse-go`](https://github.com/ClickHouse/clickhouse-go) carrying **two patches** on top of upstream:
+>
+> 1. the module path is `github.com/rudderlabs/clickhouse-go/v2`;
+> 2. the `database/sql` driver registers as **`clickhouse-v2`**, not `clickhouse`.
+>
+> **Why it exists.** `rudder-server` still depends on v1 (`github.com/ClickHouse/clickhouse-go`) while the ClickHouse warehouse integration migrates to v2. Both upstream versions register the driver name `clickhouse` in `init()`, so linking them into one binary panics with `sql: Register called twice for driver clickhouse` before `main` — including when only `clickhouse.OpenDB` is used, since `OpenDB` sits in the same package as that `init()`. Renaming the registration lets both drivers coexist and be selected per destination at runtime, which is what makes a staged, reversible rollout possible.
+>
+> **It is temporary.** Once every destination is on v2 and the v1 dependency is dropped, `rudder-server` moves its import back to upstream and this fork is retired. The two patches are deliberately minimal so that stays a one-line change.
+>
+> **Tracking upstream.** The `upstream-main` branch holds upstream verbatim. To take a new upstream version: fetch it, rebase these two commits on top, run the tests, tag.
+>
+> Everything below is upstream's documentation, unchanged apart from the module path.
+
+
 ## Install
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# ClickHouse [![run-tests](https://github.com/ClickHouse/clickhouse-go/actions/workflows/run-tests.yml/badge.svg?branch=v2)](https://github.com/ClickHouse/clickhouse-go/actions/workflows/run-tests.yml) [![Go Reference](https://pkg.go.dev/badge/github.com/ClickHouse/clickhouse-go/v2.svg)](https://pkg.go.dev/github.com/ClickHouse/clickhouse-go/v2)
+# ClickHouse [![run-tests](https://github.com/ClickHouse/clickhouse-go/actions/workflows/run-tests.yml/badge.svg?branch=v2)](https://github.com/ClickHouse/clickhouse-go/actions/workflows/run-tests.yml) [![Go Reference](https://pkg.go.dev/badge/github.com/rudderlabs/clickhouse-go/v2.svg)](https://pkg.go.dev/github.com/rudderlabs/clickhouse-go/v2)
 
 Golang SQL database client for [ClickHouse](https://clickhouse.com/).
 
 ## Install
 
 ```sh
-go get github.com/ClickHouse/clickhouse-go/v2
+go get github.com/rudderlabs/clickhouse-go/v2
 ```
 
 ## Which interface should I use?

--- a/TYPES.md
+++ b/TYPES.md
@@ -101,7 +101,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func main() {

--- a/benchmark/json_test.go
+++ b/benchmark/json_test.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 const testSet string = "json_bench"

--- a/benchmark/v2/read-native/basic_test.go
+++ b/benchmark/v2/read-native/basic_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func getConnection() clickhouse.Conn {

--- a/benchmark/v2/read-native/main.go
+++ b/benchmark/v2/read-native/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func benchmarkRead(conn clickhouse.Conn) error {

--- a/benchmark/v2/read/main.go
+++ b/benchmark/v2/read/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	_ "github.com/ClickHouse/clickhouse-go/v2"
+	_ "github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func benchmarkRead(conn *sql.DB) error {

--- a/benchmark/v2/read/main.go
+++ b/benchmark/v2/read/main.go
@@ -52,7 +52,7 @@ func benchmarkString(conn *sql.DB) error {
 }
 
 func main() {
-	conn, err := sql.Open("clickhouse", "clickhouse://127.0.0.1:9000")
+	conn, err := sql.Open("clickhouse-v2", "clickhouse://127.0.0.1:9000")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/benchmark/v2/write-async-std/main.go
+++ b/benchmark/v2/write-async-std/main.go
@@ -37,7 +37,7 @@ func benchmark(conn *sql.DB) error {
 }
 
 func main() {
-	conn, err := sql.Open("clickhouse", "clickhouse://127.0.0.1:9000")
+	conn, err := sql.Open("clickhouse-v2", "clickhouse://127.0.0.1:9000")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/benchmark/v2/write-async-std/main.go
+++ b/benchmark/v2/write-async-std/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 const ddl = `

--- a/benchmark/v2/write-async/main.go
+++ b/benchmark/v2/write-async/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 const ddl = `

--- a/benchmark/v2/write-compress-buffer-limit/write_test.go
+++ b/benchmark/v2/write-compress-buffer-limit/write_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func bToMb(b uint64) uint64 {

--- a/benchmark/v2/write-native-columnar/main.go
+++ b/benchmark/v2/write-native-columnar/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 const ddl = `

--- a/benchmark/v2/write-native-struct/main.go
+++ b/benchmark/v2/write-native-struct/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 const ddl = `

--- a/benchmark/v2/write-native/main.go
+++ b/benchmark/v2/write-native/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 const ddl = `

--- a/benchmark/v2/write-native/write_test.go
+++ b/benchmark/v2/write-native/write_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func getConnection() clickhouse.Conn {

--- a/benchmark/v2/write/main.go
+++ b/benchmark/v2/write/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	_ "github.com/ClickHouse/clickhouse-go/v2"
+	_ "github.com/rudderlabs/clickhouse-go/v2"
 )
 
 const ddl = `

--- a/benchmark/v2/write/main.go
+++ b/benchmark/v2/write/main.go
@@ -46,7 +46,7 @@ func benchmark(conn *sql.DB) error {
 	return scope.Commit()
 }
 func main() {
-	conn, err := sql.Open("clickhouse", "clickhouse://127.0.0.1:9000")
+	conn, err := sql.Open("clickhouse-v2", "clickhouse://127.0.0.1:9000")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/bind.go
+++ b/bind.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 var (

--- a/bind_test.go
+++ b/bind_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 func TestBindNumeric(t *testing.T) {

--- a/chcol.go
+++ b/chcol.go
@@ -1,6 +1,6 @@
 package clickhouse
 
-import "github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+import "github.com/rudderlabs/clickhouse-go/v2/lib/chcol"
 
 // Re-export chcol types/funcs to top level clickhouse package
 

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -13,9 +13,9 @@ import (
 
 	_ "time/tzdata"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 type Conn = driver.Conn

--- a/clickhouse_options.go
+++ b/clickhouse_options.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/ClickHouse/ch-go/compress"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/churl"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/churl"
 )
 
 type CompressionMethod byte

--- a/clickhouse_rows.go
+++ b/clickhouse_rows.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"io"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 type rows struct {

--- a/clickhouse_rows_column_type.go
+++ b/clickhouse_rows_column_type.go
@@ -3,8 +3,8 @@ package clickhouse
 import (
 	"reflect"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 type columnType struct {

--- a/clickhouse_rows_test.go
+++ b/clickhouse_rows_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 func TestReadWithEmptyBlock(t *testing.T) {

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -14,8 +14,8 @@ import (
 	"sync/atomic"
 	"syscall"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
-	chdriver "github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
+	chdriver "github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 var globalConnID int64

--- a/clickhouse_std.go
+++ b/clickhouse_std.go
@@ -94,7 +94,7 @@ func (o *stdConnOpener) Connect(ctx context.Context) (_ driver.Conn, err error) 
 var _ driver.Connector = (*stdConnOpener)(nil)
 
 func init() {
-	sql.Register("clickhouse", &stdDriver{logger: newNoopLogger()})
+	sql.Register("clickhouse-v2", &stdDriver{logger: newNoopLogger()})
 }
 
 // isConnBrokenError returns true if the error class indicates that the

--- a/client_info.go
+++ b/client_info.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 const ClientName = "clickhouse-go"

--- a/conn.go
+++ b/conn.go
@@ -12,14 +12,14 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
 
-	"github.com/ClickHouse/clickhouse-go/v2/resources"
+	"github.com/rudderlabs/clickhouse-go/v2/resources"
 
 	"github.com/ClickHouse/ch-go/compress"
 	chproto "github.com/ClickHouse/ch-go/proto"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 func dial(ctx context.Context, addr string, num int, opt *Options) (*connect, error) {

--- a/conn_async_insert.go
+++ b/conn_async_insert.go
@@ -3,7 +3,7 @@ package clickhouse
 import (
 	"context"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 func (c *connect) asyncInsert(ctx context.Context, query string, wait bool, args ...any) error {

--- a/conn_batch.go
+++ b/conn_batch.go
@@ -11,9 +11,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 var insertMatch = regexp.MustCompile(`(?i)(?:(?:--[^\n]*|#![^\n]*|#\s[^\n]*)\n\s*)*(INSERT\s+INTO\s+[^( ]+(?:\s*\([^()]*(?:\([^()]*\)[^()]*)*\))?)(?:\s*VALUES)?`)

--- a/conn_error_context_test.go
+++ b/conn_error_context_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 // mockNetConn is a mock net.Conn that can be configured to return specific errors

--- a/conn_exec.go
+++ b/conn_exec.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 func (c *connect) exec(ctx context.Context, query string, args ...any) error {

--- a/conn_handshake.go
+++ b/conn_handshake.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 func (c *connect) handshake(auth Auth) error {

--- a/conn_http.go
+++ b/conn_http.go
@@ -24,8 +24,8 @@ import (
 	chproto "github.com/ClickHouse/ch-go/proto"
 	"github.com/andybalholm/brotli"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/timezone"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/timezone"
 )
 
 const (

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"slices"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 func fetchColumnNamesAndTypesForInsert(h *httpConnect, release nativeTransportRelease, ctx context.Context, tableName string, requestedColumnNames []string) ([]ColumnNameAndType, error) {

--- a/conn_http_format_test.go
+++ b/conn_http_format_test.go
@@ -18,7 +18,7 @@ import (
 
 	chproto "github.com/ClickHouse/ch-go/proto"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 // oneByteReader forces marker detection across read boundaries.

--- a/conn_http_query.go
+++ b/conn_http_query.go
@@ -11,7 +11,7 @@ import (
 
 	chproto "github.com/ClickHouse/ch-go/proto"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 // captureTailSize bounds how much recently-read data capturingReader retains:

--- a/conn_logs.go
+++ b/conn_logs.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 type Log struct {

--- a/conn_ping.go
+++ b/conn_ping.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 // Connection::ping

--- a/conn_pool.go
+++ b/conn_pool.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2/internal/circular"
+	"github.com/rudderlabs/clickhouse-go/v2/internal/circular"
 )
 
 var errQueueEmpty = errors.New("clickhouse: connection pool queue is empty")

--- a/conn_pool_test.go
+++ b/conn_pool_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 func TestConnPool_Cap(t *testing.T) {

--- a/conn_process.go
+++ b/conn_process.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"log/slog"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 type onProcess struct {

--- a/conn_profile_events.go
+++ b/conn_profile_events.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 type ProfileEvent struct {

--- a/conn_query.go
+++ b/conn_query.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 func (c *connect) query(ctx context.Context, release nativeTransportRelease, query string, args ...any) (*rows, error) {

--- a/conn_send_query.go
+++ b/conn_send_query.go
@@ -3,7 +3,7 @@ package clickhouse
 import (
 	"log/slog"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 // Connection::sendQuery

--- a/context.go
+++ b/context.go
@@ -8,7 +8,7 @@ import (
 
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/ClickHouse/clickhouse-go/v2/ext"
+	"github.com/rudderlabs/clickhouse-go/v2/ext"
 )
 
 var _contextOptionKey = &QueryOptions{

--- a/docs/config-reference.mdx
+++ b/docs/config-reference.mdx
@@ -353,7 +353,7 @@ rows, err := conn.Query(ctx, "SELECT * FROM users WHERE id = {user_id:String}")
 
 ## Batch options {#batch-options}
 
-Passed to `PrepareBatch()`. Import: `github.com/ClickHouse/clickhouse-go/v2/lib/driver`.
+Passed to `PrepareBatch()`. Import: `github.com/rudderlabs/clickhouse-go/v2/lib/driver`.
 
 | Option | Default | Description | Best practice | When misconfigured |
 |--------|---------|-------------|---------------|-------------------|

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -41,8 +41,8 @@ import (
     "fmt"
     "log"
 
-    "github.com/ClickHouse/clickhouse-go/v2"
-    "github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+    "github.com/rudderlabs/clickhouse-go/v2"
+    "github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 func main() {
@@ -198,7 +198,7 @@ v1 of the driver is deprecated and won't reach feature updates or support for ne
 
 To install the 2.x version of the client, add the package to your go.mod file:
 
-`require github.com/ClickHouse/clickhouse-go/v2 main`
+`require github.com/rudderlabs/clickhouse-go/v2 main`
 
 Or, clone the repository:
 
@@ -216,7 +216,7 @@ cat > go.mod <<-END
 
   go 1.21
 
-  require github.com/ClickHouse/clickhouse-go/v2 main
+  require github.com/rudderlabs/clickhouse-go/v2 main
 END
 
 cat > main.go <<-END
@@ -224,7 +224,7 @@ cat > main.go <<-END
 
   import (
     "fmt"
-    "github.com/ClickHouse/clickhouse-go/v2"
+    "github.com/rudderlabs/clickhouse-go/v2"
   )
 
   func main() {

--- a/example_http_error_test.go
+++ b/example_http_error_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 // Server-side failures carry a typed *clickhouse.Exception on both the native

--- a/examples/clickhouse_api/async_http.go
+++ b/examples/clickhouse_api/async_http.go
@@ -3,8 +3,8 @@ package clickhouse_api
 import (
 	"context"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func AsyncInsertHTTP() error {

--- a/examples/clickhouse_api/async_native.go
+++ b/examples/clickhouse_api/async_native.go
@@ -3,8 +3,8 @@ package clickhouse_api
 import (
 	"context"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func AsyncInsertNative() error {

--- a/examples/clickhouse_api/auth.go
+++ b/examples/clickhouse_api/auth.go
@@ -2,7 +2,7 @@ package clickhouse_api
 
 import (
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func Auth() error {

--- a/examples/clickhouse_api/batch_release_connection.go
+++ b/examples/clickhouse_api/batch_release_connection.go
@@ -3,7 +3,7 @@ package clickhouse_api
 import (
 	"context"
 	"errors"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 func BatchWithReleaseConnection() error {

--- a/examples/clickhouse_api/bfloat16.go
+++ b/examples/clickhouse_api/bfloat16.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func BFloat16() error {

--- a/examples/clickhouse_api/bind.go
+++ b/examples/clickhouse_api/bind.go
@@ -3,7 +3,7 @@ package clickhouse_api
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 	"time"
 )
 

--- a/examples/clickhouse_api/bind_special.go
+++ b/examples/clickhouse_api/bind_special.go
@@ -3,7 +3,7 @@ package clickhouse_api
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 	"time"
 )
 

--- a/examples/clickhouse_api/client_info.go
+++ b/examples/clickhouse_api/client_info.go
@@ -2,7 +2,7 @@ package clickhouse_api
 
 import (
 	"context"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func ClientInfo() error {

--- a/examples/clickhouse_api/compression.go
+++ b/examples/clickhouse_api/compression.go
@@ -3,7 +3,7 @@ package clickhouse_api
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 	"strconv"
 )
 

--- a/examples/clickhouse_api/connect.go
+++ b/examples/clickhouse_api/connect.go
@@ -2,7 +2,7 @@ package clickhouse_api
 
 import (
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func Connect() error {

--- a/examples/clickhouse_api/connect_settings.go
+++ b/examples/clickhouse_api/connect_settings.go
@@ -3,7 +3,7 @@ package clickhouse_api
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 	"net"
 	"time"
 )

--- a/examples/clickhouse_api/context.go
+++ b/examples/clickhouse_api/context.go
@@ -6,8 +6,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 	"github.com/google/uuid"
 )
 

--- a/examples/clickhouse_api/dynamic.go
+++ b/examples/clickhouse_api/dynamic.go
@@ -3,7 +3,7 @@ package clickhouse_api
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func DynamicExample() error {

--- a/examples/clickhouse_api/external_data.go
+++ b/examples/clickhouse_api/external_data.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/ext"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/ext"
 )
 
 func ExternalData() error {

--- a/examples/clickhouse_api/geo.go
+++ b/examples/clickhouse_api/geo.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 	"github.com/paulmach/orb"
 )
 

--- a/examples/clickhouse_api/json_fast_structs.go
+++ b/examples/clickhouse_api/json_fast_structs.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 type FastProductPricing struct {

--- a/examples/clickhouse_api/json_paths.go
+++ b/examples/clickhouse_api/json_paths.go
@@ -3,7 +3,7 @@ package clickhouse_api
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 	"time"
 )
 

--- a/examples/clickhouse_api/json_strings.go
+++ b/examples/clickhouse_api/json_strings.go
@@ -3,7 +3,7 @@ package clickhouse_api
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func JSONStringExample() error {

--- a/examples/clickhouse_api/json_structs.go
+++ b/examples/clickhouse_api/json_structs.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 type ProductPricing struct {

--- a/examples/clickhouse_api/logger_test.go
+++ b/examples/clickhouse_api/logger_test.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func Logger() error {

--- a/examples/clickhouse_api/main_test.go
+++ b/examples/clickhouse_api/main_test.go
@@ -3,7 +3,7 @@ package clickhouse_api
 import (
 	"context"
 	"fmt"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
 	"os"
 	"strconv"

--- a/examples/clickhouse_api/map.go
+++ b/examples/clickhouse_api/map.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column/orderedmap"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column/orderedmap"
 )
 
 func MapInsertRead() error {

--- a/examples/clickhouse_api/multi_host.go
+++ b/examples/clickhouse_api/multi_host.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func MultiHostVersion() error {

--- a/examples/clickhouse_api/nested.go
+++ b/examples/clickhouse_api/nested.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func NestedUnFlattened() error {

--- a/examples/clickhouse_api/open_telemetry.go
+++ b/examples/clickhouse_api/open_telemetry.go
@@ -3,7 +3,7 @@ package clickhouse_api
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/examples/clickhouse_api/progress.go
+++ b/examples/clickhouse_api/progress.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func ProgressProfileLogs() error {

--- a/examples/clickhouse_api/qbit.go
+++ b/examples/clickhouse_api/qbit.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func QBit() error {

--- a/examples/clickhouse_api/qbit_subcolumns.go
+++ b/examples/clickhouse_api/qbit_subcolumns.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func QBitSubcolumns() error {

--- a/examples/clickhouse_api/query_parameters.go
+++ b/examples/clickhouse_api/query_parameters.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func QueryWithParameters() error {

--- a/examples/clickhouse_api/server_exceptions.go
+++ b/examples/clickhouse_api/server_exceptions.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 // ServerExceptions shows how to branch on server-side failures. A typed

--- a/examples/clickhouse_api/ssl.go
+++ b/examples/clickhouse_api/ssl.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func SSLVersion() error {

--- a/examples/clickhouse_api/ssl_no_verify.go
+++ b/examples/clickhouse_api/ssl_no_verify.go
@@ -3,7 +3,7 @@ package clickhouse_api
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func SSLNoVerifyVersion() error {

--- a/examples/clickhouse_api/utils.go
+++ b/examples/clickhouse_api/utils.go
@@ -5,9 +5,9 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 const TestSet string = "examples_clickhouse_api"

--- a/examples/clickhouse_api/variant.go
+++ b/examples/clickhouse_api/variant.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func VariantExample() error {

--- a/examples/std/async_http.go
+++ b/examples/std/async_http.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func AsyncInsertHTTP() error {

--- a/examples/std/async_native.go
+++ b/examples/std/async_native.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func AsyncInsertNative() error {

--- a/examples/std/auth.go
+++ b/examples/std/auth.go
@@ -3,7 +3,7 @@ package std
 import (
 	"database/sql"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func ConnectAuth() error {

--- a/examples/std/auth.go
+++ b/examples/std/auth.go
@@ -24,14 +24,14 @@ func ConnectAuth() error {
 
 func ConnectDSNAuth() error {
 	env, err := GetStdTestEnvironment()
-	conn, err := sql.Open("clickhouse", fmt.Sprintf("http://%s:%d?username=%s&password=%s", env.Host, env.HttpPort, env.Username, env.Password))
+	conn, err := sql.Open("clickhouse-v2", fmt.Sprintf("http://%s:%d?username=%s&password=%s", env.Host, env.HttpPort, env.Username, env.Password))
 	if err != nil {
 		return err
 	}
 	if err = conn.Ping(); err != nil {
 		return err
 	}
-	conn, err = sql.Open("clickhouse", fmt.Sprintf("http://%s:%s@%s:%d", env.Username, env.Password, env.Host, env.HttpPort))
+	conn, err = sql.Open("clickhouse-v2", fmt.Sprintf("http://%s:%s@%s:%d", env.Username, env.Password, env.Host, env.HttpPort))
 	if err != nil {
 		return err
 	}

--- a/examples/std/batch.go
+++ b/examples/std/batch.go
@@ -1,10 +1,10 @@
 package std
 
 import (
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 	"time"
 
-	_ "github.com/ClickHouse/clickhouse-go/v2"
+	_ "github.com/rudderlabs/clickhouse-go/v2"
 	"github.com/google/uuid"
 )
 

--- a/examples/std/bfloat16.go
+++ b/examples/std/bfloat16.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func BFloat16() error {

--- a/examples/std/bind.go
+++ b/examples/std/bind.go
@@ -3,8 +3,8 @@ package std
 import (
 	"database/sql"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 	"time"
 )
 

--- a/examples/std/client_info.go
+++ b/examples/std/client_info.go
@@ -3,7 +3,7 @@ package std
 import "database/sql"
 
 func ClientInfo() error {
-	db, err := sql.Open("clickhouse", "clickhouse://default@127.0.0.1/default?client_info_product[my-app]=0.1")
+	db, err := sql.Open("clickhouse-v2", "clickhouse://default@127.0.0.1/default?client_info_product[my-app]=0.1")
 	if err != nil {
 		return err
 	}

--- a/examples/std/compression.go
+++ b/examples/std/compression.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func CompressOpenDB() error {

--- a/examples/std/compression.go
+++ b/examples/std/compression.go
@@ -66,7 +66,7 @@ func CompressOpen() error {
 		return err
 	}
 	// note compress=gzip&compress_level=5
-	conn, err := sql.Open("clickhouse", fmt.Sprintf("http://%s:%d?username=%s&password=%s&compress=gzip&compress_level=5", env.Host, env.HttpPort, env.Username, env.Password))
+	conn, err := sql.Open("clickhouse-v2", fmt.Sprintf("http://%s:%d?username=%s&password=%s&compress=gzip&compress_level=5", env.Host, env.HttpPort, env.Username, env.Password))
 	defer func() {
 		conn.Exec("DROP TABLE example")
 	}()

--- a/examples/std/connect.go
+++ b/examples/std/connect.go
@@ -29,7 +29,7 @@ func ConnectDSN() error {
 	if err != nil {
 		return err
 	}
-	conn, err := sql.Open("clickhouse", fmt.Sprintf("clickhouse://%s:%d?username=%s&password=%s", env.Host, env.Port, env.Username, env.Password))
+	conn, err := sql.Open("clickhouse-v2", fmt.Sprintf("clickhouse://%s:%d?username=%s&password=%s", env.Host, env.Port, env.Username, env.Password))
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func ConnectUsingHTTPProxyDSN() error {
 
 	urlEncodedProxyURL := url.QueryEscape("http://proxy.example.com:3128")
 
-	conn, err := sql.Open("clickhouse", fmt.Sprintf("clickhouse://%s:%d?username=%s&password=%s&http_proxy=%s", env.Host, env.Port, env.Username, env.Password, urlEncodedProxyURL))
+	conn, err := sql.Open("clickhouse-v2", fmt.Sprintf("clickhouse://%s:%d?username=%s&password=%s&http_proxy=%s", env.Host, env.Port, env.Username, env.Password, urlEncodedProxyURL))
 	if err != nil {
 		return err
 	}

--- a/examples/std/connect.go
+++ b/examples/std/connect.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func Connect() error {

--- a/examples/std/connect_http.go
+++ b/examples/std/connect_http.go
@@ -3,7 +3,7 @@ package std
 import (
 	"database/sql"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func ConnectHTTP() error {

--- a/examples/std/connect_http.go
+++ b/examples/std/connect_http.go
@@ -28,7 +28,7 @@ func ConnectDSNHTTP() error {
 	if err != nil {
 		return err
 	}
-	conn, err := sql.Open("clickhouse", fmt.Sprintf("http://%s:%d?username=%s&password=%s", env.Host, env.HttpPort, env.Username, env.Password))
+	conn, err := sql.Open("clickhouse-v2", fmt.Sprintf("http://%s:%d?username=%s&password=%s", env.Host, env.HttpPort, env.Username, env.Password))
 	if err != nil {
 		return err
 	}

--- a/examples/std/connect_settings.go
+++ b/examples/std/connect_settings.go
@@ -10,7 +10,7 @@ func ConnectSettings() error {
 	if err != nil {
 		return err
 	}
-	conn, err := sql.Open("clickhouse", fmt.Sprintf("clickhouse://127.0.0.1:9001,127.0.0.1:9002,%s:%d/%s?username=%s&password=%s&dial_timeout=10s&connection_open_strategy=round_robin&debug=true&compress=lz4", env.Host, env.Port, env.Database, env.Username, env.Password))
+	conn, err := sql.Open("clickhouse-v2", fmt.Sprintf("clickhouse://127.0.0.1:9001,127.0.0.1:9002,%s:%d/%s?username=%s&password=%s&dial_timeout=10s&connection_open_strategy=round_robin&debug=true&compress=lz4", env.Host, env.Port, env.Database, env.Username, env.Password))
 	if err != nil {
 		return err
 	}

--- a/examples/std/context.go
+++ b/examples/std/context.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 	"github.com/google/uuid"
 )
 

--- a/examples/std/dynamic.go
+++ b/examples/std/dynamic.go
@@ -3,7 +3,7 @@ package std
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func DynamicExample() error {

--- a/examples/std/dynamic_scan_types.go
+++ b/examples/std/dynamic_scan_types.go
@@ -3,7 +3,7 @@ package std
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 	"reflect"
 )
 

--- a/examples/std/ephemeral_http.go
+++ b/examples/std/ephemeral_http.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func EphemeralColumnHTTP() error {

--- a/examples/std/ephemeral_native.go
+++ b/examples/std/ephemeral_native.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func EphemeralColumnNative() error {

--- a/examples/std/exec.go
+++ b/examples/std/exec.go
@@ -1,6 +1,6 @@
 package std
 
-import "github.com/ClickHouse/clickhouse-go/v2"
+import "github.com/rudderlabs/clickhouse-go/v2"
 
 func Exec() error {
 	conn, err := GetStdOpenDBConnection(clickhouse.Native, nil, nil, nil)

--- a/examples/std/external_data.go
+++ b/examples/std/external_data.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/ext"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/ext"
 )
 
 func ExternalData() error {

--- a/examples/std/geo.go
+++ b/examples/std/geo.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 	"github.com/paulmach/orb"
 )
 

--- a/examples/std/json_paths.go
+++ b/examples/std/json_paths.go
@@ -3,7 +3,7 @@ package std
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 	"time"
 )
 

--- a/examples/std/json_strings.go
+++ b/examples/std/json_strings.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func JSONStringExample() error {

--- a/examples/std/logger_test.go
+++ b/examples/std/logger_test.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func StdLogger() error {

--- a/examples/std/main_test.go
+++ b/examples/std/main_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
 )
 

--- a/examples/std/map.go
+++ b/examples/std/map.go
@@ -3,7 +3,7 @@ package std
 import (
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func MapInsertRead() error {

--- a/examples/std/multi_host.go
+++ b/examples/std/multi_host.go
@@ -36,7 +36,7 @@ func MultiStdHostDSN() error {
 	if err != nil {
 		return err
 	}
-	conn, err := sql.Open("clickhouse", fmt.Sprintf("clickhouse://127.0.0.1:9001,127.0.0.1:9002,%s:%d?username=%s&password=%s&connection_open_strategy=round_robin", env.Host, env.Port, env.Username, env.Password))
+	conn, err := sql.Open("clickhouse-v2", fmt.Sprintf("clickhouse://127.0.0.1:9001,127.0.0.1:9002,%s:%d?username=%s&password=%s&connection_open_strategy=round_robin", env.Host, env.Port, env.Username, env.Password))
 	if err != nil {
 		return err
 	}

--- a/examples/std/multi_host.go
+++ b/examples/std/multi_host.go
@@ -3,7 +3,7 @@ package std
 import (
 	"database/sql"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func MultiStdHost() error {

--- a/examples/std/open_db.go
+++ b/examples/std/open_db.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func OpenDb() error {

--- a/examples/std/open_telemetry.go
+++ b/examples/std/open_telemetry.go
@@ -3,7 +3,7 @@ package std
 import (
 	"context"
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/examples/std/progress.go
+++ b/examples/std/progress.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func ProgressProfileLogs() error {

--- a/examples/std/qbit.go
+++ b/examples/std/qbit.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func QBit() error {

--- a/examples/std/qbit_subcolumns.go
+++ b/examples/std/qbit_subcolumns.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func QBitSubcolumns() error {

--- a/examples/std/query_parameters.go
+++ b/examples/std/query_parameters.go
@@ -3,8 +3,8 @@ package std
 import (
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/tests/std"
 )
 
 func QueryWithParameters() error {

--- a/examples/std/query_row.go
+++ b/examples/std/query_row.go
@@ -2,7 +2,7 @@ package std
 
 import (
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 	"github.com/google/uuid"
 	"strconv"
 	"time"

--- a/examples/std/query_rows.go
+++ b/examples/std/query_rows.go
@@ -2,7 +2,7 @@ package std
 
 import (
 	"fmt"
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 	"github.com/google/uuid"
 	"strconv"
 	"time"

--- a/examples/std/ssl.go
+++ b/examples/std/ssl.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func ConnectSSL() error {

--- a/examples/std/ssl.go
+++ b/examples/std/ssl.go
@@ -49,7 +49,7 @@ func ConnectDSNSSL() error {
 	if err != nil {
 		return err
 	}
-	conn, err := sql.Open("clickhouse", fmt.Sprintf("https://%s:%d?secure=true&skip_verify=true&username=%s&password=%s", env.Host, env.HttpsPort, env.Username, env.Password))
+	conn, err := sql.Open("clickhouse-v2", fmt.Sprintf("https://%s:%d?secure=true&skip_verify=true&username=%s&password=%s", env.Host, env.HttpsPort, env.Username, env.Password))
 	if err != nil {
 		return err
 	}

--- a/examples/std/utils.go
+++ b/examples/std/utils.go
@@ -3,9 +3,9 @@ package std
 import (
 	"crypto/tls"
 	"database/sql"
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	clickhouse_tests_std "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
+	clickhouse_tests_std "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 )
 
 const TestSet string = "examples_std_api"

--- a/examples/std/variant.go
+++ b/examples/std/variant.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func VariantExample() error {

--- a/ext/ext.go
+++ b/ext/ext.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 func NewTable(name string, columns ...func(t *Table) error) (*Table, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ClickHouse/clickhouse-go/v2
+module github.com/rudderlabs/clickhouse-go/v2
 
 go 1.25.0
 

--- a/lib/column/codegen/column.tpl
+++ b/lib/column/codegen/column.tpl
@@ -17,7 +17,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"github.com/ClickHouse/ch-go/proto"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/chcol"
 )
 
 func (t Type) Column(name string, sc *ServerContext) (Interface, error) {

--- a/lib/column/column_gen.go
+++ b/lib/column/column_gen.go
@@ -8,7 +8,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"github.com/ClickHouse/ch-go/proto"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/chcol"
 	"github.com/google/uuid"
 	"github.com/paulmach/orb"
 	"github.com/shopspring/decimal"

--- a/lib/column/datetime.go
+++ b/lib/column/datetime.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ClickHouse/ch-go/proto"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/timezone"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/timezone"
 )
 
 var (

--- a/lib/column/datetime64.go
+++ b/lib/column/datetime64.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/ClickHouse/ch-go/proto"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/timezone"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/timezone"
 )
 
 var (

--- a/lib/column/dynamic.go
+++ b/lib/column/dynamic.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ClickHouse/ch-go/proto"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/chcol"
 )
 
 const DynamicSerializationVersion = 3

--- a/lib/column/fixed_string.go
+++ b/lib/column/fixed_string.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ClickHouse/ch-go/proto"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/binary"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/binary"
 )
 
 type FixedString struct {

--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/ClickHouse/ch-go/proto"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/binary"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/binary"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/chcol"
 )
 
 const JSONDeprecatedObjectSerializationVersion uint64 = 0

--- a/lib/column/json_bench_test.go
+++ b/lib/column/json_bench_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/chcol"
 )
 
 // newBenchJSONColumn builds a fresh JSON column for each benchmark. The

--- a/lib/column/json_reflect.go
+++ b/lib/column/json_reflect.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/chcol"
 )
 
 // Decoding (Scanning)

--- a/lib/column/json_test.go
+++ b/lib/column/json_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/chcol"
 )
 
 // newTestJSONColumn creates a JSON column with unset serialization version (default state)

--- a/lib/column/orderedmap/orderedmap.go
+++ b/lib/column/orderedmap/orderedmap.go
@@ -4,7 +4,7 @@ import (
 	"cmp"
 	"slices"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
 )
 
 // Map is a simple implementation of [column.IterableOrderedMap] interface.

--- a/lib/column/string.go
+++ b/lib/column/string.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ClickHouse/ch-go/proto"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/binary"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/binary"
 )
 
 type String struct {

--- a/lib/column/variant.go
+++ b/lib/column/variant.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ClickHouse/ch-go/proto"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/chcol"
 )
 
 const SupportedVariantSerializationVersion = 0

--- a/lib/driver/driver.go
+++ b/lib/driver/driver.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 type ServerVersion = proto.ServerHandshake

--- a/lib/proto/block.go
+++ b/lib/proto/block.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ClickHouse/ch-go/proto"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
 )
 
 type Block struct {

--- a/lib/proto/handshake.go
+++ b/lib/proto/handshake.go
@@ -8,7 +8,7 @@ import (
 
 	chproto "github.com/ClickHouse/ch-go/proto"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/timezone"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/timezone"
 )
 
 type ClientHandshake struct {

--- a/query_parameters.go
+++ b/query_parameters.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 var (

--- a/resources/meta.go
+++ b/resources/meta.go
@@ -1,6 +1,6 @@
 package resources
 
-import "github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+import "github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 
 // MinSupportedVersion is the minimum ClickHouse server version supported by this driver.
 var MinSupportedVersion = proto.Version{Major: 25, Minor: 8, Patch: 0}

--- a/scan.go
+++ b/scan.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 type scanSelectQueryFunc func(ctx context.Context, query string, args ...any) (driver.Rows, error)

--- a/tests/abort_test.go
+++ b/tests/abort_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestAbort(t *testing.T) {

--- a/tests/array_test.go
+++ b/tests/array_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestSimpleArray(t *testing.T) {

--- a/tests/base_types_test.go
+++ b/tests/base_types_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 type customUint8 uint8

--- a/tests/batch_block_test.go
+++ b/tests/batch_block_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
 )
 
 // TestBatchAppendRows tests experimental batch rows blocks append feature.

--- a/tests/batch_release_connection_test.go
+++ b/tests/batch_release_connection_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 func TestBatchReleaseConnection(t *testing.T) {

--- a/tests/batch_test.go
+++ b/tests/batch_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestBatchContextCancellation(t *testing.T) {

--- a/tests/bfloat16_test.go
+++ b/tests/bfloat16_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestSimpleBFloat16(t *testing.T) {

--- a/tests/bigint_test.go
+++ b/tests/bigint_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestSimpleBigInt(t *testing.T) {

--- a/tests/bool_test.go
+++ b/tests/bool_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestBool(t *testing.T) {

--- a/tests/client_info_test.go
+++ b/tests/client_info_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 func TestClientInfo(t *testing.T) {

--- a/tests/column_types_test.go
+++ b/tests/column_types_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestColumnTypes(t *testing.T) {

--- a/tests/columnar_batch_test.go
+++ b/tests/columnar_batch_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestColumnarInterface(t *testing.T) {

--- a/tests/compression_test.go
+++ b/tests/compression_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestZSTDCompression(t *testing.T) {

--- a/tests/conn_test.go
+++ b/tests/conn_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestConn(t *testing.T) {

--- a/tests/context_cancel_test.go
+++ b/tests/context_cancel_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestContextCancellationOfHeavyGeneratedInsert(t *testing.T) {

--- a/tests/contributors_test.go
+++ b/tests/contributors_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 // Contributors is retained for backwards compatibility but always returns an

--- a/tests/custom_dial_test.go
+++ b/tests/custom_dial_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestCustomDialContext(t *testing.T) {

--- a/tests/date32_test.go
+++ b/tests/date32_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestDate32(t *testing.T) {

--- a/tests/date_test.go
+++ b/tests/date_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestDate(t *testing.T) {

--- a/tests/datetime64_test.go
+++ b/tests/datetime64_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestDateTime64(t *testing.T) {

--- a/tests/datetime_test.go
+++ b/tests/datetime_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestDateTime(t *testing.T) {

--- a/tests/ddl_test.go
+++ b/tests/ddl_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestQuotedDDL(t *testing.T) {

--- a/tests/decimal_test.go
+++ b/tests/decimal_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestDecimal(t *testing.T) {

--- a/tests/dynamic_test.go
+++ b/tests/dynamic_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 var dynamicTestDate, _ = time.Parse(time.RFC3339, "2024-12-13T02:09:30.123Z")

--- a/tests/empty_query_test.go
+++ b/tests/empty_query_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestEmptyQuery(t *testing.T) {

--- a/tests/enum_test.go
+++ b/tests/enum_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestSimpleEnum(t *testing.T) {

--- a/tests/external_table_test.go
+++ b/tests/external_table_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/ext"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/ext"
 )
 
 func TestExternalTable(t *testing.T) {

--- a/tests/fixed_string_test.go
+++ b/tests/fixed_string_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 type BinFixedString struct {

--- a/tests/float64_test.go
+++ b/tests/float64_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestFloat64(t *testing.T) {

--- a/tests/float_test.go
+++ b/tests/float_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestSimpleFloat(t *testing.T) {

--- a/tests/flush_test.go
+++ b/tests/flush_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 func TestBatchNoFlush(t *testing.T) {

--- a/tests/format_regression_test.go
+++ b/tests/format_regression_test.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/tests/format_test.go
+++ b/tests/format_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 const formatTestDDL = `

--- a/tests/geo_linestring_test.go
+++ b/tests/geo_linestring_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestGeoLineString(t *testing.T) {

--- a/tests/geo_multi_linestring_test.go
+++ b/tests/geo_multi_linestring_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestGeoMultiLineString(t *testing.T) {

--- a/tests/geo_multipolygon_test.go
+++ b/tests/geo_multipolygon_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestGeoMultiPolygon(t *testing.T) {

--- a/tests/geo_point_test.go
+++ b/tests/geo_point_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestGeoPoint(t *testing.T) {

--- a/tests/geo_polygon_test.go
+++ b/tests/geo_polygon_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestGeoPolygon(t *testing.T) {

--- a/tests/geo_ring_test.go
+++ b/tests/geo_ring_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestGeoRing(t *testing.T) {

--- a/tests/has_data_test.go
+++ b/tests/has_data_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestRowsHasData(t *testing.T) {

--- a/tests/http_exception_test.go
+++ b/tests/http_exception_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestHTTPExceptionHandling(t *testing.T) {

--- a/tests/insert_bind_test.go
+++ b/tests/insert_bind_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestBindArrayInsert(t *testing.T) {

--- a/tests/int64_test.go
+++ b/tests/int64_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestDurationInt64(t *testing.T) {

--- a/tests/interval_test.go
+++ b/tests/interval_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestInterval(t *testing.T) {

--- a/tests/ipv4_test.go
+++ b/tests/ipv4_test.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestSimpleIPv4(t *testing.T) {

--- a/tests/ipv6_test.go
+++ b/tests/ipv6_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/ClickHouse/ch-go/proto"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestIPv6(t *testing.T) {

--- a/tests/issues/1016_test.go
+++ b/tests/issues/1016_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1016(t *testing.T) {

--- a/tests/issues/1049_test.go
+++ b/tests/issues/1049_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1049(t *testing.T) {

--- a/tests/issues/1053_test.go
+++ b/tests/issues/1053_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1053(t *testing.T) {

--- a/tests/issues/1066_test.go
+++ b/tests/issues/1066_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1066(t *testing.T) {

--- a/tests/issues/1067_test.go
+++ b/tests/issues/1067_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1067(t *testing.T) {

--- a/tests/issues/1072_test.go
+++ b/tests/issues/1072_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1072(t *testing.T) {

--- a/tests/issues/1106_test.go
+++ b/tests/issues/1106_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1106(t *testing.T) {

--- a/tests/issues/1113_test.go
+++ b/tests/issues/1113_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1113(t *testing.T) {

--- a/tests/issues/1119_test.go
+++ b/tests/issues/1119_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1119(t *testing.T) {

--- a/tests/issues/1127_test.go
+++ b/tests/issues/1127_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1127(t *testing.T) {

--- a/tests/issues/1128_test.go
+++ b/tests/issues/1128_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 const (

--- a/tests/issues/1163_test.go
+++ b/tests/issues/1163_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue1163(t *testing.T) {

--- a/tests/issues/1164_test.go
+++ b/tests/issues/1164_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue1164(t *testing.T) {

--- a/tests/issues/1169_test.go
+++ b/tests/issues/1169_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1169(t *testing.T) {

--- a/tests/issues/1200_pr_test.go
+++ b/tests/issues/1200_pr_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1200(t *testing.T) {

--- a/tests/issues/1216_test.go
+++ b/tests/issues/1216_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1216(t *testing.T) {

--- a/tests/issues/1229_test.go
+++ b/tests/issues/1229_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1229(t *testing.T) {

--- a/tests/issues/1245_test.go
+++ b/tests/issues/1245_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1245Native(t *testing.T) {

--- a/tests/issues/1247_test.go
+++ b/tests/issues/1247_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1247(t *testing.T) {

--- a/tests/issues/1257_test.go
+++ b/tests/issues/1257_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1257(t *testing.T) {

--- a/tests/issues/1271_test.go
+++ b/tests/issues/1271_test.go
@@ -11,12 +11,12 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 // test for https://github.com/ClickHouse/clickhouse-go/issues/1271

--- a/tests/issues/1280_test.go
+++ b/tests/issues/1280_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1280(t *testing.T) {

--- a/tests/issues/1297_test.go
+++ b/tests/issues/1297_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1297(t *testing.T) {

--- a/tests/issues/1299_test.go
+++ b/tests/issues/1299_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue1299(t *testing.T) {

--- a/tests/issues/1300_test.go
+++ b/tests/issues/1300_test.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/issues/1329_test.go
+++ b/tests/issues/1329_test.go
@@ -15,7 +15,7 @@ func Test1329(t *testing.T) {
 	testEnv, err := clickhouse_tests.GetTestEnvironment("issues")
 	require.NoError(t, err)
 	opts := clickhouse_tests.ClientOptionsFromEnv(testEnv, clickhouse.Settings{}, true)
-	conn, err := sql.Open("clickhouse", clickhouse_tests.OptionsToDSN(&opts))
+	conn, err := sql.Open("clickhouse-v2", clickhouse_tests.OptionsToDSN(&opts))
 	require.NoError(t, err)
 
 	_, err = conn.Exec(`CREATE TABLE test_1329 (Col String) Engine MergeTree() ORDER BY tuple()`)

--- a/tests/issues/1329_test.go
+++ b/tests/issues/1329_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1329(t *testing.T) {

--- a/tests/issues/1345_test.go
+++ b/tests/issues/1345_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue1345(t *testing.T) {

--- a/tests/issues/1349_test.go
+++ b/tests/issues/1349_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue1349(t *testing.T) {

--- a/tests/issues/1359_test.go
+++ b/tests/issues/1359_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 type SomeStruct struct {

--- a/tests/issues/1365_test.go
+++ b/tests/issues/1365_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
+	"github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 type T1365OrderedMap int

--- a/tests/issues/1395_test.go
+++ b/tests/issues/1395_test.go
@@ -17,7 +17,7 @@ func Test1395(t *testing.T) {
 	testEnv, err := clickhouse_tests.GetTestEnvironment("issues")
 	require.NoError(t, err)
 	opts := clickhouse_tests.ClientOptionsFromEnv(testEnv, clickhouse.Settings{}, false)
-	conn, err := sql.Open("clickhouse", clickhouse_tests.OptionsToDSN(&opts))
+	conn, err := sql.Open("clickhouse-v2", clickhouse_tests.OptionsToDSN(&opts))
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/tests/issues/1395_test.go
+++ b/tests/issues/1395_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1395(t *testing.T) {

--- a/tests/issues/1421_test.go
+++ b/tests/issues/1421_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 //goland:noinspection ALL

--- a/tests/issues/1446_test.go
+++ b/tests/issues/1446_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 type sampleFailTuple struct {

--- a/tests/issues/1503_test.go
+++ b/tests/issues/1503_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue1503(t *testing.T) {

--- a/tests/issues/1515_test.go
+++ b/tests/issues/1515_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue1515(t *testing.T) {

--- a/tests/issues/1565_test.go
+++ b/tests/issues/1565_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue1565(t *testing.T) {

--- a/tests/issues/1638_test.go
+++ b/tests/issues/1638_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue1638_NullableJSON(t *testing.T) {

--- a/tests/issues/164_test.go
+++ b/tests/issues/164_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 )
 
 func TestIssue164(t *testing.T) {

--- a/tests/issues/1685_test.go
+++ b/tests/issues/1685_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func benchmark1685(ctx context.Context, conn clickhouse.Conn) error {

--- a/tests/issues/1708_test.go
+++ b/tests/issues/1708_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhousetests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhousetests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1708(t *testing.T) {

--- a/tests/issues/1775_test.go
+++ b/tests/issues/1775_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue1775_JSONMapScanOmitsAbsentKeys(t *testing.T) {

--- a/tests/issues/1801_test.go
+++ b/tests/issues/1801_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test1801(t *testing.T) {

--- a/tests/issues/1841_test.go
+++ b/tests/issues/1841_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 // TestIssue1841_JSONSerializationVersion locks the behaviors PR #1850

--- a/tests/issues/1881_test.go
+++ b/tests/issues/1881_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 // TestIssue1881_FixedUTCOffsetTimezone verifies that DateTime / DateTime64

--- a/tests/issues/1881_test.go
+++ b/tests/issues/1881_test.go
@@ -83,7 +83,7 @@ func TestIssue1881_FixedUTCOffsetTimezone(t *testing.T) {
 			}
 			t.Run(proto, func(t *testing.T) {
 				opts := clickhouse_tests.ClientOptionsFromEnv(testEnv, nil, useHTTP)
-				db, err := sql.Open("clickhouse", clickhouse_tests.OptionsToDSN(&opts))
+				db, err := sql.Open("clickhouse-v2", clickhouse_tests.OptionsToDSN(&opts))
 				require.NoError(t, err)
 				t.Cleanup(func() { db.Close() })
 

--- a/tests/issues/1891_test.go
+++ b/tests/issues/1891_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 // TestIssue1891_ArrayBoolQueryParameter covers the fix for #1891: bools in

--- a/tests/issues/1898_test.go
+++ b/tests/issues/1898_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 // TestIssue1898_MapQueryParameter covers the fix for #1898: a Go map sent as

--- a/tests/issues/209/main.go
+++ b/tests/issues/209/main.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func getClickhouseClient() driver.Conn {

--- a/tests/issues/260_test.go
+++ b/tests/issues/260_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/issues/357_test.go
+++ b/tests/issues/357_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/issues/360/main.go
+++ b/tests/issues/360/main.go
@@ -8,9 +8,9 @@ import (
 	_ "net/http/pprof"
 	"time"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 var conn *sql.DB

--- a/tests/issues/389_test.go
+++ b/tests/issues/389_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue389(t *testing.T) {

--- a/tests/issues/406_test.go
+++ b/tests/issues/406_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue406(t *testing.T) {

--- a/tests/issues/412_test.go
+++ b/tests/issues/412_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue412(t *testing.T) {

--- a/tests/issues/470/main.go
+++ b/tests/issues/470/main.go
@@ -6,9 +6,9 @@ import (
 	"log"
 	"reflect"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 
-	_ "github.com/ClickHouse/clickhouse-go/v2"
+	_ "github.com/rudderlabs/clickhouse-go/v2"
 )
 
 type DatabaseFrame struct {

--- a/tests/issues/470_pr_test.go
+++ b/tests/issues/470_pr_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/issues/472_test.go
+++ b/tests/issues/472_test.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/google/uuid"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestIssue472(t *testing.T) {

--- a/tests/issues/476/main.go
+++ b/tests/issues/476/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"reflect"
 
-	_ "github.com/ClickHouse/clickhouse-go/v2"
+	_ "github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func main() {

--- a/tests/issues/476/main.go
+++ b/tests/issues/476/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	c, err := sql.Open("clickhouse", fmt.Sprintf("clickhouse://%s:%s@%s:%d/", "", "", "localhost", 9000))
+	c, err := sql.Open("clickhouse-v2", fmt.Sprintf("clickhouse://%s:%s@%s:%d/", "", "", "localhost", 9000))
 	if err != nil {
 		log.Printf("Can't create connection to db")
 		log.Fatal(err)

--- a/tests/issues/476_test.go
+++ b/tests/issues/476_test.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestIssue476(t *testing.T) {

--- a/tests/issues/482_test.go
+++ b/tests/issues/482_test.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestIssue482(t *testing.T) {

--- a/tests/issues/483_test.go
+++ b/tests/issues/483_test.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestIssue483(t *testing.T) {

--- a/tests/issues/484/main.go
+++ b/tests/issues/484/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 )
 
 func main() {

--- a/tests/issues/485/main.go
+++ b/tests/issues/485/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func example() error {

--- a/tests/issues/502_test.go
+++ b/tests/issues/502_test.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestIssue502(t *testing.T) {

--- a/tests/issues/504_test.go
+++ b/tests/issues/504_test.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestIssue504(t *testing.T) {

--- a/tests/issues/506_test.go
+++ b/tests/issues/506_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue506(t *testing.T) {

--- a/tests/issues/517_test.go
+++ b/tests/issues/517_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue517(t *testing.T) {

--- a/tests/issues/546_test.go
+++ b/tests/issues/546_test.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestIssue546(t *testing.T) {

--- a/tests/issues/548_test.go
+++ b/tests/issues/548_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestIssue548(t *testing.T) {

--- a/tests/issues/570_test.go
+++ b/tests/issues/570_test.go
@@ -59,7 +59,7 @@ func TestIssue570(t *testing.T) {
 	assert.NoError(t, conn.Ping())
 
 	// check we can open with a DSN
-	conn, err = sql.Open("clickhouse", dsn)
+	conn, err = sql.Open("clickhouse-v2", dsn)
 	require.NoError(t, err)
 	assert.NoError(t, conn.Ping())
 }

--- a/tests/issues/570_test.go
+++ b/tests/issues/570_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 )
 
 func TestIssue570(t *testing.T) {

--- a/tests/issues/578_test.go
+++ b/tests/issues/578_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue578(t *testing.T) {

--- a/tests/issues/584_test.go
+++ b/tests/issues/584_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue584(t *testing.T) {

--- a/tests/issues/592_test.go
+++ b/tests/issues/592_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestIssue592(t *testing.T) {

--- a/tests/issues/615_test.go
+++ b/tests/issues/615_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue615(t *testing.T) {

--- a/tests/issues/647_test.go
+++ b/tests/issues/647_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue647(t *testing.T) {

--- a/tests/issues/648_test.go
+++ b/tests/issues/648_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue648(t *testing.T) {

--- a/tests/issues/655_test.go
+++ b/tests/issues/655_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 // Test655 confirms an agreed semantic on failing batch append results with entire batch cancellation.

--- a/tests/issues/692_test.go
+++ b/tests/issues/692_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/ClickHouse/clickhouse-go/v2/tests/std"
-	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2/tests/std"
+	clickhouse_std_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 )
 
 func TestIssue692(t *testing.T) {

--- a/tests/issues/693_test.go
+++ b/tests/issues/693_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 )
 
 func TestIssue693(t *testing.T) {

--- a/tests/issues/741_test.go
+++ b/tests/issues/741_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 )
 
 func TestIssue741(t *testing.T) {

--- a/tests/issues/751_test.go
+++ b/tests/issues/751_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestIssue751(t *testing.T) {

--- a/tests/issues/759_test.go
+++ b/tests/issues/759_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test759(t *testing.T) {

--- a/tests/issues/762_test.go
+++ b/tests/issues/762_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 )
 
 func Test762(t *testing.T) {

--- a/tests/issues/777_test.go
+++ b/tests/issues/777_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestInsertNullableString(t *testing.T) {

--- a/tests/issues/783_test.go
+++ b/tests/issues/783_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 )
 
 func Test783(t *testing.T) {

--- a/tests/issues/798_test.go
+++ b/tests/issues/798_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test798(t *testing.T) {

--- a/tests/issues/812_test.go
+++ b/tests/issues/812_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test812(t *testing.T) {

--- a/tests/issues/813_test.go
+++ b/tests/issues/813_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 )
 
 func Test813(t *testing.T) {

--- a/tests/issues/816_test.go
+++ b/tests/issues/816_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 )
 
 func Test816(t *testing.T) {

--- a/tests/issues/828_test.go
+++ b/tests/issues/828_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test828(t *testing.T) {

--- a/tests/issues/870_test.go
+++ b/tests/issues/870_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test870(t *testing.T) {

--- a/tests/issues/904_test.go
+++ b/tests/issues/904_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test904(t *testing.T) {

--- a/tests/issues/955_test.go
+++ b/tests/issues/955_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test955(t *testing.T) {

--- a/tests/issues/957_test.go
+++ b/tests/issues/957_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func Test957(t *testing.T) {

--- a/tests/issues/990_test.go
+++ b/tests/issues/990_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/ext"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/ext"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 )
 
 func Test990(t *testing.T) {

--- a/tests/issues/issue_1862_test.go
+++ b/tests/issues/issue_1862_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	clickhouse_std_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
+	clickhouse_std_tests "github.com/rudderlabs/clickhouse-go/v2/tests/std"
 )
 
 // queryRowFunc abstracts single-row parameter binding + scan so the same

--- a/tests/issues/issue_1868_test.go
+++ b/tests/issues/issue_1868_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 // failOnWriteConn wraps net.Conn and injects a *net.OpError on the next Write call,

--- a/tests/issues/issue_1877_test.go
+++ b/tests/issues/issue_1877_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 // TestIssue1877_StructuredHTTPExceptions verifies that server exceptions over

--- a/tests/issues/issue_1932_test.go
+++ b/tests/issues/issue_1932_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 // TestIssue1932_LowCardinalityNullableScanClearsDest is a regression test for

--- a/tests/issues/main_test.go
+++ b/tests/issues/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 const testSet string = "issues"

--- a/tests/issues/stress_http_batch_test.go
+++ b/tests/issues/stress_http_batch_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestStressHTTPBatchConcurrency(t *testing.T) {

--- a/tests/json_helper.go
+++ b/tests/json_helper.go
@@ -3,8 +3,8 @@ package tests
 import (
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/chcol"
 )
 
 var JSONTestDate, _ = time.Parse(time.RFC3339, "2024-12-13T02:09:30.123Z")

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 func setupJSONTest(t *testing.T, protocol clickhouse.Protocol) driver.Conn {

--- a/tests/lowcardinality_test.go
+++ b/tests/lowcardinality_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestLowCardinality(t *testing.T) {

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 const testSet string = "native"

--- a/tests/map_test.go
+++ b/tests/map_test.go
@@ -7,13 +7,13 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestMap(t *testing.T) {

--- a/tests/nested_test.go
+++ b/tests/nested_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestSimpleNested(t *testing.T) {

--- a/tests/nothing_test.go
+++ b/tests/nothing_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestNothing(t *testing.T) {

--- a/tests/nullable_array_test.go
+++ b/tests/nullable_array_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestNullableArray(t *testing.T) {

--- a/tests/opentelemetry_test.go
+++ b/tests/opentelemetry_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestOpenTelemetry(t *testing.T) {

--- a/tests/package.go
+++ b/tests/package.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 var LocalClickHouse = false

--- a/tests/query_parameters_test.go
+++ b/tests/query_parameters_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestQueryParameters(t *testing.T) {

--- a/tests/read_only_user_test.go
+++ b/tests/read_only_user_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 func TestReadOnlyUser(t *testing.T) {

--- a/tests/scan_struct_test.go
+++ b/tests/scan_struct_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestQueryRowScanStruct(t *testing.T) {

--- a/tests/simple_aggregate_function_test.go
+++ b/tests/simple_aggregate_function_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestSimpleAggregateFunction(t *testing.T) {

--- a/tests/std/1891_test.go
+++ b/tests/std/1891_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 // TestIssue1891ArrayBoolQueryParameter checks the fix for #1891 through the

--- a/tests/std/1898_test.go
+++ b/tests/std/1898_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 // TestIssue1898MapQueryParameter checks the fix for #1898 through the

--- a/tests/std/array_test.go
+++ b/tests/std/array_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/bigint_test.go
+++ b/tests/std/bigint_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/bool_test.go
+++ b/tests/std/bool_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/client_info_test.go
+++ b/tests/std/client_info_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestClientInfo(t *testing.T) {

--- a/tests/std/close_test.go
+++ b/tests/std/close_test.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestStdConnClose(t *testing.T) {

--- a/tests/std/compression_test.go
+++ b/tests/std/compression_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestCompressionStd(t *testing.T) {

--- a/tests/std/conn_test.go
+++ b/tests/std/conn_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestStdConn(t *testing.T) {

--- a/tests/std/conn_test.go
+++ b/tests/std/conn_test.go
@@ -77,7 +77,7 @@ func testStdConnFailover(t *testing.T, openStrategy string) {
 	}
 	for name, dsn := range dsns {
 		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
-			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
+			if conn, err := sql.Open("clickhouse-v2", dsn); assert.NoError(t, err) {
 				if err := conn.PingContext(context.Background()); assert.NoError(t, err) {
 					t.Log(conn.PingContext(context.Background()))
 				}
@@ -103,7 +103,7 @@ func TestStdPingDeadline(t *testing.T) {
 	}
 	for name, dsn := range dsns {
 		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
-			if conn, err := sql.Open("clickhouse", dsn); assert.NoError(t, err) {
+			if conn, err := sql.Open("clickhouse-v2", dsn); assert.NoError(t, err) {
 				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 				defer cancel()
 				if err := conn.PingContext(ctx); assert.Error(t, err) {
@@ -127,7 +127,7 @@ func TestStdConnAuth(t *testing.T) {
 	}
 	for name, dsn := range dsns {
 		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
-			conn, err := sql.Open("clickhouse", dsn)
+			conn, err := sql.Open("clickhouse-v2", dsn)
 			require.NoError(t, err)
 			require.NoError(t, conn.PingContext(context.Background()))
 			require.NoError(t, conn.Close())
@@ -332,7 +332,7 @@ func TestEmptyDatabaseConfig(t *testing.T) {
 		}
 	}
 
-	setupConn, err := sql.Open("clickhouse", dsns["Native"])
+	setupConn, err := sql.Open("clickhouse-v2", dsns["Native"])
 	require.NoError(t, err)
 
 	// Setup
@@ -341,7 +341,7 @@ func TestEmptyDatabaseConfig(t *testing.T) {
 
 	for name, dsn := range dsns {
 		t.Run(fmt.Sprintf("%s Protocol", name), func(t *testing.T) {
-			conn, err := sql.Open("clickhouse", dsn)
+			conn, err := sql.Open("clickhouse-v2", dsn)
 			require.NoError(t, err)
 			err = conn.Ping()
 			require.NoError(t, err)

--- a/tests/std/connect_check_test.go
+++ b/tests/std/connect_check_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/context_timeout_test.go
+++ b/tests/std/context_timeout_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/custom_dial_test.go
+++ b/tests/std/custom_dial_test.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestStdCustomDial(t *testing.T) {

--- a/tests/std/date32_test.go
+++ b/tests/std/date32_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestStdDate32(t *testing.T) {

--- a/tests/std/date_test.go
+++ b/tests/std/date_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestStdDate(t *testing.T) {

--- a/tests/std/datetime64_test.go
+++ b/tests/std/datetime64_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestStdDateTime64(t *testing.T) {

--- a/tests/std/datetime_test.go
+++ b/tests/std/datetime_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestStdDateTime(t *testing.T) {

--- a/tests/std/ddl_test.go
+++ b/tests/std/ddl_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestQuotedDDL(t *testing.T) {

--- a/tests/std/decimal_test.go
+++ b/tests/std/decimal_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"

--- a/tests/std/dynamic_test.go
+++ b/tests/std/dynamic_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"fmt"
 	"testing"
@@ -12,8 +12,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/chcol"
 )
 
 var dynamicTestDate, _ = time.Parse(time.RFC3339, "2024-12-13T02:09:30.123Z")

--- a/tests/std/enum_test.go
+++ b/tests/std/enum_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/external_table_test.go
+++ b/tests/std/external_table_test.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/ext"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/ext"
 )
 
 func TestStdExternalTable(t *testing.T) {

--- a/tests/std/fixed_string_test.go
+++ b/tests/std/fixed_string_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/geo_linestring_test.go
+++ b/tests/std/geo_linestring_test.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestStdGeoLineString(t *testing.T) {

--- a/tests/std/geo_multi_linestring_test.go
+++ b/tests/std/geo_multi_linestring_test.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestStdGeoMultiLineString(t *testing.T) {

--- a/tests/std/geo_multipolygon_test.go
+++ b/tests/std/geo_multipolygon_test.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestStdGeoMultiPolygon(t *testing.T) {

--- a/tests/std/geo_point_test.go
+++ b/tests/std/geo_point_test.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestStdGeoPoint(t *testing.T) {

--- a/tests/std/geo_polygon_test.go
+++ b/tests/std/geo_polygon_test.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestStdGeoPolygon(t *testing.T) {

--- a/tests/std/geo_ring_test.go
+++ b/tests/std/geo_ring_test.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/paulmach/orb"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestStdGeoRing(t *testing.T) {

--- a/tests/std/http_exception_test.go
+++ b/tests/std/http_exception_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestHTTPExceptionHandlingDB(t *testing.T) {

--- a/tests/std/ipv4_test.go
+++ b/tests/std/ipv4_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/json_test.go
+++ b/tests/std/json_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/chcol"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 var jsonTestDate, _ = time.Parse(time.RFC3339, "2024-12-13T02:09:30.123Z")

--- a/tests/std/lowcardinality_test.go
+++ b/tests/std/lowcardinality_test.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestStdLowCardinality(t *testing.T) {

--- a/tests/std/main_test.go
+++ b/tests/std/main_test.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 const testSet string = "std"

--- a/tests/std/map_test.go
+++ b/tests/std/map_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/materialized_column_test.go
+++ b/tests/std/materialized_column_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestMaterializedColumnInsert(t *testing.T) {

--- a/tests/std/nested_test.go
+++ b/tests/std/nested_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestStdNested(t *testing.T) {

--- a/tests/std/query_parameters_test.go
+++ b/tests/std/query_parameters_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestQueryParameters(t *testing.T) {

--- a/tests/std/string_test.go
+++ b/tests/std/string_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func TestSimpleStdString(t *testing.T) {

--- a/tests/std/temporary_table_test.go
+++ b/tests/std/temporary_table_test.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestStdTemporaryTable(t *testing.T) {

--- a/tests/std/totals_test.go
+++ b/tests/std/totals_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/std/tuples_test.go
+++ b/tests/std/tuples_test.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 var testDate, _ = time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", "2022-05-25 17:20:57 +0100 WEST")

--- a/tests/std/utils.go
+++ b/tests/std/utils.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 )
 
 func GetStdTestEnvironment() (clickhouse_tests.ClickHouseTestEnvironment, error) {

--- a/tests/std/utils.go
+++ b/tests/std/utils.go
@@ -103,7 +103,7 @@ func GetDSNConnection(environment string, protocol clickhouse.Protocol, secure b
 		RawQuery: query.Encode(),
 	}
 
-	return sql.Open("clickhouse", dsn.String())
+	return sql.Open("clickhouse-v2", dsn.String())
 }
 
 func GetConnectionFromDSN(dsn string) (*sql.DB, error) {
@@ -111,7 +111,7 @@ func GetConnectionFromDSN(dsn string) (*sql.DB, error) {
 }
 
 func GetConnectionFromDSNWithSessionID(dsn string, sessionID string) (*sql.DB, error) {
-	conn, err := sql.Open("clickhouse", dsn)
+	conn, err := sql.Open("clickhouse-v2", dsn)
 	if err != nil {
 		return conn, err
 	}
@@ -147,7 +147,7 @@ func GetConnectionFromDSNWithSessionID(dsn string, sessionID string) (*sql.DB, e
 		}
 	}
 
-	return sql.Open("clickhouse", dsn)
+	return sql.Open("clickhouse-v2", dsn)
 }
 
 func GetConnectionWithOptions(options *clickhouse.Options) *sql.DB {

--- a/tests/std/uuid_test.go
+++ b/tests/std/uuid_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"

--- a/tests/std/variant_test.go
+++ b/tests/std/variant_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"fmt"
 	"testing"
@@ -12,8 +12,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/chcol"
 )
 
 var variantTestDate, _ = time.Parse(time.RFC3339, "2024-12-13T02:09:30.123Z")

--- a/tests/stress/stress.go
+++ b/tests/stress/stress.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+	clickhouse_tests "github.com/rudderlabs/clickhouse-go/v2/tests"
 
 	"net/http"
 	_ "net/http/pprof"
@@ -16,8 +16,8 @@ import (
 	"github.com/google/uuid"
 	_ "github.com/mkevac/debugcharts"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 type App struct {

--- a/tests/string_test.go
+++ b/tests/string_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 type testStr struct {

--- a/tests/struct_map_test.go
+++ b/tests/struct_map_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestAppendStruct(t *testing.T) {

--- a/tests/time64_test.go
+++ b/tests/time64_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func setupTime64Test(t *testing.T, protocol clickhouse.Protocol) clickhouse.Conn {

--- a/tests/time_mixed_test.go
+++ b/tests/time_mixed_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func setupTimeMixedTest(t *testing.T, protocol clickhouse.Protocol) clickhouse.Conn {

--- a/tests/time_test.go
+++ b/tests/time_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func setupTimeTest(t *testing.T, protocol clickhouse.Protocol) clickhouse.Conn {

--- a/tests/totals_test.go
+++ b/tests/totals_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestWithTotals(t *testing.T) {

--- a/tests/tuple_test.go
+++ b/tests/tuple_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 
 	"github.com/stretchr/testify/require"
 

--- a/tests/uint8_test.go
+++ b/tests/uint8_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 )
 
 func TestBoolUInt8(t *testing.T) {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -29,9 +29,9 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/proto"
 )
 
 var testUUID = uuid.NewString()[0:12]

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -446,7 +446,7 @@ func TestClientWithDefaultSettings(env ClickHouseTestEnvironment) (driver.Conn, 
 
 func TestDatabaseSQLClientWithDefaultOptions(env ClickHouseTestEnvironment, settings clickhouse.Settings) (*sql.DB, error) {
 	opts := ClientOptionsFromEnv(env, settings, false)
-	return sql.Open("clickhouse", OptionsToDSN(&opts))
+	return sql.Open("clickhouse-v2", OptionsToDSN(&opts))
 }
 
 func TestDatabaseSQLClientWithDefaultSettings(env ClickHouseTestEnvironment) (*sql.DB, error) {

--- a/tests/uuid_test.go
+++ b/tests/uuid_test.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/column"
 
 	"github.com/google/uuid"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/variant_test.go
+++ b/tests/variant_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/rudderlabs/clickhouse-go/v2"
+	"github.com/rudderlabs/clickhouse-go/v2/lib/driver"
 )
 
 var variantTestDate, _ = time.Parse(time.RFC3339, "2024-12-13T02:09:30.123Z")


### PR DESCRIPTION
## Summary

- Forks `ClickHouse/clickhouse-go` v2 as `rudderlabs/clickhouse-go`, with two patches on top of upstream:
  - Module path → `github.com/rudderlabs/clickhouse-go/v2`
  - `database/sql` driver name → `clickhouse-v2` (was `clickhouse`)
- Resolves INT-7015.
