### PR TITLE
Replace github.com/google/uuid with stdlib uuid (Go 1.27)

### DIFF
--- a/examples/clickhouse_api/batch.go
+++ b/examples/clickhouse_api/batch.go
@@ -2,7 +2,7 @@ package clickhouse_api
 
 import (
 	"context"
-	"github.com/google/uuid"
+	"uuid"
 	"time"
 )
 

--- a/examples/clickhouse_api/context.go
+++ b/examples/clickhouse_api/context.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
-	"github.com/google/uuid"
+	"uuid"
 )
 
 func UseContext() error {
@@ -68,7 +68,7 @@ func UseContext() error {
 
 	// set a query id to assist tracing queries in logs e.g. see system.query_log
 	var one uint8
-	queryId, _ := uuid.NewUUID()
+	queryId := uuid.New()
 	ctx = clickhouse.Context(context.Background(), clickhouse.WithQueryID(queryId.String()))
 	if err = conn.QueryRow(ctx, "SELECT 1").Scan(&one); err != nil {
 		return err

--- a/examples/clickhouse_api/query_row.go
+++ b/examples/clickhouse_api/query_row.go
@@ -3,7 +3,7 @@ package clickhouse_api
 import (
 	"context"
 	"fmt"
-	"github.com/google/uuid"
+	"uuid"
 	"strconv"
 	"time"
 )

--- a/examples/clickhouse_api/uuid.go
+++ b/examples/clickhouse_api/uuid.go
@@ -3,7 +3,7 @@ package clickhouse_api
 import (
 	"context"
 	"fmt"
-	"github.com/google/uuid"
+	"uuid"
 )
 
 func UUIDInsertRead() error {
@@ -28,7 +28,7 @@ func UUIDInsertRead() error {
 	if err != nil {
 		return err
 	}
-	col1Data, _ := uuid.NewUUID()
+	col1Data := uuid.New()
 	if err = batch.Append(
 		col1Data,
 		"603966d6-ed93-11ec-8ea0-0242ac120002",

--- a/examples/std/batch.go
+++ b/examples/std/batch.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	_ "github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/google/uuid"
+	"uuid"
 )
 
 func BatchInsert() error {

--- a/examples/std/context.go
+++ b/examples/std/context.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests/std"
-	"github.com/google/uuid"
+	"uuid"
 )
 
 func UseContext() error {
@@ -50,7 +50,7 @@ func UseContext() error {
 
 	// set a query id to assist tracing queries in logs e.g. see system.query_log
 	var one uint8
-	ctx = clickhouse.Context(context.Background(), clickhouse.WithQueryID(uuid.NewString()))
+	ctx = clickhouse.Context(context.Background(), clickhouse.WithQueryID(uuid.New().String()))
 	if err = conn.QueryRowContext(ctx, "SELECT 1").Scan(&one); err != nil {
 		return err
 	}

--- a/examples/std/query_row.go
+++ b/examples/std/query_row.go
@@ -3,7 +3,7 @@ package std
 import (
 	"fmt"
 	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/google/uuid"
+	"uuid"
 	"strconv"
 	"time"
 )

--- a/examples/std/query_rows.go
+++ b/examples/std/query_rows.go
@@ -3,7 +3,7 @@ package std
 import (
 	"fmt"
 	"github.com/ClickHouse/clickhouse-go/v2"
-	"github.com/google/uuid"
+	"uuid"
 	"strconv"
 	"time"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,13 @@
 module github.com/ClickHouse/clickhouse-go/v2
 
-go 1.25.0
+go 1.27
 
-toolchain go1.25.4
+toolchain go1.27rc3
 
 require (
 	github.com/ClickHouse/ch-go v0.74.0
 	github.com/andybalholm/brotli v1.2.2
 	github.com/docker/go-units v0.5.0
-	github.com/google/uuid v1.6.0
 	github.com/mkevac/debugcharts v0.0.0-20191222103121-ae1c48aa8615
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.1
@@ -19,8 +18,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.45.0
 	golang.org/x/net v0.58.0
 )
-
-require go.opentelemetry.io/otel v1.45.0 // indirect
 
 require (
 	dario.cat/mergo v1.0.2 // indirect
@@ -42,6 +39,7 @@ require (
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/klauspost/compress v1.19.1 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e // indirect
@@ -66,6 +64,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 // indirect
+	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/lib/column/array_gen.go
+++ b/lib/column/array_gen.go
@@ -8,7 +8,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"github.com/ClickHouse/ch-go/proto"
-	"github.com/google/uuid"
+	"uuid"
 	"github.com/paulmach/orb"
 	"github.com/shopspring/decimal"
 	"math/big"

--- a/lib/column/column_gen.go
+++ b/lib/column/column_gen.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"github.com/ClickHouse/ch-go/proto"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
-	"github.com/google/uuid"
+	"uuid"
 	"github.com/paulmach/orb"
 	"github.com/shopspring/decimal"
 	"math/big"

--- a/lib/column/dynamic_gen.go
+++ b/lib/column/dynamic_gen.go
@@ -7,7 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"github.com/ClickHouse/ch-go/proto"
-	"github.com/google/uuid"
+	"uuid"
 	"github.com/paulmach/orb"
 	"time"
 )

--- a/lib/column/tuple.go
+++ b/lib/column/tuple.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/ClickHouse/ch-go/proto"
-	"github.com/google/uuid"
+	"uuid"
 	"github.com/shopspring/decimal"
 )
 

--- a/lib/column/uuid.go
+++ b/lib/column/uuid.go
@@ -7,8 +7,9 @@ import (
 	"reflect"
 
 	"github.com/ClickHouse/ch-go/proto"
+	guuid "github.com/google/uuid"
 
-	"github.com/google/uuid"
+	"uuid"
 )
 
 type UUID struct {
@@ -80,7 +81,7 @@ func (col *UUID) Append(v any) (nulls []uint8, err error) {
 			if err != nil {
 				return
 			}
-			col.col.Append(u)
+			col.appendToCol(u)
 		}
 	case []*string:
 		nulls = make([]uint8, len(v))
@@ -92,26 +93,26 @@ func (col *UUID) Append(v any) (nulls []uint8, err error) {
 				if err != nil {
 					return
 				}
-				col.col.Append(value)
+				col.appendToCol(value)
 			default:
 				nulls[i] = 1
-				col.col.Append(uuid.UUID{})
+				col.appendToCol(uuid.UUID{})
 			}
 		}
 	case []uuid.UUID:
 		nulls = make([]uint8, len(v))
 		for _, v := range v {
-			col.col.Append(v)
+			col.appendToCol(v)
 		}
 	case []*uuid.UUID:
 		nulls = make([]uint8, len(v))
 		for i, v := range v {
 			switch {
 			case v != nil:
-				col.col.Append(*v)
+				col.appendToCol(*v)
 			default:
 				nulls[i] = 1
-				col.col.Append(uuid.UUID{})
+				col.appendToCol(uuid.UUID{})
 			}
 		}
 	default:
@@ -144,7 +145,7 @@ func (col *UUID) AppendRow(v any) error {
 		if err != nil {
 			return err
 		}
-		col.col.Append(u)
+		col.appendToCol(u)
 	case *string:
 		switch {
 		case v != nil:
@@ -152,21 +153,21 @@ func (col *UUID) AppendRow(v any) error {
 			if err != nil {
 				return err
 			}
-			col.col.Append(value)
+			col.appendToCol(value)
 		default:
-			col.col.Append(uuid.UUID{})
+			col.appendToCol(uuid.UUID{})
 		}
 	case uuid.UUID:
-		col.col.Append(v)
+		col.appendToCol(v)
 	case *uuid.UUID:
 		switch {
 		case v != nil:
-			col.col.Append(*v)
+			col.appendToCol(*v)
 		default:
-			col.col.Append(uuid.UUID{})
+			col.appendToCol(uuid.UUID{})
 		}
 	case nil:
-		col.col.Append(uuid.UUID{})
+		col.appendToCol(uuid.UUID{})
 	default:
 		if valuer, ok := v.(driver.Valuer); ok {
 			val, err := valuer.Value()
@@ -200,8 +201,12 @@ func (col *UUID) Encode(buffer *proto.Buffer) {
 	col.col.EncodeColumn(buffer)
 }
 
-func (col *UUID) row(i int) (uuid uuid.UUID) {
-	return col.col.Row(i)
+func (col *UUID) row(i int) (u uuid.UUID) {
+	return uuid.UUID(col.col.Row(i))
+}
+
+func (col *UUID) appendToCol(u uuid.UUID) {
+	col.col.Append(guuid.UUID(u))
 }
 
 var _ Interface = (*UUID)(nil)

--- a/tests/flush_test.go
+++ b/tests/flush_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ClickHouse/clickhouse-go/v2"

--- a/tests/issues/1271_test.go
+++ b/tests/issues/1271_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"uuid"
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 

--- a/tests/issues/472_test.go
+++ b/tests/issues/472_test.go
@@ -9,7 +9,7 @@ import (
 
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 
-	"github.com/google/uuid"
+	"uuid"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 )

--- a/tests/issues/741_test.go
+++ b/tests/issues/741_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"uuid"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 

--- a/tests/nullable_array_test.go
+++ b/tests/nullable_array_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/google/uuid"
+	"uuid"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 

--- a/tests/std/uuid_test.go
+++ b/tests/std/uuid_test.go
@@ -9,7 +9,7 @@ import (
 
 	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
 
-	"github.com/google/uuid"
+	"uuid"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tests/stress/stress.go
+++ b/tests/stress/stress.go
@@ -13,7 +13,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 
-	"github.com/google/uuid"
+	"uuid"
 	_ "github.com/mkevac/debugcharts"
 
 	"github.com/ClickHouse/clickhouse-go/v2"

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
-	"github.com/google/uuid"
+	"uuid"
 	"github.com/moby/moby/api/types/container"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -34,7 +34,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/proto"
 )
 
-var testUUID = uuid.NewString()[0:12]
+var testUUID = uuid.New().String()[0:12]
 var testTimestamp = time.Now().UnixMilli()
 var randSeed = time.Now().UnixNano()
 

--- a/tests/uuid_test.go
+++ b/tests/uuid_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2/lib/column"
 
-	"github.com/google/uuid"
+	"uuid"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 


### PR DESCRIPTION
- switch UUID column driver paths to the standard library uuid package
- go directive 1.25 -> 1.27, toolchain go1.27rc3
- google/uuid retained only as an indirect dep for ch-go proto boundary (proto.ColUUID is typed google/uuid.UUID; converted at the column edge)

## Summary
<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
