### PR TITLE
Do not hold pool mutex while waiting for drain goroutine

### DIFF
--- a/conn_pool.go
+++ b/conn_pool.go
@@ -19,6 +19,7 @@ type connPool struct {
 	ticker   *time.Ticker
 	finish   chan struct{}
 	finished chan struct{}
+	closing  bool
 
 	maxConnLifetime time.Duration
 }
@@ -116,17 +117,21 @@ func (i *connPool) Put(conn nativeTransport) {
 
 func (i *connPool) Close() error {
 	i.mu.Lock()
-	defer i.mu.Unlock()
-
-	if i.closed() {
+	if i.closed() || i.closing {
+		i.mu.Unlock()
 		return nil
 	}
-
+	i.closing = true
 	close(i.finish)
+	// Release the mutex before waiting for the drain goroutine. Holding it
+	// across <-finished deadlocks if that goroutine is blocked on Lock in
+	// the ticker branch.
+	i.mu.Unlock()
 
 	<-i.finished
 
-	// Drain all remaining connections from the pool
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	i.drainPool()
 
 	return nil
@@ -151,6 +156,10 @@ func (i *connPool) runDrainPool() {
 		select {
 		case <-i.ticker.C:
 			i.mu.Lock()
+			if i.closing {
+				i.mu.Unlock()
+				return
+			}
 			i.drainPool()
 			i.mu.Unlock()
 		case <-i.finish:

--- a/conn_pool_sync_test.go
+++ b/conn_pool_sync_test.go
@@ -67,3 +67,16 @@ func TestConnPool_ExpiredConnectionsAreDrained(t *testing.T) {
 		synctest.Wait()
 	})
 }
+
+func TestConnPool_CloseDuringTickerTick(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		pool := newConnPool(50*time.Millisecond, 5)
+		pool.Put(&mockTransport{connectedAt: time.Now(), id: 1})
+
+		time.Sleep(50 * time.Millisecond)
+		synctest.Wait()
+
+		require.NoError(t, pool.Close())
+		require.NoError(t, pool.Close())
+	})
+}

--- a/conn_pool_test.go
+++ b/conn_pool_test.go
@@ -529,6 +529,30 @@ func TestConnPool_FIFOOrdering(t *testing.T) {
 	}
 }
 
+func TestConnPool_CloseDoesNotDeadlockWithDrainTicker(t *testing.T) {
+	// Close used to hold mu while waiting for runDrainPool. If the drain
+	// goroutine had already woken on ticker.C and was blocked on that
+	// same mutex, neither side made progress.
+	for range 50 {
+		pool := newConnPool(time.Millisecond, 5)
+		pool.Put(&mockTransport{connectedAt: time.Now(), id: 1})
+
+		done := make(chan struct{})
+		go func() {
+			assert.NoError(t, pool.Close())
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Fatal("Close deadlocked against runDrainPool")
+		}
+
+		assert.NoError(t, pool.Close())
+	}
+}
+
 // mockTransport implements nativeTransport for testing
 type mockTransport struct {
 	connectedAt   time.Time


### PR DESCRIPTION
Fixes #1990

`connPool.Close` held `mu` across `<-i.finished`. `runDrainPool` acquires the same mutex in the ticker branch. If Close ran while that goroutine was already queued on `Lock`, Close waited for `finished` and the drain goroutine waited for `mu`: permanent hang, and every later `Get`/`Put` stuck behind the held lock.

Close now records `closing` and signals `finish` under the lock, releases it before waiting, then drains remaining connections after the background goroutine has exited. A second `Close` is still a no-op.

The drain loop also returns immediately if it observes `closing` after taking the lock on a ticker tick.