### PR TITLE
fix: missing err check after rows.Next()

### DIFF
--- a/conn_http_batch.go
+++ b/conn_http_batch.go
@@ -42,6 +42,9 @@ func fetchColumnNamesAndTypesForInsert(h *httpConnect, release nativeTransportRe
 		columnsToTypes[colName] = colType
 		allColumns = append(allColumns, colName)
 	}
+	if err = r.Err(); err != nil {
+		return nil, err
+	}
 
 	// The order of the columns must match the INSERT list, or the DESC table if no insert list was provided
 	insertColumns := make([]ColumnNameAndType, 0, len(allColumns))


### PR DESCRIPTION
Adds the missing `rows.Err()` check after `Next()` in `fetchColumnNamesAndTypesForInsert`, where a mid-stream error was silently swallowed.

note: following https://github.com/ClickHouse/clickhouse-go/pull/2017, I asked claude to look for other places with missing rows.Err() check