### PR TITLE
fix(bind): handle fmt.Stringer in server-side query parameter switch

### DIFF
--- a/query_parameters.go
+++ b/query_parameters.go
@@ -80,6 +80,11 @@ func bindQueryOrAppendParameters(paramsProtocolSupport bool, options *QueryOptio
 				case *time.Duration:
 					options.parameters[p.Name] = formatDurationBody(*v)
 					continue
+				// Must follow the time.Time and time.Duration cases: their
+				// String() output is Go's format, not the server's text format.
+				case fmt.Stringer:
+					options.parameters[p.Name] = v.String()
+					continue
 				}
 				strVal, err := formatValue(timezone, Seconds, p.Value, formatParamText)
 				if err != nil {

--- a/query_parameters_test.go
+++ b/query_parameters_test.go
@@ -1,9 +1,11 @@
 package clickhouse
 
 import (
+	"net/netip"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,6 +43,7 @@ func TestBindQueryOrAppendParameters(t *testing.T) {
 func TestBindQueryOrAppendParametersNamedValue(t *testing.T) {
 	str := "hello"
 	tm := time.Unix(1700000000, 500_000_000)
+	addr := netip.MustParseAddr("10.0.0.1")
 
 	cases := []struct {
 		name  string
@@ -52,6 +55,9 @@ func TestBindQueryOrAppendParametersNamedValue(t *testing.T) {
 		{"*string is dereferenced and sent raw", &str, "hello"},
 		{"time.Time uses formatTimeParam", tm, "1700000000.500"},
 		{"*time.Time uses formatTimeParam", &tm, "1700000000.500"},
+		{"time.Duration keeps its own text, not String()", 90 * time.Minute, "01:30:00"},
+		{"fmt.Stringer is sent raw and unquoted", uuid.MustParse("11111111-1111-1111-1111-111111111111"), "11111111-1111-1111-1111-111111111111"},
+		{"fmt.Stringer pointer is sent raw and unquoted", &addr, "10.0.0.1"},
 		{"other types go through formatValue", 42, "42"},
 	}
 	for _, tc := range cases {
@@ -60,6 +66,26 @@ func TestBindQueryOrAppendParametersNamedValue(t *testing.T) {
 			query, err := bindQueryOrAppendParameters(true, options, "SELECT {p:String}", time.UTC, Named("p", tc.value))
 			require.NoError(t, err)
 			assert.Equal(t, "SELECT {p:String}", query)
+			assert.Equal(t, tc.want, options.parameters["p"])
+		})
+	}
+}
+
+func TestBindQueryOrAppendParametersNestedStringerStaysQuoted(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+		value any
+		want  string
+	}{
+		{"array element", "SELECT {p:Array(UUID)}", []uuid.UUID{uuid.MustParse("11111111-1111-1111-1111-111111111111")}, "['11111111-1111-1111-1111-111111111111']"},
+		{"tuple element", "SELECT {p:Tuple(UUID, UInt8)}", GroupSet{Value: []any{uuid.MustParse("11111111-1111-1111-1111-111111111111"), uint8(1)}}, "('11111111-1111-1111-1111-111111111111', 1)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			options := &QueryOptions{}
+			_, err := bindQueryOrAppendParameters(true, options, tc.query, time.UTC, Named("p", tc.value))
+			require.NoError(t, err)
 			assert.Equal(t, tc.want, options.parameters["p"])
 		})
 	}

--- a/tests/query_parameters_test.go
+++ b/tests/query_parameters_test.go
@@ -3,9 +3,12 @@ package tests
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/netip"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -192,6 +195,30 @@ func TestQueryParameters(t *testing.T) {
 		require.NoError(t, row.Err())
 		require.NoError(t, row.Scan(&got))
 		assert.True(t, got.Equal(in.Truncate(time.Second)), "want truncated instant %s, got %s", in.Truncate(time.Second).UTC(), got.UTC())
+	})
+
+	t.Run("Stringer values", func(t *testing.T) {
+		id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+		addr := netip.MustParseAddr("10.0.0.1")
+
+		var (
+			gotUUID  uuid.UUID
+			gotIP    net.IP
+			gotArray []uuid.UUID
+		)
+		row := client.QueryRow(
+			ctx,
+			"SELECT {id:UUID}, {addr:IPv4}, {ids:Array(UUID)}",
+			clickhouse.Named("id", id),
+			clickhouse.Named("addr", addr),
+			clickhouse.Named("ids", []uuid.UUID{id}),
+		)
+		require.NoError(t, row.Err())
+		require.NoError(t, row.Scan(&gotUUID, &gotIP, &gotArray))
+
+		assert.Equal(t, id, gotUUID)
+		assert.Equal(t, "10.0.0.1", gotIP.String())
+		assert.Equal(t, []uuid.UUID{id}, gotArray)
 	})
 
 	t.Run("with bind backwards compatibility", func(t *testing.T) {

--- a/tests/std/query_parameters_test.go
+++ b/tests/std/query_parameters_test.go
@@ -2,10 +2,13 @@ package std
 
 import (
 	"fmt"
+	"net"
+	"net/netip"
 	"strconv"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -174,6 +177,29 @@ func TestQueryParameters(t *testing.T) {
 				require.NoError(t, row.Err())
 				require.NoError(t, row.Scan(&got))
 				assert.True(t, got.Equal(in.Truncate(time.Second)), "want truncated instant %s, got %s", in.Truncate(time.Second).UTC(), got.UTC())
+			})
+
+			t.Run("Stringer values", func(t *testing.T) {
+				id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+				addr := netip.MustParseAddr("10.0.0.1")
+
+				var (
+					gotUUID  uuid.UUID
+					gotIP    net.IP
+					gotArray []uuid.UUID
+				)
+				row := conn.QueryRow(
+					"SELECT {id:UUID}, {addr:IPv4}, {ids:Array(UUID)}",
+					clickhouse.Named("id", id),
+					clickhouse.Named("addr", addr),
+					clickhouse.Named("ids", []uuid.UUID{id}),
+				)
+				require.NoError(t, row.Err())
+				require.NoError(t, row.Scan(&gotUUID, &gotIP, &gotArray))
+
+				assert.Equal(t, id, gotUUID)
+				assert.Equal(t, "10.0.0.1", gotIP.String())
+				assert.Equal(t, []uuid.UUID{id}, gotArray)
 			})
 
 			t.Run("with bind backwards compatibility", func(t *testing.T) {


### PR DESCRIPTION
## Summary
The switch in bindQueryOrAppendParameters handles some types explicitly but not fmt.Stringer. A named argument {p:UUID} fell through to formatValue which does quote(v.String()) so this would lead to an error like:

code: 457, message: Value '11111111-1111-1111-1111-111111111111' cannot be parsed as UUID for query parameter 'p' because it isn't parsed completely: only 32 of 38 bytes was parsed

This adds an additional case to the recent change in https://github.com/ClickHouse/clickhouse-go/pull/1978.


## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
