### PR TITLE
fix(json): consume v0 SharedData to keep native stream aligned

### DIFF
--- a/lib/column/json.go
+++ b/lib/column/json.go
@@ -55,6 +55,11 @@ type JSON struct {
 
 	maxDynamicPaths int
 	maxDynamicTypes int
+
+	// sharedData is JSON v0 overflow storage: Array(Tuple(String, String)).
+	// Populated only by decodeObjectData_v1. Each tuple is (path, Dynamic
+	// serializeBinary payload) for paths that exceeded max_dynamic_paths.
+	sharedData Interface
 }
 
 // jsonMode is the mode preference a value carries when offered to a JSON
@@ -244,6 +249,8 @@ func (c *JSON) rowAsJSON(row int) *chcol.JSON {
 		col := c.dynamicColumns[i]
 		obj.SetValueAtPath(path, col.Row(row, false))
 	}
+
+	c.mergeSharedDataRow(obj, row)
 
 	return obj
 }
@@ -940,6 +947,11 @@ func (c *JSON) Reset() {
 		}
 	case JSONStringSerializationVersion:
 		c.jsonStrings.Reset()
+	}
+
+	if c.sharedData != nil {
+		c.sharedData.Reset()
+		c.sharedData = nil
 	}
 
 	// Clear the latched mode so the next batch starts unbiased. An all-null

--- a/lib/column/json_deprecated.go
+++ b/lib/column/json_deprecated.go
@@ -1,9 +1,12 @@
 package column
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/ClickHouse/ch-go/proto"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
 )
 
 func (c *JSON) encodeObjectHeader_v1(buffer *proto.Buffer) error {
@@ -114,11 +117,227 @@ func (c *JSON) decodeObjectData_v1(reader *proto.Reader, rows int) error {
 		}
 	}
 
-	// SharedData per row, ignored for now. May cause stream offset issues if present
-	_, err := reader.ReadRaw(8 * rows) // one UInt64 per row
-	if err != nil {
-		return fmt.Errorf("failed to read shared data for json column: %w", err)
+	if err := c.decodeSharedData_v1(reader, rows); err != nil {
+		return err
 	}
 
 	return nil
+}
+
+func (c *JSON) decodeSharedData_v1(reader *proto.Reader, rows int) error {
+	// ClickHouse stores overflow JSON paths as Array(Tuple(String, String)):
+	// UInt64 offsets followed by the flattened Tuple columns. Reading only the
+	// offsets leaves the Tuple payload in the stream and desyncs every later
+	// column (issue #1854).
+	col, err := Type("Array(Tuple(String, String))").Column("", c.sc)
+	if err != nil {
+		return fmt.Errorf("failed to init shared data for json column: %w", err)
+	}
+	if err := col.Decode(reader, rows); err != nil {
+		return fmt.Errorf("failed to read shared data for json column: %w", err)
+	}
+	c.sharedData = col
+	return nil
+}
+
+func (c *JSON) mergeSharedDataRow(obj *chcol.JSON, row int) {
+	if c.sharedData == nil || row >= c.sharedData.Rows() {
+		return
+	}
+	for _, pair := range sharedDataPairs(c.sharedData.Row(row, false)) {
+		value, chType := decodeSharedDataValue(pair[1])
+		obj.SetValueAtPath(pair[0], chcol.NewDynamicWithType(value, chType))
+	}
+}
+
+func sharedDataPairs(raw any) [][2]string {
+	switch rows := raw.(type) {
+	case [][]any:
+		out := make([][2]string, 0, len(rows))
+		for _, p := range rows {
+			if len(p) < 2 {
+				continue
+			}
+			path, _ := p[0].(string)
+			val, _ := p[1].(string)
+			if path != "" {
+				out = append(out, [2]string{path, val})
+			}
+		}
+		return out
+	case []any:
+		out := make([][2]string, 0, len(rows))
+		for _, item := range rows {
+			p, ok := item.([]any)
+			if !ok || len(p) < 2 {
+				continue
+			}
+			path, _ := p[0].(string)
+			val, _ := p[1].(string)
+			if path != "" {
+				out = append(out, [2]string{path, val})
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// Binary type indexes from ClickHouse src/DataTypes/DataTypesBinaryEncoding.cpp.
+const (
+	binNothing  = 0x00
+	binUInt8    = 0x01
+	binUInt16   = 0x02
+	binUInt32   = 0x03
+	binUInt64   = 0x04
+	binInt8     = 0x07
+	binInt16    = 0x08
+	binInt32    = 0x09
+	binInt64    = 0x0A
+	binFloat32  = 0x0D
+	binFloat64  = 0x0E
+	binString   = 0x15
+	binArray    = 0x1E
+	binNullable = 0x23
+	binBool     = 0x2D
+	binDynamic  = 0x2B
+)
+
+type sharedBinType struct {
+	kind  byte
+	child *sharedBinType
+	name  string
+}
+
+func decodeSharedDataValue(raw string) (any, string) {
+	if raw == "" {
+		return nil, ""
+	}
+	r := proto.NewReader(bytes.NewReader([]byte(raw)))
+	t, err := readSharedBinType(r)
+	if err != nil {
+		return raw, "String"
+	}
+	v, err := readSharedBinValue(r, t)
+	if err != nil {
+		return raw, "String"
+	}
+	return v, t.name
+}
+
+func readSharedBinType(r *proto.Reader) (sharedBinType, error) {
+	idx, err := r.ReadByte()
+	if err != nil {
+		return sharedBinType{}, err
+	}
+	switch idx {
+	case binNothing:
+		return sharedBinType{kind: idx, name: "Nothing"}, nil
+	case binUInt8:
+		return sharedBinType{kind: idx, name: "UInt8"}, nil
+	case binUInt16:
+		return sharedBinType{kind: idx, name: "UInt16"}, nil
+	case binUInt32:
+		return sharedBinType{kind: idx, name: "UInt32"}, nil
+	case binUInt64:
+		return sharedBinType{kind: idx, name: "UInt64"}, nil
+	case binInt8:
+		return sharedBinType{kind: idx, name: "Int8"}, nil
+	case binInt16:
+		return sharedBinType{kind: idx, name: "Int16"}, nil
+	case binInt32:
+		return sharedBinType{kind: idx, name: "Int32"}, nil
+	case binInt64:
+		return sharedBinType{kind: idx, name: "Int64"}, nil
+	case binFloat32:
+		return sharedBinType{kind: idx, name: "Float32"}, nil
+	case binFloat64:
+		return sharedBinType{kind: idx, name: "Float64"}, nil
+	case binString:
+		return sharedBinType{kind: idx, name: "String"}, nil
+	case binBool:
+		return sharedBinType{kind: idx, name: "Bool"}, nil
+	case binArray:
+		child, err := readSharedBinType(r)
+		if err != nil {
+			return sharedBinType{}, err
+		}
+		return sharedBinType{kind: idx, child: &child, name: "Array(" + child.name + ")"}, nil
+	case binNullable:
+		child, err := readSharedBinType(r)
+		if err != nil {
+			return sharedBinType{}, err
+		}
+		return sharedBinType{kind: idx, child: &child, name: "Nullable(" + child.name + ")"}, nil
+	case binDynamic:
+		if _, err := r.ReadByte(); err != nil { // uint8 max_types
+			return sharedBinType{}, err
+		}
+		return sharedBinType{kind: idx, name: "Dynamic"}, nil
+	default:
+		return sharedBinType{}, fmt.Errorf("unsupported shared-data type index 0x%02x", idx)
+	}
+}
+
+func readSharedBinValue(r *proto.Reader, t sharedBinType) (any, error) {
+	switch t.kind {
+	case binNothing:
+		return nil, nil
+	case binUInt8:
+		return r.UInt8()
+	case binUInt16:
+		return r.UInt16()
+	case binUInt32:
+		return r.UInt32()
+	case binUInt64:
+		return r.UInt64()
+	case binInt8:
+		return r.Int8()
+	case binInt16:
+		return r.Int16()
+	case binInt32:
+		return r.Int32()
+	case binInt64:
+		return r.Int64()
+	case binFloat32:
+		return r.Float32()
+	case binFloat64:
+		return r.Float64()
+	case binString:
+		return r.Str()
+	case binBool:
+		return r.Bool()
+	case binArray:
+		n, err := r.UVarInt()
+		if err != nil {
+			return nil, err
+		}
+		out := make([]any, 0, n)
+		for i := uint64(0); i < n; i++ {
+			v, err := readSharedBinValue(r, *t.child)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, v)
+		}
+		return out, nil
+	case binNullable:
+		flag, err := r.ReadByte()
+		if err != nil {
+			return nil, err
+		}
+		if flag != 0 {
+			return nil, nil
+		}
+		return readSharedBinValue(r, *t.child)
+	case binDynamic:
+		inner, err := readSharedBinType(r)
+		if err != nil {
+			return nil, err
+		}
+		return readSharedBinValue(r, inner)
+	default:
+		return nil, fmt.Errorf("unsupported shared-data type index 0x%02x", t.kind)
+	}
 }

--- a/lib/column/json_deprecated_test.go
+++ b/lib/column/json_deprecated_test.go
@@ -1,0 +1,176 @@
+package column
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/ClickHouse/ch-go/proto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/chcol"
+)
+
+// encodeDynamicBinary is ClickHouse ISerialization::serializeBinary for Dynamic:
+// <binary type index><value>. Used to build JSON shared-data payloads the way
+// the server writes them into Array(Tuple(String, String)).
+func encodeDynamicInt64(v int64) string {
+	b := make([]byte, 9)
+	b[0] = 0x0A // BinaryTypeIndex::Int64
+	binary.LittleEndian.PutUint64(b[1:], uint64(v))
+	return string(b)
+}
+
+func encodeDynamicFloat64(v float64) string {
+	b := make([]byte, 9)
+	b[0] = 0x0E // BinaryTypeIndex::Float64
+	binary.LittleEndian.PutUint64(b[1:], math.Float64bits(v))
+	return string(b)
+}
+
+func encodeDynamicString(s string) string {
+	var buf proto.Buffer
+	buf.PutUInt8(0x15) // BinaryTypeIndex::String
+	buf.PutString(s)
+	return string(buf.Buf)
+}
+
+func encodeDynamicBool(v bool) string {
+	b := []byte{0x2D, 0} // BinaryTypeIndex::Bool
+	if v {
+		b[1] = 1
+	}
+	return string(b)
+}
+
+func encodeDynamicEmptyArrayInt64() string {
+	// Array + Int64 + varuint count 0
+	return string([]byte{0x1E, 0x0A, 0x00})
+}
+
+func encodeSharedData(t *testing.T, rows [][][2]string) []byte {
+	t.Helper()
+	col, err := Type("Array(Tuple(String, String))").Column("", nil)
+	require.NoError(t, err)
+	for _, row := range rows {
+		pairs := make([][]any, len(row))
+		for i, p := range row {
+			pairs[i] = []any{p[0], p[1]}
+		}
+		require.NoError(t, col.AppendRow(pairs))
+	}
+	var buf proto.Buffer
+	col.Encode(&buf)
+	return buf.Buf
+}
+
+// TestJSONDeprecatedSharedDataConsumedAndMerged is the #1854 repro at the
+// native-protocol layer: ClickHouse JSON v0 (deprecated object) stores overflow
+// paths in SharedData as Array(Tuple(String, String)). The decoder used to
+// skip only the UInt64 offsets and leave the Tuple payload in the stream,
+// which desyncs every later column (makeslice panics, "unexpected value N
+// for boolean", "unexpected packet N").
+func TestJSONDeprecatedSharedDataConsumedAndMerged(t *testing.T) {
+	shared := encodeSharedData(t, [][][2]string{
+		{
+			{"k08", encodeDynamicInt64(8)},
+			{"satellites", encodeDynamicInt64(11)},
+			{"region", encodeDynamicString("us-east")},
+			{"ok", encodeDynamicBool(true)},
+			{"ratio", encodeDynamicFloat64(12.5)},
+			{"latency_ms", encodeDynamicEmptyArrayInt64()},
+		},
+	})
+
+	const sentinel byte = 0xAB
+	payload := append(append([]byte{}, shared...), sentinel)
+
+	col := newTestJSONColumn(t)
+	col.serializationVersion = JSONDeprecatedObjectSerializationVersion
+
+	reader := proto.NewReader(bytes.NewReader(payload))
+	require.NoError(t, col.Decode(reader, 1))
+
+	got, err := reader.ReadByte()
+	require.NoError(t, err, "shared-data payload must be fully consumed")
+	require.Equal(t, sentinel, got, "bytes after the JSON column must stay aligned for the next column")
+
+	obj, ok := col.Row(0, false).(*chcol.JSON)
+	require.True(t, ok)
+
+	k08, ok := chcol.ExtractJSONPathAs[int64](obj, "k08")
+	require.True(t, ok, "overflow path k08 must be merged from shared data")
+	require.Equal(t, int64(8), k08)
+
+	sat, ok := chcol.ExtractJSONPathAs[int64](obj, "satellites")
+	require.True(t, ok)
+	require.Equal(t, int64(11), sat)
+
+	region, ok := chcol.ExtractJSONPathAs[string](obj, "region")
+	require.True(t, ok)
+	require.Equal(t, "us-east", region)
+
+	flag, ok := chcol.ExtractJSONPathAs[bool](obj, "ok")
+	require.True(t, ok)
+	require.Equal(t, true, flag)
+
+	ratio, ok := chcol.ExtractJSONPathAs[float64](obj, "ratio")
+	require.True(t, ok)
+	require.Equal(t, 12.5, ratio)
+
+	latency, ok := chcol.ExtractJSONPathAs[[]any](obj, "latency_ms")
+	require.True(t, ok)
+	require.Empty(t, latency)
+}
+
+func TestJSONDeprecatedSharedDataEmptyRoundtrip(t *testing.T) {
+	src := newTestJSONColumn(t)
+	require.NoError(t, src.AppendRow(map[string]any{"kept": int64(7)}))
+
+	var buf proto.Buffer
+	require.NoError(t, src.WriteStatePrefix(&buf))
+	src.Encode(&buf)
+
+	dst := newTestJSONColumn(t)
+	reader := proto.NewReader(bytes.NewReader(buf.Buf))
+	require.NoError(t, dst.ReadStatePrefix(reader))
+	require.NoError(t, dst.Decode(reader, 1))
+
+	obj, ok := dst.Row(0, false).(*chcol.JSON)
+	require.True(t, ok)
+	kept, ok := chcol.ExtractJSONPathAs[int64](obj, "kept")
+	require.True(t, ok)
+	require.Equal(t, int64(7), kept)
+}
+
+func TestJSONDeprecatedSharedDataSecondRowOnly(t *testing.T) {
+	shared := encodeSharedData(t, [][][2]string{
+		{},
+		{{"overflow", encodeDynamicInt64(42)}},
+	})
+
+	const sentinel byte = 0xCD
+	payload := append(append([]byte{}, shared...), sentinel)
+
+	col := newTestJSONColumn(t)
+	col.serializationVersion = JSONDeprecatedObjectSerializationVersion
+
+	reader := proto.NewReader(bytes.NewReader(payload))
+	require.NoError(t, col.Decode(reader, 2))
+
+	got, err := reader.ReadByte()
+	require.NoError(t, err)
+	require.Equal(t, sentinel, got)
+
+	row0, ok := col.Row(0, false).(*chcol.JSON)
+	require.True(t, ok)
+	_, present := row0.ValueAtPath("overflow")
+	require.False(t, present, "row 0 has empty shared data")
+
+	row1, ok := col.Row(1, false).(*chcol.JSON)
+	require.True(t, ok)
+	v, ok := chcol.ExtractJSONPathAs[int64](row1, "overflow")
+	require.True(t, ok)
+	require.Equal(t, int64(42), v)
+}


### PR DESCRIPTION
## Summary
- JSON deprecated (v0) object decoding only skipped SharedData `UInt64` offsets and left the `Array(Tuple(String, String))` payload in the native stream, desyncing every later column (`makeslice`, unexpected boolean/packet).
- Decode the full SharedData array and merge overflow paths into the scanned JSON object.
- Adds unit coverage that asserts stream alignment and merged overflow values.

Fixes #1854

## Test plan
- [x] `go test -count=1 -timeout 60s -run 'TestJSONDeprecatedSharedData' ./lib/column/`