### PR TITLE
fix: preserve LowCardinality float dictionary values

### DIFF
--- a/lib/column/lowcardinality.go
+++ b/lib/column/lowcardinality.go
@@ -144,13 +144,24 @@ func (col *LowCardinality) AppendRow(v any) error {
 	case time.Time:
 		v = x.Truncate(time.Second)
 	}
-	if _, found := col.append.index[v]; !found {
+	key := v
+	// Float equality merges signed zero and cannot look up NaN. Use the wire
+	// representation so dictionary entries preserve both values and NaN payloads.
+	switch x := v.(type) {
+	case float32:
+		key = struct{ bits uint32 }{math.Float32bits(x)}
+	case float64:
+		key = struct{ bits uint64 }{math.Float64bits(x)}
+	}
+	idx, found := col.append.index[key]
+	if !found {
 		if err := col.index.AppendRow(v); err != nil {
 			return err
 		}
-		col.append.index[v] = col.index.Rows() - 1
+		idx = col.index.Rows() - 1
+		col.append.index[key] = idx
 	}
-	col.append.keys = append(col.append.keys, col.append.index[v])
+	col.append.keys = append(col.append.keys, idx)
 	return nil
 }
 

--- a/lib/column/lowcardinality_test.go
+++ b/lib/column/lowcardinality_test.go
@@ -1,12 +1,73 @@
 package column
 
 import (
+	"bytes"
+	"math"
 	"testing"
 
 	chproto "github.com/ClickHouse/ch-go/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLowCardinalityFloatBits(t *testing.T) {
+	for _, inner := range []string{"Float32", "Float64", "Nullable(Float32)", "Nullable(Float64)"} {
+		t.Run(inner, func(t *testing.T) {
+			values := []any{float64(0), math.Copysign(0, -1), math.NaN(), math.NaN(), math.Inf(1), math.Inf(-1), 1.5}
+			if inner == "Float32" || inner == "Nullable(Float32)" {
+				for i, value := range values {
+					values[i] = float32(value.(float64))
+				}
+				values = append(values, math.Float32frombits(0x7fc00013))
+			} else {
+				values = append(values, math.Float64frombits(0x7ff8000000000013))
+			}
+			if inner == "Nullable(Float32)" || inner == "Nullable(Float64)" {
+				values = append(values, nil)
+			}
+			col, err := Type("LowCardinality("+inner+")").Column("test", nil)
+			require.NoError(t, err)
+			for _, columnar := range []bool{false, true} {
+				col.Reset()
+				if columnar {
+					_, err = col.Append(values)
+					require.NoError(t, err)
+				} else {
+					for _, value := range values {
+						require.NoError(t, col.AppendRow(value))
+					}
+				}
+				// The repeated NaN shares an entry, while different payloads do not.
+				// Reserved default/null slots offset the duplicate and nil rows.
+				assert.Equal(t, len(values), col.(*LowCardinality).index.Rows())
+				var buf chproto.Buffer
+				col.Encode(&buf)
+				decoded, err := col.Type().Column("test", nil)
+				require.NoError(t, err)
+				require.NoError(t, decoded.Decode(chproto.NewReader(bytes.NewReader(buf.Buf)), len(values)))
+				for i, value := range values {
+					got := decoded.Row(i, false)
+					switch want := value.(type) {
+					case float32:
+						if ptr, ok := got.(*float32); ok {
+							got = *ptr
+						}
+						require.NotNil(t, got, "row %d", i)
+						assert.Equal(t, math.Float32bits(want), math.Float32bits(got.(float32)), "row %d", i)
+					case float64:
+						if ptr, ok := got.(*float64); ok {
+							got = *ptr
+						}
+						require.NotNil(t, got, "row %d", i)
+						assert.Equal(t, math.Float64bits(want), math.Float64bits(got.(float64)), "row %d", i)
+					default:
+						assert.Nil(t, got)
+					}
+				}
+			}
+		})
+	}
+}
 
 func TestLowCardinalityAppendAnySlice(t *testing.T) {
 	col, err := Type("LowCardinality(String)").Column("test", nil)

--- a/tests/issues/issue_2007_test.go
+++ b/tests/issues/issue_2007_test.go
@@ -54,6 +54,13 @@ func TestIssue2007LowCardinalityFloats(t *testing.T) {
 					assert.True(t, math.IsNaN(f64))
 					assert.True(t, math.IsNaN(float64(*n32)))
 					assert.True(t, math.IsNaN(*n64))
+				} else if want == 0 {
+					// ClickHouse can merge signed zeros in its LowCardinality
+					// dictionary. Exact wire bits are checked by the column unit tests.
+					assert.Zero(t, f32)
+					assert.Zero(t, f64)
+					assert.Zero(t, *n32)
+					assert.Zero(t, *n64)
 				} else {
 					assert.Equal(t, math.Float32bits(float32(want)), math.Float32bits(f32))
 					assert.Equal(t, math.Float64bits(want), math.Float64bits(f64))

--- a/tests/issues/issue_2007_test.go
+++ b/tests/issues/issue_2007_test.go
@@ -1,0 +1,76 @@
+package issues
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse_tests "github.com/ClickHouse/clickhouse-go/v2/tests"
+)
+
+func TestIssue2007LowCardinalityFloats(t *testing.T) {
+	for _, protocol := range []clickhouse.Protocol{clickhouse.Native, clickhouse.HTTP} {
+		t.Run(protocol.String(), func(t *testing.T) {
+			conn, err := clickhouse_tests.GetConnection("issues", t, protocol, clickhouse.Settings{
+				"allow_suspicious_low_cardinality_types": 1,
+			}, nil, nil)
+			require.NoError(t, err)
+			t.Cleanup(func() { assert.NoError(t, conn.Close()) })
+			ctx := context.Background()
+			const table = "issue_2007_lowcardinality_floats"
+			require.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS "+table))
+			require.NoError(t, conn.Exec(ctx, `CREATE TABLE `+table+` (
+				id UInt8,
+				f32 LowCardinality(Float32), f64 LowCardinality(Float64),
+				n32 LowCardinality(Nullable(Float32)), n64 LowCardinality(Nullable(Float64))
+			) ENGINE = Memory`))
+			t.Cleanup(func() { assert.NoError(t, conn.Exec(ctx, "DROP TABLE IF EXISTS "+table)) })
+			values := []float64{0, math.Copysign(0, -1), math.NaN(), math.NaN(), math.Inf(1), math.Inf(-1), 1.5}
+			batch, err := conn.PrepareBatch(ctx, "INSERT INTO "+table)
+			require.NoError(t, err)
+			for i, value := range values {
+				require.NoError(t, batch.Append(uint8(i), float32(value), value, float32(value), value))
+			}
+			require.NoError(t, batch.Append(uint8(len(values)), float32(0), float64(0), nil, nil))
+			require.NoError(t, batch.Send())
+			rows, err := conn.Query(ctx, "SELECT f32, f64, n32, n64 FROM "+table+" ORDER BY id")
+			require.NoError(t, err)
+			defer func() { assert.NoError(t, rows.Close()) }()
+			for _, want := range values {
+				require.True(t, rows.Next())
+				var f32 float32
+				var f64 float64
+				var n32 *float32
+				var n64 *float64
+				require.NoError(t, rows.Scan(&f32, &f64, &n32, &n64))
+				require.NotNil(t, n32)
+				require.NotNil(t, n64)
+				if math.IsNaN(want) {
+					assert.True(t, math.IsNaN(float64(f32)))
+					assert.True(t, math.IsNaN(f64))
+					assert.True(t, math.IsNaN(float64(*n32)))
+					assert.True(t, math.IsNaN(*n64))
+				} else {
+					assert.Equal(t, math.Float32bits(float32(want)), math.Float32bits(f32))
+					assert.Equal(t, math.Float64bits(want), math.Float64bits(f64))
+					assert.Equal(t, math.Float32bits(float32(want)), math.Float32bits(*n32))
+					assert.Equal(t, math.Float64bits(want), math.Float64bits(*n64))
+				}
+			}
+			require.True(t, rows.Next())
+			var f32 float32
+			var f64 float64
+			var n32 *float32
+			var n64 *float64
+			require.NoError(t, rows.Scan(&f32, &f64, &n32, &n64))
+			assert.Nil(t, n32)
+			assert.Nil(t, n64)
+			assert.False(t, rows.Next())
+			require.NoError(t, rows.Err())
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2007.

Use float bit representations for LowCardinality Float32/Float64 dictionary keys and retain each assigned index. Go value equality otherwise collapses signed zero, and a second lookup of a NaN misses and returns index zero. The driver preserves signed-zero and NaN payload bits in its wire encoding without changing the wire layout.

Column tests cover nullable and nonnullable floats, signed zeros, NaN payloads, infinities, append paths and encode/decode. Native and HTTP integration tests allow signed-zero normalization because an [independent ClickHouse 26.3.33.24 diagnostic](https://github.com/sankalpsthakur/clickhouse-go/actions/runs/34684631582) confirms that the server merges signed zeros in its LowCardinality dictionaries. These schemas require `allow_suspicious_low_cardinality_types`.

[Validation at b6d6009](https://github.com/sankalpsthakur/clickhouse-go/actions/runs/34684766157), Go 1.25.14 on Linux with ClickHouse 26.3.33.24:

- Native and HTTP integration cases passed without skips.
- Library race tests and full `make test` passed. Existing individual feature/protocol skips remain in the logs; no integration suite was skipped for unavailable Docker.
- Direct golangci-lint v2.11.0 passed with zero issues.

AI tools, including Codex, assisted with implementation, tests and this description.
