### PR TITLE
Fix HTTP Exec treating 200 + ClickHouse exception as success.

### DIFF
--- a/conn_http_errors.go
+++ b/conn_http_errors.go
@@ -235,14 +235,14 @@ func parseHTTPException(text, headerCode, headerName string) *Exception {
 	return &Exception{Code: int32(code), Name: name, CodeName: codeName, Message: msg}
 }
 
-// insertResponseError drains a 200 insert response and surfaces a server
-// exception that was flushed after the status line. An insert normally
-// answers 200 with an empty body, but when the failure happens after the
-// headers went out (send_progress_in_http_headers enabled, or the insert
-// outlived the response buffer) the only failure signal is an in-band
-// "__exception__" block on an otherwise successful-looking response. Result
-// data cannot appear in an insert response, so the framed marker alone is
-// trustworthy here.
+// insertResponseError drains a 200 insert/exec response and surfaces a server
+// exception that was flushed after the status line. Those paths normally
+// answer 200 with an empty body, but when the failure happens after the
+// headers went out (send_progress_in_http_headers enabled, or the query
+// outlived the response buffer) the failure signal is an in-band
+// "__exception__" block and/or X-ClickHouse-Exception-Code on an otherwise
+// successful-looking response. Result data cannot appear in an insert or exec
+// response, so either signal is trustworthy here.
 func (h *httpConnect) insertResponseError(res *http.Response) error {
 	body, err := h.readRawResponse(res)
 	discardAndClose(res.Body)
@@ -251,6 +251,11 @@ func (h *httpConnect) insertResponseError(res *http.Response) error {
 	}
 	if isFramedException(body) {
 		return parseExceptionFromBytes(body)
+	}
+	if headerCode := res.Header.Get(exceptionCodeHeader); headerCode != "" {
+		if ex := parseHTTPException(string(body), headerCode, res.Header.Get(exceptionNameHeader)); ex != nil {
+			return ex
+		}
 	}
 	return nil
 }

--- a/conn_http_exec.go
+++ b/conn_http_exec.go
@@ -15,7 +15,9 @@ func (h *httpConnect) exec(ctx context.Context, query string, args ...any) error
 	if err != nil {
 		return err
 	}
-	defer discardAndClose(res.Body)
-
-	return nil
+	// Exec answers 200 with an empty body on success. A failure after the
+	// status line was flushed shows up as an in-band "__exception__" block
+	// and/or X-ClickHouse-Exception-Code — same as insert/batch, not as a
+	// non-200 status. Discarding the body here used to report those as nil.
+	return h.insertResponseError(res)
 }

--- a/conn_http_exec_test.go
+++ b/conn_http_exec_test.go
@@ -1,0 +1,84 @@
+package clickhouse
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPExecEmptyBodyIsSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	h := newTestHTTPConnect(t, srv.URL)
+	require.NoError(t, h.exec(context.Background(), "CREATE TABLE t (a Int64) ENGINE = Memory"))
+}
+
+func TestHTTPExecInBandExceptionOn200(t *testing.T) {
+	// Same hole insertFormat already closed: a DDL/exec whose failure arrives
+	// after the 200 headers must not report success.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(taggedExceptionPayload))
+	}))
+	defer srv.Close()
+
+	h := newTestHTTPConnect(t, srv.URL)
+	err := h.exec(context.Background(), "DROP TABLE t")
+	require.Error(t, err)
+	var ex *Exception
+	require.ErrorAs(t, err, &ex)
+	assert.Equal(t, int32(395), ex.Code)
+}
+
+func TestHTTPExecExceptionCodeHeaderOn200(t *testing.T) {
+	// Mid-stream failure after the status line was flushed: some servers keep
+	// HTTP 200 and put the code on X-ClickHouse-Exception-Code with a plain
+	// (not "__exception__"-framed) body. Exec used to discard that as success.
+	const body = "Code: 44. DB::Exception: Sorting key contains nullable columns. (ILLEGAL_COLUMN)"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set(exceptionCodeHeader, "44")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	h := newTestHTTPConnect(t, srv.URL)
+	err := h.exec(context.Background(),
+		"CREATE TABLE t (a Nullable(String)) ENGINE = MergeTree PRIMARY KEY a")
+	require.Error(t, err)
+	var ex *Exception
+	require.ErrorAs(t, err, &ex)
+	assert.Equal(t, int32(44), ex.Code)
+	assert.Contains(t, err.Error(), "nullable")
+}
+
+func TestInsertFormatExceptionCodeHeaderOn200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set(exceptionCodeHeader, "44")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Code: 44. DB::Exception: Sorting key contains nullable columns"))
+	}))
+	defer srv.Close()
+
+	h := newTestHTTPConnect(t, srv.URL)
+	err := h.insertFormat(context.Background(),
+		func(_ nativeTransport, _ error) {},
+		"CSV", "INSERT INTO t (a)", strings.NewReader("1\n"))
+	require.Error(t, err)
+	var ex *Exception
+	require.ErrorAs(t, err, &ex)
+	assert.Equal(t, int32(44), ex.Code)
+}


### PR DESCRIPTION
## Summary
- HTTP `Exec` treated `200 OK` as success even when ClickHouse already reported a failure (`__exception__` body and/or `X-ClickHouse-Exception-Code`).
- Reuse the same drain/parse path INSERT already uses.
- Unit tests with `httptest` (no live ClickHouse).

Fixes #1859