### PR TITLE
fix(column): reject oversized byte slices in FixedString bulk append

### DIFF
--- a/lib/column/fixed_string.go
+++ b/lib/column/fixed_string.go
@@ -174,17 +174,7 @@ func (col *FixedString) Append(v any) (nulls []uint8, err error) {
 			if v == nil {
 				nulls[i] = 1
 			}
-			n := len(v)
-			var err error
-			switch {
-			case n == 0:
-				err = col.safeAppendRow(nil)
-			case n >= col.col.Size:
-				err = col.safeAppendRow(v[0:col.col.Size])
-			default:
-				err = col.safeAppendRow(v)
-			}
-
+			err := col.safeAppendRow(v)
 			if err != nil {
 				return nil, err
 			}

--- a/lib/column/fixed_string_test.go
+++ b/lib/column/fixed_string_test.go
@@ -69,3 +69,13 @@ func TestFixedStringAppendBinaryMarshaler(t *testing.T) {
 		})
 	}
 }
+
+func TestFixedStringAppendByteSlicesOverflow(t *testing.T) {
+	col := &FixedString{
+		col: proto.ColFixedStr{Size: 3},
+	}
+
+	_, err := col.Append([][]byte{[]byte("abcd")})
+	require.EqualError(t, err, "input value with length 4 exceeds FixedString(3) capacity")
+	require.Equal(t, 0, col.Rows())
+}


### PR DESCRIPTION
## Summary

- return an error when a `[][]byte` value is longer than `FixedString(N)`
- keep bulk byte-slice appends consistent with row appends
- add a regression test

## Why

The bulk `[][]byte` path sliced values to the column size before calling the length check. For example, `FixedString(3)` accepted `[]byte("abcd")` and stored `abc`.

This silently changed the input. The existing append helper already returns an error for oversized values, so this change lets it handle the full value.

## Tests

- `go test ./lib/column`