### PR TITLE
fix: return error from appendRowsBlocks on mid-stream failure

### DIFF
--- a/conn_batch.go
+++ b/conn_batch.go
@@ -159,7 +159,7 @@ func (b *batch) appendRowsBlocks(r *rows) error {
 		lastReadLock = r.block
 	}
 
-	return nil
+	return r.Err()
 }
 
 func (b *batch) AppendStruct(v any) error {


### PR DESCRIPTION
see https://github.com/ClickHouse/clickhouse-go/issues/2016