### PR TITLE
fix: keep a single query_id for native batch INSERT

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -411,3 +411,27 @@ INSERT INTO ` + "`_test_1345# $.ДБ`.`2. Таблица №2`" + ` (col1, col2)
 		})
 	}
 }
+
+func TestDisableAsyncInsertUnlessSet(t *testing.T) {
+	t.Run("sets zero when unset", func(t *testing.T) {
+		o := QueryOptions{settings: make(Settings)}
+		disableAsyncInsertUnlessSet(nil, &o)
+		assert.Equal(t, 0, o.settings["async_insert"])
+	})
+	t.Run("initializes nil settings", func(t *testing.T) {
+		o := QueryOptions{}
+		disableAsyncInsertUnlessSet(&Options{}, &o)
+		assert.Equal(t, 0, o.settings["async_insert"])
+	})
+	t.Run("respects query setting", func(t *testing.T) {
+		o := QueryOptions{settings: Settings{"async_insert": 1}}
+		disableAsyncInsertUnlessSet(nil, &o)
+		assert.Equal(t, 1, o.settings["async_insert"])
+	})
+	t.Run("respects connection setting", func(t *testing.T) {
+		o := QueryOptions{settings: make(Settings)}
+		disableAsyncInsertUnlessSet(&Options{Settings: Settings{"async_insert": 1}}, &o)
+		_, setOnQuery := o.settings["async_insert"]
+		assert.False(t, setOnQuery)
+	})
+}

--- a/batch_test.go
+++ b/batch_test.go
@@ -428,6 +428,23 @@ func TestDisableAsyncInsertUnlessSet(t *testing.T) {
 		disableAsyncInsertUnlessSet(nil, &o)
 		assert.Equal(t, 1, o.settings["async_insert"])
 	})
+	t.Run("honors WithAsync true", func(t *testing.T) {
+		o := QueryOptions{async: AsyncOptions{ok: true, wait: true}}
+		disableAsyncInsertUnlessSet(nil, &o)
+		assert.Equal(t, 1, o.settings["async_insert"])
+		assert.Equal(t, 1, o.settings["wait_for_async_insert"])
+	})
+	t.Run("honors WithAsync false wait", func(t *testing.T) {
+		o := QueryOptions{async: AsyncOptions{ok: true, wait: false}}
+		disableAsyncInsertUnlessSet(&Options{Settings: Settings{"async_insert": 0}}, &o)
+		assert.Equal(t, 1, o.settings["async_insert"])
+		assert.Equal(t, 0, o.settings["wait_for_async_insert"])
+	})
+	t.Run("query setting wins over WithAsync", func(t *testing.T) {
+		o := QueryOptions{settings: Settings{"async_insert": 0}, async: AsyncOptions{ok: true, wait: true}}
+		disableAsyncInsertUnlessSet(nil, &o)
+		assert.Equal(t, 0, o.settings["async_insert"])
+	})
 	t.Run("respects connection setting", func(t *testing.T) {
 		o := QueryOptions{settings: make(Settings)}
 		disableAsyncInsertUnlessSet(&Options{Settings: Settings{"async_insert": 1}}, &o)

--- a/conn_batch.go
+++ b/conn_batch.go
@@ -19,6 +19,31 @@ import (
 var insertMatch = regexp.MustCompile(`(?i)(?:(?:--[^\n]*|#![^\n]*|#\s[^\n]*)\n\s*)*(INSERT\s+INTO\s+[^( ]+(?:\s*\([^()]*(?:\([^()]*\)[^()]*)*\))?)(?:\s*VALUES)?`)
 var columnMatch = regexp.MustCompile(`INSERT INTO .+\s\((?P<Columns>.+)\)$`)
 
+// disableAsyncInsertUnlessSet sets `async_insert=0` when the caller did not set
+// it on the query context or connection. ClickHouse 26.3+ defaults
+// `async_insert=1`, so a single PrepareBatch/Send is logged twice in
+// `system.query_log`: the client INSERT under the intended `query_id`, then a
+// server flush that rewrites the table as `database.table` and assigns a new
+// UUID. See https://github.com/ClickHouse/clickhouse-go/issues/1997.
+// PrepareBatch already buffers client-side, so the extra flush is redundant
+// unless the user opted in.
+func disableAsyncInsertUnlessSet(opt *Options, o *QueryOptions) {
+	if o.settings != nil {
+		if _, ok := o.settings["async_insert"]; ok {
+			return
+		}
+	}
+	if opt != nil && opt.Settings != nil {
+		if _, ok := opt.Settings["async_insert"]; ok {
+			return
+		}
+	}
+	if o.settings == nil {
+		o.settings = make(Settings)
+	}
+	o.settings["async_insert"] = 0
+}
+
 func (c *connect) prepareBatch(ctx context.Context, release nativeTransportRelease, acquire nativeTransportAcquire, query string, opts driver.PrepareBatchOptions) (driver.Batch, error) {
 	query, _, queryColumns, verr := extractNormalizedInsertQueryAndColumns(query)
 	if verr != nil {
@@ -26,6 +51,7 @@ func (c *connect) prepareBatch(ctx context.Context, release nativeTransportRelea
 	}
 
 	options := queryOptions(ctx)
+	disableAsyncInsertUnlessSet(c.opt, &options)
 	if deadline, ok := ctx.Deadline(); ok {
 		c.conn.SetDeadline(deadline)
 		defer c.conn.SetDeadline(time.Time{})
@@ -250,6 +276,7 @@ func (b *batch) resetConnection() (err error) {
 	}()
 
 	options := queryOptions(b.ctx)
+	disableAsyncInsertUnlessSet(b.conn.opt, &options)
 	if deadline, ok := b.ctx.Deadline(); ok {
 		b.conn.conn.SetDeadline(deadline)
 		defer b.conn.conn.SetDeadline(time.Time{})

--- a/conn_batch.go
+++ b/conn_batch.go
@@ -33,6 +33,19 @@ func disableAsyncInsertUnlessSet(opt *Options, o *QueryOptions) {
 			return
 		}
 	}
+	// WithAsync / WithStdAsync is a query-level opt-in; honor it before
+	// falling back to the connection setting or the batch default of 0.
+	if o.async.ok {
+		if o.settings == nil {
+			o.settings = make(Settings)
+		}
+		o.settings["async_insert"] = 1
+		o.settings["wait_for_async_insert"] = 0
+		if o.async.wait {
+			o.settings["wait_for_async_insert"] = 1
+		}
+		return
+	}
 	if opt != nil && opt.Settings != nil {
 		if _, ok := opt.Settings["async_insert"]; ok {
 			return

--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -235,6 +235,7 @@ func (b *httpBatch) Send() (err error) {
 	}
 
 	options := queryOptions(b.ctx)
+	disableAsyncInsertUnlessSet(b.conn.opt, &options)
 	headers := make(map[string]string)
 	switch b.conn.compression {
 	case CompressionGZIP, CompressionDeflate, CompressionBrotli:

--- a/docs/clickhouse-api.mdx
+++ b/docs/clickhouse-api.mdx
@@ -64,6 +64,17 @@ Note the ability to pass a Context to the query. This can be used to pass specif
 
 To insert a large number of rows, the client provides batch semantics. This requires the preparation of a batch to which rows can be appended. This is finally sent via the `Send()` method. Batches are held in memory until `Send` is executed.
 
+:::warning Batch async-insert default
+For both native and HTTP batches, the driver sends `async_insert=0` unless async inserts are explicitly enabled in the query context or configured in the connection's `Settings`.
+This overrides a server-side `async_insert=1` default, including one set in a user profile.
+It is a behavior change for applications that previously relied on the server default to combine small batches: those batches now execute synchronously and are no longer coalesced by the server's async-insert buffer.
+
+To continue using async inserts, set `async_insert` explicitly in the connection's `Settings`, or pass `clickhouse.Context(ctx, clickhouse.WithAsync(true))` to `PrepareBatch`.
+`WithAsync(true)` enables async inserts and waits for the server to flush them; `WithAsync(false)` enables async inserts without waiting for the flush.
+An explicit query-level `async_insert` setting takes precedence over `WithAsync`, followed by the connection setting, then the batch default of `0`.
+This batch default does not change ordinary `Exec` inserts.
+:::
+
 It is recommended to call `Close` on the batch to prevent leaking connections. This can be done via the `defer` keyword after preparing the batch. This will clean up the connection if `Send` never gets called. Note that this will result in 0 row inserts showing up in the query log if no rows were appended.
 
 ```go

--- a/docs/database-sql-api.mdx
+++ b/docs/database-sql-api.mdx
@@ -228,6 +228,16 @@ This method doesn't support receiving a context - by default, it executes with t
 
 Batch semantics can be achieved by creating a `sql.Tx` via the `Being` method. From this, a batch can be obtained using the `Prepare` method with the `INSERT` statement. This returns a `sql.Stmt` to which rows can be appended using the `Exec` method. The batch will be accumulated in memory until `Commit` is executed on the original `sql.Tx`.
 
+:::warning Batch async-insert default
+Prepared batches send `async_insert=0` unless the query context or connection settings explicitly configure async inserts.
+This overrides a server-side `async_insert=1` default, including user-profile defaults, and changes applications that previously relied on server-side coalescing of small batches to synchronous inserts.
+
+To keep async inserts enabled, set `async_insert=1` in the connection settings, or pass `clickhouse.Context(ctx, clickhouse.WithAsync(true))` to `tx.PrepareContext`.
+The `true` argument waits for the async flush; `false` enables async inserts without waiting for it.
+An explicit query-level `async_insert` setting takes precedence over `WithAsync`, followed by the connection setting, then the batch default of `0`.
+Ordinary `ExecContext` inserts are not affected by this batch default.
+:::
+
 ```go
 batch, err := scope.Prepare("INSERT INTO example")
 if err != nil {

--- a/tests/issues/issue_1997_test.go
+++ b/tests/issues/issue_1997_test.go
@@ -1,0 +1,75 @@
+package issues
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+)
+
+// TestIssue1997_NativeInsertSingleQueryID is a regression test for
+// https://github.com/ClickHouse/clickhouse-go/issues/1997: a single native
+// PrepareBatch/Send used to produce two `system.query_log` rows with distinct
+// `query_id` values on ClickHouse 26.3+, because the server defaulted
+// `async_insert=1` and flushed the buffer as a rewritten
+// `INSERT INTO db.table` under a new UUID. PrepareBatch already buffers
+// client-side, so the driver now sends `async_insert=0` unless the caller set it.
+func TestIssue1997_NativeInsertSingleQueryID(t *testing.T) {
+	conn, err := clickhouse_tests.GetConnectionTCPWithOptions("issues", nil, nil, nil, func(o *clickhouse.Options) {
+		// Drop the suite default so this test sees the server default
+		// (async_insert=1 on 26.3+), which is what triggered the duplicate log.
+		delete(o.Settings, "async_insert")
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	ctx := context.Background()
+	table := fmt.Sprintf("issue_1997_%s", uuid.NewString()[:8])
+	require.NoError(t, conn.Exec(ctx, fmt.Sprintf(
+		`CREATE TABLE %s (id UInt64, value String) ENGINE = MergeTree() ORDER BY id`, table)))
+	t.Cleanup(func() {
+		if err := conn.Exec(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", table)); err != nil {
+			t.Logf("DROP TABLE %s failed: %v", table, err)
+		}
+	})
+
+	queryID := "issue-1997-" + uuid.NewString()
+	insertCtx := clickhouse.Context(ctx, clickhouse.WithQueryID(queryID))
+
+	batch, err := conn.PrepareBatch(insertCtx, fmt.Sprintf("INSERT INTO %s (id, value)", table))
+	require.NoError(t, err)
+	defer batch.Close()
+
+	for i := 0; i < 10; i++ {
+		require.NoError(t, batch.Append(uint64(i), fmt.Sprintf("row-%d", i)))
+	}
+	require.NoError(t, batch.Send())
+
+	var stored uint64
+	require.NoError(t, conn.QueryRow(ctx, fmt.Sprintf("SELECT count() FROM %s", table)).Scan(&stored))
+	require.Equal(t, uint64(10), stored)
+
+	if err := conn.Exec(ctx, "SYSTEM FLUSH LOGS"); err != nil {
+		t.Skipf("`system.query_log` not available: %v", err)
+	}
+
+	logFilter := fmt.Sprintf(`
+		type = 'QueryFinish'
+		AND current_database = currentDatabase()
+		AND startsWith(upper(trimLeft(query)), 'INSERT')
+		AND query ILIKE '%%%s%%'
+	`, table)
+
+	var distinctIDs uint64
+	require.NoError(t, conn.QueryRow(ctx, "SELECT uniqExact(query_id) FROM system.query_log WHERE "+logFilter).Scan(&distinctIDs))
+	require.Equal(t, uint64(1), distinctIDs, "native INSERT must log a single query_id, got %d", distinctIDs)
+
+	var loggedID string
+	require.NoError(t, conn.QueryRow(ctx, "SELECT any(query_id) FROM system.query_log WHERE "+logFilter).Scan(&loggedID))
+	require.Equal(t, queryID, loggedID)
+}

--- a/tests/issues/issue_1997_test.go
+++ b/tests/issues/issue_1997_test.go
@@ -73,3 +73,67 @@ func TestIssue1997_NativeInsertSingleQueryID(t *testing.T) {
 	require.NoError(t, conn.QueryRow(ctx, "SELECT any(query_id) FROM system.query_log WHERE "+logFilter).Scan(&loggedID))
 	require.Equal(t, queryID, loggedID)
 }
+
+// TestIssue1997_HTTPInsertSingleQueryID is the HTTP equivalent of the native
+// regression: httpBatch.Send also forces async_insert=0 unless the caller set it.
+func TestIssue1997_HTTPInsertSingleQueryID(t *testing.T) {
+	env, err := clickhouse_tests.GetTestEnvironment("issues")
+	require.NoError(t, err)
+
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Protocol: clickhouse.HTTP,
+		Addr:     []string{fmt.Sprintf("%s:%d", env.Host, env.HttpPort)},
+		Auth: clickhouse.Auth{
+			Database: env.Database,
+			Username: env.Username,
+			Password: env.Password,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	ctx := context.Background()
+	table := fmt.Sprintf("issue_1997_http_%s", uuid.NewString()[:8])
+	require.NoError(t, conn.Exec(ctx, fmt.Sprintf(
+		`CREATE TABLE %s (id UInt64, value String) ENGINE = MergeTree() ORDER BY id`, table)))
+	t.Cleanup(func() {
+		if err := conn.Exec(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", table)); err != nil {
+			t.Logf("DROP TABLE %s failed: %v", table, err)
+		}
+	})
+
+	queryID := "issue-1997-http-" + uuid.NewString()
+	insertCtx := clickhouse.Context(ctx, clickhouse.WithQueryID(queryID))
+
+	batch, err := conn.PrepareBatch(insertCtx, fmt.Sprintf("INSERT INTO %s (id, value)", table))
+	require.NoError(t, err)
+	defer batch.Close()
+
+	for i := 0; i < 10; i++ {
+		require.NoError(t, batch.Append(uint64(i), fmt.Sprintf("row-%d", i)))
+	}
+	require.NoError(t, batch.Send())
+
+	var stored uint64
+	require.NoError(t, conn.QueryRow(ctx, fmt.Sprintf("SELECT count() FROM %s", table)).Scan(&stored))
+	require.Equal(t, uint64(10), stored)
+
+	if err := conn.Exec(ctx, "SYSTEM FLUSH LOGS"); err != nil {
+		t.Skipf("`system.query_log` not available: %v", err)
+	}
+
+	logFilter := fmt.Sprintf(`
+		type = 'QueryFinish'
+		AND current_database = currentDatabase()
+		AND startsWith(upper(trimLeft(query)), 'INSERT')
+		AND query ILIKE '%%%s%%'
+	`, table)
+
+	var distinctIDs uint64
+	require.NoError(t, conn.QueryRow(ctx, "SELECT uniqExact(query_id) FROM system.query_log WHERE "+logFilter).Scan(&distinctIDs))
+	require.Equal(t, uint64(1), distinctIDs, "HTTP INSERT must log a single query_id, got %d", distinctIDs)
+
+	var loggedID string
+	require.NoError(t, conn.QueryRow(ctx, "SELECT any(query_id) FROM system.query_log WHERE "+logFilter).Scan(&loggedID))
+	require.Equal(t, queryID, loggedID)
+}

--- a/tests/issues/issue_1997_test.go
+++ b/tests/issues/issue_1997_test.go
@@ -2,6 +2,7 @@ package issues
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"testing"
 
@@ -135,5 +136,66 @@ func TestIssue1997_HTTPInsertSingleQueryID(t *testing.T) {
 
 	var loggedID string
 	require.NoError(t, conn.QueryRow(ctx, "SELECT any(query_id) FROM system.query_log WHERE "+logFilter).Scan(&loggedID))
+	require.Equal(t, queryID, loggedID)
+}
+
+// TestIssue1997_StdInsertSingleQueryID covers the database/sql PrepareContext
+// path, which shares the native prepareBatch implementation.
+func TestIssue1997_StdInsertSingleQueryID(t *testing.T) {
+	env, err := clickhouse_tests.GetTestEnvironment("issues")
+	require.NoError(t, err)
+	opts := clickhouse_tests.ClientOptionsFromEnv(env, clickhouse.Settings{}, false)
+	delete(opts.Settings, "async_insert")
+
+	conn, err := sql.Open("clickhouse", clickhouse_tests.OptionsToDSN(&opts))
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	ctx := context.Background()
+	table := fmt.Sprintf("issue_1997_std_%s", uuid.NewString()[:8])
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		`CREATE TABLE %s (id UInt64, value String) ENGINE = MergeTree() ORDER BY id`, table))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if _, err := conn.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", table)); err != nil {
+			t.Logf("DROP TABLE %s failed: %v", table, err)
+		}
+	})
+
+	queryID := "issue-1997-std-" + uuid.NewString()
+	insertCtx := clickhouse.Context(ctx, clickhouse.WithQueryID(queryID))
+	tx, err := conn.BeginTx(insertCtx, nil)
+	require.NoError(t, err)
+	stmt, err := tx.PrepareContext(insertCtx, fmt.Sprintf("INSERT INTO %s (id, value)", table))
+	require.NoError(t, err)
+	defer stmt.Close()
+
+	for i := 0; i < 10; i++ {
+		_, err = stmt.ExecContext(insertCtx, uint64(i), fmt.Sprintf("row-%d", i))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tx.Commit())
+
+	var stored uint64
+	require.NoError(t, conn.QueryRowContext(ctx, fmt.Sprintf("SELECT count() FROM %s", table)).Scan(&stored))
+	require.Equal(t, uint64(10), stored)
+
+	if _, err := conn.ExecContext(ctx, "SYSTEM FLUSH LOGS"); err != nil {
+		t.Skipf("`system.query_log` not available: %v", err)
+	}
+
+	logFilter := fmt.Sprintf(`
+		type = 'QueryFinish'
+		AND current_database = currentDatabase()
+		AND startsWith(upper(trimLeft(query)), 'INSERT')
+		AND query ILIKE '%%%s%%'
+	`, table)
+
+	var distinctIDs uint64
+	require.NoError(t, conn.QueryRowContext(ctx, "SELECT uniqExact(query_id) FROM system.query_log WHERE "+logFilter).Scan(&distinctIDs))
+	require.Equal(t, uint64(1), distinctIDs, "database/sql INSERT must log a single query_id, got %d", distinctIDs)
+
+	var loggedID string
+	require.NoError(t, conn.QueryRowContext(ctx, "SELECT any(query_id) FROM system.query_log WHERE "+logFilter).Scan(&loggedID))
 	require.Equal(t, queryID, loggedID)
 }


### PR DESCRIPTION
Fixes #1997.

On the reported ClickHouse 26.3 setup, one batch insert produced a client INSERT record and a server-side async flush record with a different query ID. Only one write reached storage.

This change defaults batch inserts to `async_insert=0` when neither query nor connection settings specify it. Explicit settings, including `WithAsync` and `WithStdAsync`, take precedence. Native and HTTP batches share the setting helper; the database/sql path is covered by a separate regression.

This changes how an unspecified client setting interacts with a server profile that enables async inserts. Whether that default belongs in the driver remains a maintainer policy decision.

### Validation

- `TestDisableAsyncInsertUnlessSet` passed locally.
- [Native, HTTP and database/sql regressions](https://github.com/sankalpsthakur/clickhouse-go/actions/runs/34684263293/job/103528355792) pass with race detection on ClickHouse 26.3.33.24 at `98817d9`. Stored-row and query-ID assertions executed on all three paths without skips. The SQL case uses BeginTx, PrepareContext, ExecContext and Commit.

AI coding tools assisted with the change and this description.
