### PR TITLE
fix(column): reject non-IPv4 addresses in IPv4 appends

### DIFF
--- a/lib/column/ipv4.go
+++ b/lib/column/ipv4.go
@@ -107,10 +107,43 @@ func strToIPV4(strIp string) (netip.Addr, error) {
 	return ip, nil
 }
 
-func (col *IPv4) AppendV4IPs(ips []netip.Addr) {
-	for i := range ips {
-		col.col.Append(proto.ToIPv4(ips[i]))
+func invalidIPv4Error(op, from string) error {
+	return &ColumnConverterError{
+		Op:   op,
+		To:   "IPv4",
+		From: from,
+		Hint: "invalid IPv4 address",
 	}
+}
+
+func toIPv4(ip netip.Addr, op string) (proto.IPv4, error) {
+	ip = ip.Unmap()
+	if !ip.Is4() {
+		return 0, invalidIPv4Error(op, "netip.Addr")
+	}
+	return proto.ToIPv4(ip), nil
+}
+
+func (col *IPv4) appendV4IPs(ips []netip.Addr, nulls []uint8) error {
+	values := make([]proto.IPv4, len(ips))
+	for i := range ips {
+		if len(nulls) != 0 && nulls[i] != 0 {
+			continue
+		}
+		value, err := toIPv4(ips[i], "Append")
+		if err != nil {
+			return err
+		}
+		values[i] = value
+	}
+	for i := range values {
+		col.col.Append(values[i])
+	}
+	return nil
+}
+
+func (col *IPv4) AppendV4IPs(ips []netip.Addr) error {
+	return col.appendV4IPs(ips, nil)
 }
 
 func (col *IPv4) Append(v any) (nulls []uint8, err error) {
@@ -126,7 +159,9 @@ func (col *IPv4) Append(v any) (nulls []uint8, err error) {
 			}
 			ips[i] = ip
 		}
-		col.AppendV4IPs(ips)
+		if err := col.AppendV4IPs(ips); err != nil {
+			return nulls, err
+		}
 	case []*string:
 		nulls = make([]uint8, len(v))
 		ips := make([]netip.Addr, len(v))
@@ -143,36 +178,56 @@ func (col *IPv4) Append(v any) (nulls []uint8, err error) {
 				nulls[i] = 1
 			}
 		}
-		col.AppendV4IPs(ips)
+		if err := col.appendV4IPs(ips, nulls); err != nil {
+			return nulls, err
+		}
 	case []netip.Addr:
 		nulls = make([]uint8, len(v))
-		col.AppendV4IPs(v)
+		if err := col.AppendV4IPs(v); err != nil {
+			return nulls, err
+		}
 	case []*netip.Addr:
 		nulls = make([]uint8, len(v))
+		ips := make([]netip.Addr, len(v))
 		for i := range v {
-			switch {
-			case v[i] != nil:
-				col.col.Append(proto.ToIPv4(*v[i]))
-			default:
+			if v[i] == nil {
 				nulls[i] = 1
-				col.col.Append(0)
+				continue
 			}
+			ips[i] = *v[i]
+		}
+		if err := col.appendV4IPs(ips, nulls); err != nil {
+			return nulls, err
 		}
 	case []net.IP:
 		nulls = make([]uint8, len(v))
+		values := make([]proto.IPv4, len(v))
 		for i := range v {
-			col.col.Append(proto.ToIPv4(netIPToNetIPAddr(v[i])))
+			value, err := netIPToIPv4(v[i], "Append")
+			if err != nil {
+				return nulls, err
+			}
+			values[i] = value
+		}
+		for i := range values {
+			col.col.Append(values[i])
 		}
 	case []*net.IP:
 		nulls = make([]uint8, len(v))
+		values := make([]proto.IPv4, len(v))
 		for i := range v {
-			switch {
-			case v[i] != nil:
-				col.col.Append(proto.ToIPv4(netIPToNetIPAddr(*v[i])))
-			default:
+			if v[i] == nil {
 				nulls[i] = 1
-				col.col.Append(0)
+				continue
 			}
+			value, err := netIPToIPv4(*v[i], "Append")
+			if err != nil {
+				return nulls, err
+			}
+			values[i] = value
+		}
+		for i := range values {
+			col.col.Append(values[i])
 		}
 	case []uint32:
 		nulls = make([]uint8, len(v))
@@ -220,7 +275,11 @@ func (col *IPv4) AppendRow(v any) (err error) {
 		if err != nil {
 			return err
 		}
-		col.col.Append(proto.ToIPv4(ip))
+		value, err := toIPv4(ip, "AppendRow")
+		if err != nil {
+			return err
+		}
+		col.col.Append(value)
 	case *string:
 		switch {
 		case v != nil:
@@ -228,30 +287,45 @@ func (col *IPv4) AppendRow(v any) (err error) {
 			if err != nil {
 				return err
 			}
-			col.col.Append(proto.ToIPv4(ip))
+			value, err := toIPv4(ip, "AppendRow")
+			if err != nil {
+				return err
+			}
+			col.col.Append(value)
 		default:
 			col.col.Append(0)
 		}
 	case netip.Addr:
-		col.col.Append(proto.ToIPv4(v))
+		value, err := toIPv4(v, "AppendRow")
+		if err != nil {
+			return err
+		}
+		col.col.Append(value)
 	case *netip.Addr:
 		switch {
 		case v != nil:
-			col.col.Append(proto.ToIPv4(*v))
+			value, err := toIPv4(*v, "AppendRow")
+			if err != nil {
+				return err
+			}
+			col.col.Append(value)
 		default:
 			col.col.Append(0)
 		}
 	case net.IP:
-		switch {
-		case len(v) == 0:
-			col.col.Append(0)
-		default:
-			col.col.Append(proto.ToIPv4(netIPToNetIPAddr(v)))
+		value, err := netIPToIPv4(v, "AppendRow")
+		if err != nil {
+			return err
 		}
+		col.col.Append(value)
 	case *net.IP:
 		switch {
 		case v != nil:
-			col.col.Append(proto.ToIPv4(netIPToNetIPAddr(*v)))
+			value, err := netIPToIPv4(*v, "AppendRow")
+			if err != nil {
+				return err
+			}
+			col.col.Append(value)
 		default:
 			col.col.Append(0)
 		}
@@ -308,14 +382,15 @@ func (col *IPv4) rowAddr(i int) netip.Addr {
 	return col.col.Row(i).ToIP()
 }
 
-func netIPToNetIPAddr(ip net.IP) netip.Addr {
-	switch len(ip) {
-	case 4:
-		return netip.AddrFrom4([4]byte{ip[0], ip[1], ip[2], ip[3]})
-	case 16:
-		return netip.AddrFrom4([4]byte{ip[12], ip[13], ip[14], ip[15]})
+func netIPToIPv4(ip net.IP, op string) (proto.IPv4, error) {
+	if len(ip) == 0 {
+		return 0, nil
 	}
-	return netip.Addr{}
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return 0, invalidIPv4Error(op, "net.IP")
+	}
+	return proto.IPv4(binary.BigEndian.Uint32(ip4)), nil
 }
 
 var _ Interface = (*IPv4)(nil)

--- a/lib/column/ipv4_test.go
+++ b/lib/column/ipv4_test.go
@@ -1,0 +1,163 @@
+package column
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIPv4AppendRejectsNonIPv4(t *testing.T) {
+	ipv6String := "2001:db8::1"
+	ipv6Addr := netip.MustParseAddr(ipv6String)
+	ipv6NetIP := net.ParseIP(ipv6String)
+
+	tests := []struct {
+		name   string
+		append func(*IPv4) error
+	}{
+		{
+			name: "string row",
+			append: func(col *IPv4) error {
+				return col.AppendRow(ipv6String)
+			},
+		},
+		{
+			name: "string pointer row",
+			append: func(col *IPv4) error {
+				return col.AppendRow(&ipv6String)
+			},
+		},
+		{
+			name: "netip row",
+			append: func(col *IPv4) error {
+				return col.AppendRow(ipv6Addr)
+			},
+		},
+		{
+			name: "netip pointer row",
+			append: func(col *IPv4) error {
+				return col.AppendRow(&ipv6Addr)
+			},
+		},
+		{
+			name: "net.IP row",
+			append: func(col *IPv4) error {
+				return col.AppendRow(ipv6NetIP)
+			},
+		},
+		{
+			name: "net.IP pointer row",
+			append: func(col *IPv4) error {
+				return col.AppendRow(&ipv6NetIP)
+			},
+		},
+		{
+			name: "string bulk",
+			append: func(col *IPv4) error {
+				_, err := col.Append([]string{ipv6String})
+				return err
+			},
+		},
+		{
+			name: "string pointer bulk",
+			append: func(col *IPv4) error {
+				_, err := col.Append([]*string{&ipv6String})
+				return err
+			},
+		},
+		{
+			name: "netip bulk",
+			append: func(col *IPv4) error {
+				_, err := col.Append([]netip.Addr{ipv6Addr})
+				return err
+			},
+		},
+		{
+			name: "netip pointer bulk",
+			append: func(col *IPv4) error {
+				_, err := col.Append([]*netip.Addr{&ipv6Addr})
+				return err
+			},
+		},
+		{
+			name: "net.IP bulk",
+			append: func(col *IPv4) error {
+				_, err := col.Append([]net.IP{ipv6NetIP})
+				return err
+			},
+		},
+		{
+			name: "net.IP pointer bulk",
+			append: func(col *IPv4) error {
+				_, err := col.Append([]*net.IP{&ipv6NetIP})
+				return err
+			},
+		},
+		{
+			name: "netip helper",
+			append: func(col *IPv4) error {
+				return col.AppendV4IPs([]netip.Addr{ipv6Addr})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			col := &IPv4{}
+			var err error
+			require.NotPanics(t, func() {
+				err = tt.append(col)
+			})
+			require.Error(t, err)
+			require.IsType(t, &ColumnConverterError{}, err)
+			require.Equal(t, 0, col.Rows())
+		})
+	}
+}
+
+func TestIPv4AppendAcceptsIPv4MappedIPv6(t *testing.T) {
+	mappedAddr := netip.MustParseAddr("::ffff:192.0.2.1")
+	mappedNetIP := net.ParseIP("::ffff:192.0.2.1")
+
+	tests := []struct {
+		name   string
+		append func(*IPv4) error
+	}{
+		{
+			name: "netip row",
+			append: func(col *IPv4) error {
+				return col.AppendRow(mappedAddr)
+			},
+		},
+		{
+			name: "net.IP row",
+			append: func(col *IPv4) error {
+				return col.AppendRow(mappedNetIP)
+			},
+		},
+		{
+			name: "netip bulk",
+			append: func(col *IPv4) error {
+				_, err := col.Append([]netip.Addr{mappedAddr})
+				return err
+			},
+		},
+		{
+			name: "net.IP bulk",
+			append: func(col *IPv4) error {
+				_, err := col.Append([]net.IP{mappedNetIP})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			col := &IPv4{}
+			require.NoError(t, tt.append(col))
+			require.Equal(t, "192.0.2.1", col.Row(0, false).(net.IP).String())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- reject IPv6 values passed to IPv4 columns
- return conversion errors instead of panicking
- avoid treating the last four bytes of IPv6 `net.IP` values as IPv4
- keep IPv4-mapped IPv6 input working
- add unit coverage for row and bulk append inputs

## Why

`proto.ToIPv4` panics for non-IPv4 `netip.Addr` values. The `net.IP` conversion also treated every 16-byte value as IPv4 by taking bytes 12-15, so a real IPv6 address could be stored as a different IPv4 address.

## Tests

- `go test ./lib/column`